### PR TITLE
add -ffold-copy=BOTH

### DIFF
--- a/cobc/cobc.c
+++ b/cobc/cobc.c
@@ -3581,11 +3581,13 @@ process_command_line (const int argc, char **argv)
 			break;
 
 		case 4:
-			/* -ffold-copy=<UPPER/LOWER> : COPY fold case */
+			/* -ffold-copy=<UPPER/LOWER/BOTH> : COPY fold case */
 			if (!cb_strcasecmp (cob_optarg, "UPPER")) {
 				cb_fold_copy = COB_FOLD_UPPER;
 			} else if (!cb_strcasecmp (cob_optarg, "LOWER")) {
 				cb_fold_copy = COB_FOLD_LOWER;
+			} else if (!strcasecmp (cob_optarg, "BOTH")) {
+				cb_fold_copy = COB_FOLD_BOTH;
 			} else {
 				cobc_err_exit (COBC_INV_PAR, "-ffold-copy");
 			}

--- a/cobc/cobc.h
+++ b/cobc/cobc.h
@@ -697,5 +697,6 @@ extern void		deactivate_system_name (const char *, const char *, const int);
 extern void		activate_system_name (const char *, const char *, const int);
 
 extern int		cb_strcasecmp (const void *, const void *);
+extern char *           fold_upper (char *name);
 
 #endif /* CB_COBC_H */

--- a/cobc/flag.def
+++ b/cobc/flag.def
@@ -55,7 +55,7 @@ CB_FLAG_RQ (cb_ebcdic_sign, 1, "sign", 0, 3,
 	  "                        * default: machine native"))
 
 CB_FLAG_RQ (cb_fold_copy, 1, "fold-copy", 0, 4,
-	_("  -ffold-copy=[UPPER|LOWER]\tfold COPY subject to value\n"
+	_("  -ffold-copy=[UPPER|LOWER|BOTH]\tfold COPY subject to value\n"
 	  "                        * default: no transformation"))
 
 CB_FLAG_RQ (cb_fold_call, 1, "fold-call", 0, 5,

--- a/cobc/pplex.l
+++ b/cobc/pplex.l
@@ -1194,7 +1194,7 @@ ppcopy_try_open (const char *dir, const char *name, int has_ext)
    1 - as is
    2 - all known copybook directories */
 static const char *
-ppcopy_find_file (const char *name, int has_ext)
+ppcopy_find_file_case (const char *name, int has_ext)
 {
 	const char* filename;
 
@@ -1221,6 +1221,27 @@ ppcopy_find_file (const char *name, int has_ext)
 
 	/* no candidate found */
 	return NULL;
+}
+
+static const char *
+ppcopy_find_file (const char *name, int has_ext)
+{
+	const char* filename;
+
+	filename = ppcopy_find_file_case (name, has_ext);
+	if (filename) {
+		return filename;
+	}
+
+        if(cb_fold_copy == COB_FOLD_BOTH){
+          const int len = strlen(name);
+          char* name_upper = cob_malloc( len + 1 );
+          strncpy( name_upper, name, len+1 );
+          fold_upper( name_upper );
+  	  filename = ppcopy_find_file_case (name_upper, has_ext);
+          cobc_free( name_upper );
+        }
+        return filename;
 }
 
 int

--- a/cobc/ppparse.y
+++ b/cobc/ppparse.y
@@ -95,7 +95,7 @@ fold_lower (char *name)
 	return name;
 }
 
-static char *
+char *
 fold_upper (char *name)
 {
 	unsigned char	*p;
@@ -924,6 +924,8 @@ set_choice:
 		cb_fold_copy = COB_FOLD_UPPER;
 	} else if (!cb_strcasecmp (p, "LOWER")) {
 		cb_fold_copy = COB_FOLD_LOWER;
+	} else if (!strcasecmp (p, "BOTH")) {
+		cb_fold_copy = COB_FOLD_BOTH;
 	} else {
 		ppp_error_invalid_option ("FOLD-COPY-NAME", p);
 	}
@@ -1536,7 +1538,7 @@ copy_source:
   TOKEN
   {
 	$$ = fix_filename ($1);
-	if (cb_fold_copy == COB_FOLD_LOWER) {
+	if (cb_fold_copy == COB_FOLD_LOWER || cb_fold_copy == COB_FOLD_BOTH) {
 		$$ = fold_lower ($$);
 	} else if (cb_fold_copy == COB_FOLD_UPPER) {
 		$$ = fold_upper ($$);

--- a/libcob/common.h
+++ b/libcob/common.h
@@ -640,6 +640,7 @@ only usable with COB_USE_VC2013_OR_GREATER */
 #define	COB_FOLD_NONE		0
 #define	COB_FOLD_UPPER		1
 #define	COB_FOLD_LOWER		2
+#define	COB_FOLD_BOTH		3
 
 /* Locale types */
 #define	COB_LC_COLLATE		0


### PR DESCRIPTION
Add flag value `BOTH` to `-ffold-copy`. It can be used to match filenames of copies independantly of the case (before, it was either `UPPER` or `LOWER`)