### PR TITLE
[GCOS] Add support for paragraphs that do not terminate with a period

### DIFF
--- a/cobc/config.def
+++ b/cobc/config.def
@@ -75,6 +75,13 @@ CB_CONFIG_INT (cb_align_record, "align-record", 0, 256, CB_XRANGE(0,256),
 CB_CONFIG_BOOLEAN (cb_align_opt, "align-opt",
 	_("align like MF OPT, Default: false (Like MF ALIGN=FIXED)"))
 
+CB_CONFIG_SUPPORT (cb_loose_area_a, "loose-area-a",
+	_("fixed form programs may use area A freely"))
+
+/* FIXME: the following flag implies `loose-area-a'; this is not yet
+    checked by the compiler. */
+CB_CONFIG_BOOLEAN (cb_rely_on_area_a, "rely-on-area-a",
+	_("checking emptyness of area A is required to parse programs"))
 
 /* Flags with required parameter and special values */
 

--- a/cobc/pplex.l
+++ b/cobc/pplex.l
@@ -408,6 +408,17 @@ DEFNUM_LITERAL	[+-]?[0-9]*[\.]*[0-9]+
 	skip_to_eol ();
 }
 
+<*>#\n {
+	/* Output a special marker that precedes lines starting in area A.  This
+	   is required to deal with a GCOS Cobol extension that permits sections
+	   and paragraphs that do not terminate with a period.
+
+	   See "(*GCOS*)" in `ppinput' function below for the code that emits
+	   the `#'.
+	*/
+	fprintf (ppout, "\n#area_a\n");
+}
+
 "COPY"			{
 	yy_push_state (COPY_STATE);
 	if (cb_src_list_file) {
@@ -1589,6 +1600,7 @@ ppinput (char *buff, const size_t max_size)
 	int	i,k;
 	int	n;
 	int	coln;
+	int	in_area_a;
 	struct list_skip *skip;
 	const char	*paragraph_name;
 
@@ -2003,7 +2015,13 @@ start:
 	buff[cb_indicator_column - 1] = ' ';
 	bp = buff + cb_indicator_column;
 
+	/* Check blank area A */
+	in_area_a = strncmp (bp, "    ", 4) != 0;
+
 	if (continuation) {
+		if (in_area_a)
+			(void) cb_verify (cb_loose_area_a && !cb_rely_on_area_a,
+					  _("non-blank area A on line continuation"));
 		/* Line continuation */
 		need_continuation = 0;
 		for (; *bp == ' '; ++bp) {
@@ -2115,6 +2133,16 @@ start:
 			memmove (buff + newline_count, buff, gotcr + 1);
 			memset (buff, '\n', newline_count);
 			gotcr += newline_count;
+		}
+		if (in_area_a && cb_rely_on_area_a) {
+			/* (*GCOS*): prepend special marker `#', indicating the
+			   current line starts in area A (see <*>#\n lexer rule
+			   above).
+
+			   Assumes `buff' is large enough for one extra char. */
+			memmove (buff + 1, buff, gotcr + 1);
+			buff[0] = '#';
+			gotcr += 1;
 		}
 		newline_count = 1;
 	}

--- a/cobc/scanner.l
+++ b/cobc/scanner.l
@@ -301,6 +301,11 @@ static void *	copy_literal (cb_tree l);
 	cb_assign_type_default = (enum cb_assign_type)(text[1] - '0');
 }
 
+<*>^[ ]?"#AREA_A" {
+	if (cobc_in_procedure)
+		return AREA_A;
+}
+
 <*>\n {
 	cb_source_line++;
 }

--- a/config/acu-strict.conf
+++ b/config/acu-strict.conf
@@ -284,6 +284,8 @@ vsam-status:				ok
 record-contains-depending-clause:	unconformable
 align-record: 4 
 align-opt: no
+loose-area-a:				ok
+rely-on-area-a:				no
 
 # use fixed word list, synonyms and exceptions specified there
 reserved-words:		ACU

--- a/config/bs2000-strict.conf
+++ b/config/bs2000-strict.conf
@@ -281,6 +281,8 @@ vsam-status:				ok
 record-contains-depending-clause:	unconformable
 align-record: 8 
 align-opt: no
+loose-area-a:				ok
+rely-on-area-a:				no
 
 # use fixed word list, synonyms and exceptions specified there
 reserved-words:		BS2000

--- a/config/default.conf
+++ b/config/default.conf
@@ -290,6 +290,8 @@ vsam-status:				ok
 record-contains-depending-clause:	obsolete
 align-record: 0
 align-opt: no
+loose-area-a:				ok
+rely-on-area-a:				no
 
 # use complete word list; synonyms and exceptions are specified below
 reserved-words:		default

--- a/config/gcos-strict.conf
+++ b/config/gcos-strict.conf
@@ -262,6 +262,8 @@ vsam-status:				unconformable
 record-contains-depending-clause:	obsolete      # According to GCOS 7 documentation
 align-record:				0
 align-opt:				no
+loose-area-a:				error
+rely-on-area-a:				yes
 
 # use fixed word list, synonyms and exceptions specified there
 reserved-words:		GCOS

--- a/config/ibm-strict.conf
+++ b/config/ibm-strict.conf
@@ -278,6 +278,8 @@ vsam-status:				ok
 record-contains-depending-clause:	unconformable
 align-record: 8
 align-opt: yes
+loose-area-a:				ok
+rely-on-area-a:				no
 
 # use fixed word list, synonyms and exceptions specified there
 reserved-words:		IBM

--- a/config/mf-strict.conf
+++ b/config/mf-strict.conf
@@ -282,6 +282,8 @@ vsam-status:				ok
 record-contains-depending-clause:	unconformable
 align-record: 8
 align-opt: yes
+loose-area-a:				ok
+rely-on-area-a:				no
 
 # use fixed word list, synonyms and exceptions specified there
 reserved-words:		MF

--- a/config/mvs-strict.conf
+++ b/config/mvs-strict.conf
@@ -278,6 +278,8 @@ vsam-status:				ok
 record-contains-depending-clause:	unconformable
 align-record: 8
 align-opt: yes
+loose-area-a:				ok
+rely-on-area-a:				no
 
 # use fixed word list, synonyms and exceptions specified there
 reserved-words:		MVS

--- a/config/realia-strict.conf
+++ b/config/realia-strict.conf
@@ -285,6 +285,8 @@ vsam-status:				ok
 record-contains-depending-clause:	unconformable
 align-record: 0
 align-opt: no
+loose-area-a:				ok
+rely-on-area-a:				no
 
 # use fixed word list, synonyms and exceptions specified there
 reserved-words:		realia

--- a/config/rm-strict.conf
+++ b/config/rm-strict.conf
@@ -286,6 +286,8 @@ vsam-status:				unconformable
 record-contains-depending-clause:	unconformable
 align-record: 4
 align-opt: no
+loose-area-a:				ok
+rely-on-area-a:				no
 
 # obsolete in COBOL85 and currently not available as dialect features:
 # 1: All literal with numeric or numeric edited item


### PR DESCRIPTION
In fixed form programs, section and paragraph headers must often start
in area A, and in the GCOS dialect this form is exploited to allow
paragraphs that do not terminate with a period.  GNUCobol currently
discards any information about the use of area A, since every dialect
it supports requires paragraphs to terminate with a period.

To support the GCOS dialect, this change modifies the pre-processor to
insert special markers `#area_a' before every word that starts in area
A.  This information is then exploited by the parser to detect
paragraph termination.