### PR TITLE
Avoid SIGSEGV on SORT of toplevel field

### DIFF
--- a/cobc/ChangeLog
+++ b/cobc/ChangeLog
@@ -1,4 +1,8 @@
 
+2022-07-27  Nicolas Berthier <nicolas.berthier@ocamlpro.com>
+
+	* typeck.c (cb_emit_sort_init): avoid SIGSEGV on SORT of toplevel field
+
 2022-07-19  Simon Sobisch <simonsobisch@gnu.org>
 
 	* parser.y, typeck.c: temporary adjust source reference when building

--- a/cobc/typeck.c
+++ b/cobc/typeck.c
@@ -1643,7 +1643,7 @@ cb_build_generic_register (const char *name, const char *external_definition,
 				}
 				memset (p, ' ', sep - p);
 			} else {
-		
+
 				/* on the first run we don't add anything to the actual parse tree */
 #if 0			/* TODO: move literal building out of scanner.l and call here */
 				if (current_program) {
@@ -3026,7 +3026,7 @@ cb_validate_parameters_and_returning (struct cb_program *prog, cb_tree using_lis
 	}
 }
 
- 
+
 /* TO-DO: Add params differing in BY REFERENCE/VALUE and OPTIONAL to testsuite */
 
 static struct cb_program *
@@ -11623,7 +11623,7 @@ cb_emit_move (cb_tree src, cb_tree dsts)
 					}
 					if (bgnpos >= 1
 					 && p->storage != CB_STORAGE_LINKAGE
-					 && !p->flag_item_based 
+					 && !p->flag_item_based
 					 && CB_LITERAL_P (src)
 					 && !cb_is_field_unbounded (p)) {
 						CB_REFERENCE (x)->length = cb_int (p->size - bgnpos + 1);
@@ -12406,7 +12406,7 @@ void
 cb_emit_set_to (cb_tree vars, cb_tree x)
 {
 	cb_tree	l;
-	
+
 	if (cb_check_set_to (vars, x, 1)) {
 		return;
 	}
@@ -12775,11 +12775,12 @@ cb_emit_sort_init (cb_tree name, cb_tree keys, cb_tree col, cb_tree nat_col)
 					     cb_int ((int)cb_list_length (keys)), col));
 		/* TODO: pass key-specific collation to libcob */
 		for (l = keys; l; l = CB_CHAIN (l)) {
+			struct cb_field * const f = CB_FIELD_PTR (CB_VALUE(l));
 			cb_emit (CB_BUILD_FUNCALL_3 ("cob_table_sort_init_key",
-					CB_VALUE (l),
-					CB_PURPOSE (l),
-					cb_int(CB_FIELD_PTR (CB_VALUE(l))->offset
-						   - CB_FIELD_PTR (CB_VALUE(l))->parent->offset)));
+						     CB_VALUE (l),
+						     CB_PURPOSE (l),
+						     cb_int(f->offset -
+							    (f->parent ? f->parent->offset : 0))));
 		}
 		f = CB_FIELD (rtree);
 		cb_emit (CB_BUILD_FUNCALL_2 ("cob_table_sort", name,

--- a/tests/testsuite.src/run_misc.at
+++ b/tests/testsuite.src/run_misc.at
@@ -3165,6 +3165,28 @@ AT_CHECK([$COBCRUN_DIRECT ./prog2], [0], [0004030201], [])
 AT_CLEANUP
 
 
+AT_SETUP([SORT: table sort (toplevel)])
+AT_KEYWORDS([runmisc])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      prog.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01 VAL           PIC X(5) VALUE "43512".
+       01 TBL           REDEFINES VAL PIC X OCCURS 5.
+       PROCEDURE        DIVISION.
+           SORT TBL ASCENDING
+           IF VAL NOT = "12345" DISPLAY VAL.
+           STOP RUN.
+])
+
+AT_CHECK([$COMPILE prog.cob], [0], [], [])
+AT_CHECK([$COBCRUN_DIRECT ./prog], [0], [], [])
+
+AT_CLEANUP
+
+
 AT_SETUP([SORT: EBCDIC table sort])
 AT_KEYWORDS([runmisc ALPHABET OBJECT-COMPUTER])
 


### PR DESCRIPTION
Yet, `SORT` on a `01 table` might not be allowed for some dialects. In any case, until now this raised a segfault.