### PR TITLE
adding gitpod configuration

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,60 @@
+
+image: gitpod/workspace-c
+
+tasks:
+
+- name: setup coding environment on Ubuntu 20.04
+  before: |
+    # note: sadly we need this to be done every time as only /workspace is kept, but linked
+    #       against those dependencies; and also we do want to recompile after adjustments
+    #       this can all be dropped as soon as we would use a prepared docker
+    sudo apt update && sudo apt upgrade -y
+    sudo apt install -y build-essential libgmp-dev libdb-dev libjson-c-dev ncurses-dev libxml2-dev \
+         automake libtool flex bison help2man texinfo \
+         lcov
+    # sudo apt install gettext texlive-base  # for make dist (po/*, doc/gnucobol.pdf)
+    gp sync-done system-prepare
+
+- name: building GnuCOBOL
+  init: |
+    mkdir -p $GITPOD_REPO_ROOTS/_build
+    cd $GITPOD_REPO_ROOTS/_build
+    gp sync-await system-prepare
+    ../autogen.sh
+    ../configure --enable-cobc-internal-checks --enable-debug --enable-code-coverage
+    make --jobs=$(nproc)
+  command: |
+    cd $GITPOD_REPO_ROOTS/_build
+    gp sync-done build-finish
+
+- name: running GnuCOBOL tests with coverage
+  command: |
+    gp sync-await build-finish
+    cd $GITPOD_REPO_ROOTS/_build
+    half_jobs=$(( $(nproc) / 2 ))
+    nice make --jobs=${half_jobs} check-code-coverage TESTSUITEFLAGS="--jobs=${half_jobs}"
+
+- name: running NIST85 tests
+  command: |
+    gp sync-await build-finish
+    cd $GITPOD_REPO_ROOTS/_build
+    half_jobs=$(( $(nproc) / 2 ))
+    nice make -C tests/cobol85 --jobs=${half_jobs} test
+
+# disabled as the download takes too long
+#- name: running GnuCOBOL distribution tests with testuite
+#  command: |
+#    gp sync-await build-finish
+#    cd $GITPOD_REPO_ROOTS/_build
+#    half_jobs=$(( $(nproc) / 2 ))
+#    nice make --jobs=${half_jobs} distcheck TESTSUITEFLAGS="--jobs=${half_jobs}"
+
+vscode:
+  extensions:
+    - llvm-vs-code-extensions.vscode-clangd
+    - maelvalais.autoconf
+    - Dizy.lex-flex-yacc-bison
+    - ryanluker.vscode-coverage-gutters
+    - tenninebt.vscode-koverage
+    - meronz.manpages
+    - webfreak.debug


### PR DESCRIPTION
this file alone only "prepares" for use of GitPod, but I consider this useful, too

I suggest to additional do the following, after #51:
* possibly register for GitPod, if not done already
* [apply for "Open Source contribution"](https://www.gitpod.io/for/opensource) (effectively upgrading the gratis account to a professional one without costs)
* login and install the app here, see https://github.com/apps/gitpod-io
* configuring [pre-builds](https://www.gitpod.io/docs/prebuilds)

but as noted, that's "optional"; some benefits of GitPod: nice performance, running without costs, _full_ coding and building possible in the browser from anywhere, when pre-builds are active the development can start nearly in an instant, in theory also easy for people to start coding on the project