### PR TITLE
[CANCELLED] Allow paragraph names to redefine field and section names

### DIFF
--- a/cobc/ChangeLog
+++ b/cobc/ChangeLog
@@ -1,4 +1,9 @@
 
+2026-08-26  David Declerck <david.declerck@ocamlpro.com>
+
+	* config.def, typeck.c: allow paragraph names to redefine field
+	  and section names; related to FR#260
+
 2026-08-09  Oğuzcan Kırmemiş <oguzcan.kirmemis@gmail.com>
 
 	* cobc.c [_MSC_VER]: use new macros CB_MSC_CRT and CB_MSC_CRT_DLL to pass

--- a/cobc/config.def
+++ b/cobc/config.def
@@ -442,3 +442,7 @@ CB_CONFIG_SUPPORT (cb_record_contains_depending_clause, "record-contains-dependi
 
 CB_CONFIG_SUPPORT (cb_picture_l, "picture-l",
 	_("PICTURE string with 'L' character"))
+
+CB_CONFIG_SUPPORT (cb_non_unique_procedure_names, "non-unique-procedure-names",
+	_("allow paragraph names to redefine field and section names"))
+

--- a/cobc/error.c
+++ b/cobc/error.c
@@ -1074,6 +1074,24 @@ cb_verify (const enum cb_support tag, const char *feature)
 	return cb_verify_x (&loc, tag, feature);
 }
 
+/**
+ * tells whether the given compiler option is supported by the current std/configuration
+ * \return	1 = ok/warning/obsolete, 0 = skip/ignore/error/unconformable
+ */
+unsigned int
+cb_is_supported (const enum cb_support tag)
+{
+	switch (tag) {
+	case CB_OK:
+	case CB_WARNING:
+	case CB_ARCHAIC:
+	case CB_OBSOLETE:
+		return 1;
+	default:;
+	}
+	return 0;
+}
+
 enum cb_warn_val
 redefinition_error (cb_tree x)
 {

--- a/cobc/tree.h
+++ b/cobc/tree.h
@@ -2320,6 +2320,7 @@ extern unsigned int	cb_syntax_check_x (cb_tree, const char *, ...) COB_A_FORMAT2
 extern unsigned int	cb_verify (const enum cb_support, const char *);
 extern unsigned int	cb_verify_x (const cb_tree, const enum cb_support,
 				     const char *);
+extern unsigned int	cb_is_supported (const enum cb_support);
 #if 0 /* CHECKME: Is there any place other than "note" where we want to do listing suppression? */
 extern void		listprint_suppress (void);
 extern void		listprint_restore (void);

--- a/cobc/typeck.c
+++ b/cobc/typeck.c
@@ -2123,8 +2123,15 @@ cb_build_section_name (cb_tree name, const int sect_or_para)
 		if (!CB_LABEL_P (x) || sect_or_para == 0 ||
 		    (sect_or_para && CB_LABEL_P (x) &&
 		    CB_LABEL (x)->flag_section)) {
-			redefinition_error (name);
-			return cb_error_node;
+			if (cb_is_supported(cb_non_unique_procedure_names) &&
+			    (CB_FIELD_P (x) ||
+			     (CB_LABEL_P (x) && CB_LABEL (x)->flag_section))) {
+				/* To display the usual warning messages, if any */
+				cb_verify(cb_non_unique_procedure_names, _("non-unique section or paragraph name"));
+			} else {
+				redefinition_error (name);
+				return cb_error_node;
+			}
 		}
 	}
 

--- a/config/ChangeLog
+++ b/config/ChangeLog
@@ -204,6 +204,7 @@
 
 	* gcos-strict.conf, gcos.conf, gcos.words: added config files for
 	  GCOS 7 (Bull) dialect
+	* general: add a non-unique-paragraph-names option
 
 2022-02-07  David Declerck <david.declerck@ocamlpro.com>
 

--- a/config/acu-strict.conf
+++ b/config/acu-strict.conf
@@ -285,6 +285,7 @@ self-call-recursive:			skip
 record-contains-depending-clause:	unconformable
 defaultbyte:				" "
 picture-l:				unconformable
+non-unique-procedure-names:		ok
 
 # use fixed word list, synonyms and exceptions specified there
 reserved-words:		ACU

--- a/config/bs2000-strict.conf
+++ b/config/bs2000-strict.conf
@@ -282,6 +282,7 @@ self-call-recursive:			skip
 record-contains-depending-clause:	unconformable
 defaultbyte:				0		# not verified yet, but likely to be as IBM
 picture-l:				unconformable
+non-unique-procedure-names:		error
 
 # use fixed word list, synonyms and exceptions specified there
 reserved-words:		BS2000

--- a/config/cobol2002.conf
+++ b/config/cobol2002.conf
@@ -281,6 +281,7 @@ self-call-recursive:			skip
 record-contains-depending-clause:	unconformable
 defaultbyte:				none		# initial storage is undefined
 picture-l:				unconformable
+non-unique-procedure-names:		error
 
 # archaic in COBOL2002 and currently not available as dialect features:
 # 1: MOVE of alphanumeric figurative constants to numeric items

--- a/config/cobol2014.conf
+++ b/config/cobol2014.conf
@@ -281,6 +281,7 @@ self-call-recursive:			skip
 record-contains-depending-clause:	unconformable
 defaultbyte:				none		# initial storage is undefined
 picture-l:				unconformable
+non-unique-procedure-names:		error
 
 # use fixed word list, synonyms and exceptions specified there
 reserved-words:		COBOL2014

--- a/config/cobol85.conf
+++ b/config/cobol85.conf
@@ -281,6 +281,7 @@ self-call-recursive:			skip
 record-contains-depending-clause:	unconformable
 defaultbyte:				none		# initial storage is undefined
 picture-l:				unconformable
+non-unique-procedure-names:		error
 
 # obsolete in COBOL85 and currently not available as dialect features:
 # 1: All literal with numeric or numeric edited item

--- a/config/default.conf
+++ b/config/default.conf
@@ -303,6 +303,7 @@ record-contains-depending-clause:	unconformable
 defaultbyte:				init		# GC inits as INITIALIZE ALL TO VALUE THEN TO DEFAULT,
             		    				# with INDEXED BY variables initialized to 1
 picture-l:				ok
+non-unique-procedure-names:		warning
 
 # use complete word list; synonyms and exceptions are specified below
 reserved-words:		default

--- a/config/gcos-strict.conf
+++ b/config/gcos-strict.conf
@@ -280,6 +280,7 @@ self-call-recursive:			skip
 record-contains-depending-clause:	obsolete
 defaultbyte:				0
 picture-l:				ok
+non-unique-procedure-names:		ok
 
 # use fixed word list, synonyms and exceptions specified there
 reserved-words:		GCOS

--- a/config/ibm-strict.conf
+++ b/config/ibm-strict.conf
@@ -280,6 +280,7 @@ self-call-recursive:			skip
 record-contains-depending-clause:	unconformable
 defaultbyte:				0
 picture-l:				unconformable
+non-unique-procedure-names:		error
 
 # use fixed word list, synonyms and exceptions specified there
 reserved-words:		IBM

--- a/config/mf-strict.conf
+++ b/config/mf-strict.conf
@@ -284,6 +284,7 @@ self-call-recursive:			skip
 record-contains-depending-clause:	unconformable
 defaultbyte:				" "
 picture-l:				unconformable
+non-unique-procedure-names:		error
 
 # use fixed word list, synonyms and exceptions specified there
 reserved-words:		MF

--- a/config/mvs-strict.conf
+++ b/config/mvs-strict.conf
@@ -280,6 +280,7 @@ self-call-recursive:			skip
 record-contains-depending-clause:	unconformable
 defaultbyte:				0		# not verified yet, but likely to be as IBM
 picture-l:				unconformable
+non-unique-procedure-names:		error
 
 # use fixed word list, synonyms and exceptions specified there
 reserved-words:		MVS

--- a/config/realia-strict.conf
+++ b/config/realia-strict.conf
@@ -285,6 +285,7 @@ self-call-recursive:			skip
 record-contains-depending-clause:	unconformable
 defaultbyte:				0		# not verified, but likely like IBM
 picture-l:				unconformable
+non-unique-procedure-names:		error
 
 # use fixed word list, synonyms and exceptions specified there
 reserved-words:		realia

--- a/config/rm-strict.conf
+++ b/config/rm-strict.conf
@@ -288,6 +288,7 @@ self-call-recursive:			skip
 record-contains-depending-clause:	unconformable
 defaultbyte:				" "		# not verified, but possibly like ACU/MF
 picture-l:				unconformable
+non-unique-procedure-names:		ok
 
 # obsolete in COBOL85 and currently not available as dialect features:
 # 1: All literal with numeric or numeric edited item

--- a/config/xopen.conf
+++ b/config/xopen.conf
@@ -300,6 +300,7 @@ self-call-recursive:			skip
 record-contains-depending-clause:	obsolete
 defaultbyte:				none		# "not specifically defined in Standard COBOL"
 picture-l:				unconformable
+non-unique-procedure-names:		error
 
 # obsolete in COBOL85 and currently not available as dialect features:
 # 1: All literal with numeric or numeric edited item

--- a/tests/testsuite.src/configuration.at
+++ b/tests/testsuite.src/configuration.at
@@ -538,6 +538,7 @@ test.conf: missing definitions:
 	no definition of 'self-call-recursive'
 	no definition of 'record-contains-depending-clause'
 	no definition of 'picture-l'
+	no definition of 'non-unique-procedure-names'
 ])
 
 AT_CLEANUP

--- a/tests/testsuite.src/syn_definition.at
+++ b/tests/testsuite.src/syn_definition.at
@@ -650,7 +650,10 @@ AT_DATA([prog.cob], [
            .
 ])
 
-AT_CHECK([$COMPILE_ONLY prog.cob], [1], [],
+AT_CHECK([$COMPILE_ONLY prog.cob], [0], [],
+[prog.cob:10: warning: non-unique section or paragraph name used
+])
+AT_CHECK([$COMPILE_ONLY -fnon-unique-procedure-names=error prog.cob], [1], [],
 [prog.cob:10: error: redefinition of 'prog'
 prog.cob:7: note: 'prog' previously defined here
 ])
@@ -1027,15 +1030,15 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([$COMPILE_ONLY prog.cob], [1], [],
+AT_CHECK([$COMPILE_ONLY prog.cob], [0], [],
+[prog.cob: in section 'L':
+prog.cob:6: warning: non-unique section or paragraph name used
+])
+AT_CHECK([$COMPILE_ONLY -fnon-unique-procedure-names=error prog.cob], [1], [],
 [prog.cob: in section 'L':
 prog.cob:6: error: redefinition of 'L'
 prog.cob:5: note: 'L' previously defined here
 ])
-
-# FIXME: as long as there is no direct reference to the section
-#        this should be not more than a warning,
-#        maybe depending on a compiler configuration
 
 AT_CLEANUP
 
@@ -1052,16 +1055,15 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([$COMPILE_ONLY prog.cob], [1], [],
+AT_CHECK([$COMPILE_ONLY prog.cob], [0], [],
+[prog.cob: in section 'L':
+prog.cob:6: warning: non-unique section or paragraph name used
+])
+AT_CHECK([$COMPILE_ONLY -fnon-unique-procedure-names=error prog.cob], [1], [],
 [prog.cob: in section 'L':
 prog.cob:6: error: redefinition of 'L'
 prog.cob:5: note: 'L' previously defined here
 ])
-
-# FIXME: as long as there is no direct reference to
-#        the paragraph/section this should be not more
-#        than a warning, maybe depending on a compiler
-#        configuration
 
 AT_CLEANUP
 
@@ -1150,6 +1152,60 @@ AT_CHECK([$COMPILE_ONLY prog.cob], [1], [],
 prog.cob:10: error: 'L' is ambiguous; needs qualification
 prog.cob:6: note: 'L IN S-1' defined here
 prog.cob:8: note: 'L IN S-2' defined here
+])
+
+AT_CLEANUP
+
+
+AT_SETUP([Identical names for section/paragraph and data])
+AT_KEYWORDS([definition])
+
+# FIXME: Identical data and section (or paragraph) names is not yet
+# supported.
+# See https://sourceforge.net/p/gnucobol/feature-requests/260/
+
+AT_XFAIL_IF(true)
+
+AT_DATA([word.cob], [
+       identification division.
+       program-id. word.
+       data division.
+       working-storage section.
+      *-----------------------------------------------------------------
+       77 word  pic 9.
+       77 word2 pic x.
+      *-----------------------------------------------------------------
+       PROCEDURE DIVISION.
+       main section.
+      *
+           move 0 to word
+           perform word
+	   display word
+      *
+           exit program.
+      *-----------------------------------------------------------------
+       word section.
+      *
+           add 1 to word
+           if word = 2 go to word2.
+           add 1 to word.
+      *
+       word2.
+      *
+           continue.
+      *-----------------------------------------------------------------
+])
+AT_CHECK([$COMPILE_ONLY word.cob], [0], [],
+[word.cob: in section 'main':
+word.cob:19: warning: non-unique section or paragraph name used
+word.cob: in section 'word':
+word.cob:21: warning: non-unique section or paragraph name used
+word.cob:7: note: 'word' defined here
+word.cob:19: note: 'word' defined here
+word.cob:25: warning: non-unique section or paragraph name used
+])
+AT_CHECK([$COMPILE_ONLY -std=cobol2002 word.cob], [1], [],
+[#TBD
 ])
 
 AT_CLEANUP


### PR DESCRIPTION
This allows a paragraph to have the same name as a previous field or section.

It is not clear whether this is actually allowed or not by the standard or the GCOS dialect, however our customer does have Cobol programs where some paragraphs have the same name as fields or sections. Further discussion is probably required.

Below are the relevant excerpt from the standards for reference.

Both the COBOL 85 standard and GCOS say :
> Within a given source program, but excluding any contained program, the user-defined words are grouped into the following disjoint sets:
> { ..., data-names, ..., paragraph-names, ..., section-names, ... }
> All user-defined words, except segment-numbers and level-numbers, can belong to one and only one of these disjoint sets. Further, all user-defined words within a given disjoint set must be unique, except as specified in the rules for uniqueness of reference.

(nb: these rules say nothing about paragraphs)

The 2014 standard is a bit different :
> Within a source element, a given user-defined word may be used as only one type of user-defined word with the
> following exceptions:
> 1) a compilation-variable-name may be the same as any other type of user-defined word
> 2) a level-number may be the same as a paragraph-name or a section-name
> 3) the same name may be used as any of the following types of user-defined words:
> - constant-name
> - data-name
> - property-name
> - record-key-name
> - record-name

The wording in item 3 is rather ambiguous...