### PR TITLE
Small fixes

### DIFF
--- a/cobc/cobc.c
+++ b/cobc/cobc.c
@@ -3503,6 +3503,8 @@ process_command_line (const int argc, char **argv)
 				cb_fold_copy = COB_FOLD_UPPER;
 			} else if (!strcasecmp (cob_optarg, "LOWER")) {
 				cb_fold_copy = COB_FOLD_LOWER;
+			} else if (!strcasecmp (cob_optarg, "BOTH")) {
+				cb_fold_copy = COB_FOLD_BOTH;
 			} else {
 				cobc_err_exit (COBC_INV_PAR, "-ffold-copy");
 			}

--- a/cobc/cobc.h
+++ b/cobc/cobc.h
@@ -598,6 +598,8 @@ extern int		pplex (void);
 extern int		ppparse (void);
 #endif
 
+extern char *           fold_upper (char *name);
+
 extern int		ppopen (const char *, struct cb_replace_list *);
 extern int		ppcopy (const char *, const char *,
 				struct cb_replace_list *);

--- a/cobc/field.c
+++ b/cobc/field.c
@@ -591,7 +591,7 @@ cb_build_full_field_reference (struct cb_field* field)
 	cb_tree rchain = NULL;
 
 	while (field) {
-		if (field->flag_filler) continue;
+                if (field->flag_filler) break; //continue;
 		rchain = cb_build_reference (field->name);
 		if (ref) {
 			CB_REFERENCE (ref)->chain = rchain;

--- a/cobc/flag.def
+++ b/cobc/flag.def
@@ -48,7 +48,7 @@ CB_FLAG_RQ (cb_ebcdic_sign, 1, "sign", 0, 3,
 	  "                        * default: machine native"))
 
 CB_FLAG_RQ (cb_fold_copy, 1, "fold-copy", 0, 4,
-	_("  -ffold-copy=[UPPER|LOWER]\tfold COPY subject to value\n"
+	_("  -ffold-copy=[UPPER|LOWER|BOTH]\tfold COPY subject to value\n"
 	  "                        * default: no transformation"))
 
 CB_FLAG_RQ (cb_fold_call, 1, "fold-call", 0, 5,

--- a/cobc/pplex.l
+++ b/cobc/pplex.l
@@ -1199,7 +1199,7 @@ ppcopy_try_open (const char *dir, const char *name, int has_ext)
    1 - as is
    2 - all known copybook directories */
 static const char *
-ppcopy_find_file (const char *name, int has_ext)
+ppcopy_find_file_case (const char *name, int has_ext)
 {
 	const char* filename;
 
@@ -1226,6 +1226,27 @@ ppcopy_find_file (const char *name, int has_ext)
 
 	/* no candidate found */
 	return NULL;
+}
+
+static const char *
+ppcopy_find_file (const char *name, int has_ext)
+{
+	const char* filename;
+
+	filename = ppcopy_find_file_case (name, has_ext);
+	if (filename) {
+		return filename;
+	}
+
+        if(cb_fold_copy == COB_FOLD_BOTH){
+          const int len = strlen(name);
+          char* name_upper = cob_malloc( len + 1 );
+          strncpy( name_upper, name, len+1 );
+          fold_upper( name_upper );
+  	  filename = ppcopy_find_file_case (name_upper, has_ext);
+          cobc_free( name_upper );
+        }
+        return filename;
 }
 
 int
@@ -1676,7 +1697,7 @@ start:
 		*/
 		if (cb_source_format == CB_FORMAT_FREE) {
 			if (line_overflow == 0) {
-				cb_plex_warning (COBC_WARN_FILLER, newline_count + 1,
+				cb_plex_warning (cb_missing_newline, newline_count + 1,
 						 _("line not terminated by a newline"));
 			} else if (line_overflow == 2) {
 				cb_plex_warning (COBC_WARN_FILLER, newline_count + 1,
@@ -1685,7 +1706,7 @@ start:
 			}
 		} else {
 			if (line_overflow == 0) {
-				cb_plex_warning (COBC_WARN_FILLER, newline_count,
+				cb_plex_warning (cb_missing_newline, newline_count,
 						 _("line not terminated by a newline"));
 			} else if (line_overflow == 2) {
 				cb_plex_warning (COBC_WARN_FILLER, newline_count,

--- a/cobc/ppparse.y
+++ b/cobc/ppparse.y
@@ -93,7 +93,7 @@ fold_lower (char *name)
 	return name;
 }
 
-static char *
+char *
 fold_upper (char *name)
 {
 	unsigned char	*p;
@@ -862,6 +862,8 @@ set_choice:
 		cb_fold_copy = COB_FOLD_UPPER;
 	} else if (!strcasecmp (p, "LOWER")) {
 		cb_fold_copy = COB_FOLD_LOWER;
+	} else if (!strcasecmp (p, "BOTH")) {
+		cb_fold_copy = COB_FOLD_BOTH;
 	} else {
 		ppp_error_invalid_option ("FOLD-COPY-NAME", p);
 	}
@@ -1358,7 +1360,7 @@ copy_source:
   TOKEN
   {
 	$$ = fix_filename ($1);
-	if (cb_fold_copy == COB_FOLD_LOWER) {
+	if (cb_fold_copy == COB_FOLD_LOWER || cb_fold_copy == COB_FOLD_BOTH) {
 		$$ = fold_lower ($$);
 	} else if (cb_fold_copy == COB_FOLD_UPPER) {
 		$$ = fold_upper ($$);

--- a/cobc/warning.def
+++ b/cobc/warning.def
@@ -111,6 +111,9 @@ CB_ONWARNDEF (cb_warn_dialect, "dialect",
 CB_NOWARNDEF (cb_warn_source_after_code, "dangling-text",
 	_("  -Wdangling-text       warn about source text after program-area"))
 
+CB_ONWARNDEF (cb_missing_newline, "missing-newline",
+	_("  -Wno-missing-newline   do not warn about missing newlines"))
+
 CB_ONWARNDEF (cb_warn_filler, "others",
 	_("  -Wno-others           do not warn about different issues"))
 

--- a/config/gcos.words
+++ b/config/gcos.words
@@ -91,7 +91,7 @@ reserved:	COMMUNICATION
 reserved:	COMP=COMP-6
 reserved:	COMP-1=BINARY-SHORT		# GCOS
 reserved:	COMP-2=BINARY-LONG		# GCOS
-reserved:	COMP-3=COMP-6			# GCOS
+#reserved:	COMP-3=COMP-6			# GCOS
 reserved:       COMP-6				# GCOS
 reserved:	COMP-5=PACKED-DECIMAL		# GCOS
 reserved:	COMP-8=PACKED-DECIMAL		# GCOS

--- a/libcob/common.h
+++ b/libcob/common.h
@@ -650,6 +650,7 @@ only usable with COB_USE_VC2013_OR_GREATER */
 #define	COB_FOLD_NONE		0
 #define	COB_FOLD_UPPER		1
 #define	COB_FOLD_LOWER		2
+#define	COB_FOLD_BOTH		3
 
 /* Locale types */
 #define	COB_LC_COLLATE		0


### PR DESCRIPTION
* Warning for missing newlines can be disabled by -Wno-missing-newline
  instead of -Wno-others
* -ffold-copy accepts BOTH, to check both for UPPER and LOWER version
* Fix infinite loop in cb_build_full_field_reference