### PR TITLE
Handle many more missing periods before PROCEDURE DIVISION

### DIFF
--- a/cobc/ChangeLog
+++ b/cobc/ChangeLog
@@ -1,4 +1,8 @@
 
+2022-09-29  Nicolas Berthier <nicolas.berthier@ocamlpro.com>
+
+	* parser.y: handle many more missing periods before PROCEDURE DIVISION
+
 2022-09-26  Simon Sobisch <simonsobisch@gnu.org>
 
 	* cobc.c (cobc_abort_msg): use negative cb_source_line to reference

--- a/cobc/parser.y
+++ b/cobc/parser.y
@@ -5114,8 +5114,8 @@ file_control_entry:
 ;
 
 _select_clauses_or_error:
-  _select_clause_sequence TOK_DOT
-| error TOK_DOT
+  _select_clause_sequence _dot_or_else_area_a_in_file_control
+| error _dot_or_else_area_a_in_file_control
   {
 	yyerrok;
   }
@@ -5945,8 +5945,8 @@ i_o_control_header:
 ;
 
 _i_o_control_entries:
-| i_o_control_list TOK_DOT
-| i_o_control_list error TOK_DOT
+| i_o_control_list _dot_or_else_area_a_in_file_control
+| i_o_control_list error _dot_or_else_area_a_in_file_control
   {
 	yyerrok;
   }
@@ -6206,8 +6206,8 @@ file_description_entry:
 		}
 	}
   }
-  _file_description_clause_sequence TOK_DOT
-| file_type error TOK_DOT
+  _file_description_clause_sequence _dot_or_else_area_a_in_file_description
+| file_type error _dot_or_else_area_a_in_file_description
   {
 	yyerrok;
   }
@@ -6630,7 +6630,8 @@ communication_description_entry:
 	}
 	check_duplicate = 0;
   }
-  _communication_description_clause_sequence TOK_DOT
+  _communication_description_clause_sequence
+  _dot_or_else_area_a_in_communication_description
 ;
 
 _communication_description_clause_sequence:
@@ -6721,7 +6722,8 @@ unnamed_i_o_cd_clauses:
 
 working_storage: WORKING_STORAGE { check_area_a_of ("WORKING-STORAGE SECTION"); };
 _working_storage_section:
-| working_storage SECTION _dot
+| working_storage SECTION
+  _dot_or_else_area_a_in_record_description
   {
 	check_headers_present (COBC_HD_DATA_DIVISION, 0, 0, 0);
 	header_check |= COBC_HD_WORKING_STORAGE_SECTION;
@@ -6754,8 +6756,8 @@ _record_description_list:
 ;
 
 record_description_list:
-  data_description _dot_or_else_area_a_in_data_division
-| record_description_list data_description _dot_or_else_area_a_in_data_division
+  data_description _dot_or_else_area_a_in_record_description
+| record_description_list data_description _dot_or_else_area_a_in_record_description
 ;
 
 data_description:
@@ -8277,7 +8279,8 @@ report_description:
 	}
 	check_duplicate = 0;
   }
-  _report_description_options TOK_DOT
+  _report_description_options
+  _dot_or_else_area_a_in_report_description
   _report_group_description_list
   {
 	$$ = get_finalized_description_tree ();
@@ -8293,7 +8296,7 @@ report_description:
 
 _report_description_options:
 | _report_description_options report_description_option
-| error TOK_DOT
+| error _dot_or_else_area_a_in_report_description
   {
 	yyerrok;
   }
@@ -8541,15 +8544,14 @@ report_group_description_entry:
 		description_field = current_field;
 	}
   }
-  _report_group_options TOK_DOT
+  _report_group_options _dot_or_else_area_a_in_report_group_description
   {
 	  build_sum_counter (current_report, current_field);
   }
-| level_number error TOK_DOT
+| level_number error _dot_or_else_area_a_in_report_group_description
   {
 	/* Free tree associated with level number */
 	cobc_parse_free ($1);
-	cb_unput_dot ();
 	yyerrok;
 	check_pic_duplicate = 0;
 	check_duplicate = 0;
@@ -19154,14 +19156,21 @@ _dot:
   }
 ;
 
-_dot_or_else_area_a:
+_dot_or_else_area_a_in_file_control:
   TOK_DOT
-| TOKEN_EOF
+| _file_control_end_delimiter
   {
 	if (! cb_verify (cb_missing_period, _("optional period")))
 		YYERROR;
+	cobc_repeat_last_token = 1;
   }
-| WORD_IN_AREA_A
+;
+
+_file_control_end_delimiter:
+  SELECT | I_O_CONTROL | DATA | PROCEDURE;
+
+level_number_in_area_a:
+  LEVEL_NUMBER_IN_AREA_A
   {
 	/* No need to raise the error for *_IN_AREA_A tokens */
 	(void) cb_verify (cb_missing_period, _("optional period"));
@@ -19169,9 +19178,54 @@ _dot_or_else_area_a:
   }
 ;
 
-_dot_or_else_area_a_in_data_division:
+_dot_or_else_area_a_in_file_description:
   TOK_DOT
-| LEVEL_NUMBER_IN_AREA_A
+| level_number_in_area_a
+| _file_description_end_delimiter
+  {
+	if (! cb_verify (cb_missing_period, _("optional period")))
+		YYERROR;
+	cobc_repeat_last_token = 1;
+  }
+;
+
+_file_description_end_delimiter:
+  LEVEL_NUMBER
+| TOK_FILE | PROCEDURE;
+
+_dot_or_else_area_a_in_communication_description:
+_dot_or_else_area_a_in_record_description;
+
+_dot_or_else_area_a_in_report_description:
+_dot_or_else_area_a_in_record_description;
+
+_dot_or_else_area_a_in_report_group_description:
+_dot_or_else_area_a_in_record_description;
+
+_dot_or_else_area_a_in_record_description:
+  TOK_DOT
+| level_number_in_area_a
+| _record_description_end_delimiter
+  {
+	if (! cb_verify (cb_missing_period, _("optional period")))
+		YYERROR;
+	cobc_repeat_last_token = 1;
+  }
+;
+
+_record_description_end_delimiter:
+  LEVEL_NUMBER
+| PROCEDURE | COMMUNICATION | LOCAL_STORAGE
+| LINKAGE | REPORT | SCREEN;
+
+_dot_or_else_area_a:		/* in PROCEDURE DIVISION */
+  TOK_DOT
+| TOKEN_EOF
+  {
+	if (! cb_verify (cb_missing_period, _("optional period")))
+		YYERROR;
+  }
+| WORD_IN_AREA_A
   {
 	/* No need to raise the error for *_IN_AREA_A tokens */
 	(void) cb_verify (cb_missing_period, _("optional period"));

--- a/cobc/parser.y
+++ b/cobc/parser.y
@@ -5114,8 +5114,8 @@ file_control_entry:
 ;
 
 _select_clauses_or_error:
-  _select_clause_sequence _dot_or_else_area_a_in_file_control
-| error _dot_or_else_area_a_in_file_control
+  _select_clause_sequence _dot_or_else_end_of_file_control
+| error _dot_or_else_end_of_file_control
   {
 	yyerrok;
   }
@@ -5945,8 +5945,8 @@ i_o_control_header:
 ;
 
 _i_o_control_entries:
-| i_o_control_list _dot_or_else_area_a_in_file_control
-| i_o_control_list error _dot_or_else_area_a_in_file_control
+| i_o_control_list _dot_or_else_end_of_file_control
+| i_o_control_list error _dot_or_else_end_of_file_control
   {
 	yyerrok;
   }
@@ -6206,8 +6206,8 @@ file_description_entry:
 		}
 	}
   }
-  _file_description_clause_sequence _dot_or_else_area_a_in_file_description
-| file_type error _dot_or_else_area_a_in_file_description
+  _file_description_clause_sequence _dot_or_else_end_of_file_description
+| file_type error _dot_or_else_end_of_file_description
   {
 	yyerrok;
   }
@@ -6631,7 +6631,7 @@ communication_description_entry:
 	check_duplicate = 0;
   }
   _communication_description_clause_sequence
-  _dot_or_else_area_a_in_communication_description
+  _dot_or_else_end_of_communication_description
 ;
 
 _communication_description_clause_sequence:
@@ -6723,7 +6723,7 @@ unnamed_i_o_cd_clauses:
 working_storage: WORKING_STORAGE { check_area_a_of ("WORKING-STORAGE SECTION"); };
 _working_storage_section:
 | working_storage SECTION
-  _dot_or_else_area_a_in_record_description
+  _dot_or_else_end_of_record_description
   {
 	check_headers_present (COBC_HD_DATA_DIVISION, 0, 0, 0);
 	header_check |= COBC_HD_WORKING_STORAGE_SECTION;
@@ -6756,8 +6756,8 @@ _record_description_list:
 ;
 
 record_description_list:
-  data_description _dot_or_else_area_a_in_record_description
-| record_description_list data_description _dot_or_else_area_a_in_record_description
+  data_description _dot_or_else_end_of_record_description
+| record_description_list data_description _dot_or_else_end_of_record_description
 ;
 
 data_description:
@@ -8280,7 +8280,7 @@ report_description:
 	check_duplicate = 0;
   }
   _report_description_options
-  _dot_or_else_area_a_in_report_description
+  _dot_or_else_end_of_report_description
   _report_group_description_list
   {
 	$$ = get_finalized_description_tree ();
@@ -8296,7 +8296,7 @@ report_description:
 
 _report_description_options:
 | _report_description_options report_description_option
-| error _dot_or_else_area_a_in_report_description
+| error _dot_or_else_end_of_report_description
   {
 	yyerrok;
   }
@@ -8544,11 +8544,11 @@ report_group_description_entry:
 		description_field = current_field;
 	}
   }
-  _report_group_options _dot_or_else_area_a_in_report_group_description
+  _report_group_options _dot_or_else_end_of_report_group_description
   {
 	  build_sum_counter (current_report, current_field);
   }
-| level_number error _dot_or_else_area_a_in_report_group_description
+| level_number error _dot_or_else_end_of_report_group_description
   {
 	/* Free tree associated with level number */
 	cobc_parse_free ($1);
@@ -19156,7 +19156,7 @@ _dot:
   }
 ;
 
-_dot_or_else_area_a_in_file_control:
+_dot_or_else_end_of_file_control:
   TOK_DOT
 | _file_control_end_delimiter
   {
@@ -19165,9 +19165,6 @@ _dot_or_else_area_a_in_file_control:
 	cobc_repeat_last_token = 1;
   }
 ;
-
-_file_control_end_delimiter:
-  SELECT | I_O_CONTROL | DATA | PROCEDURE;
 
 level_number_in_area_a:
   LEVEL_NUMBER_IN_AREA_A
@@ -19178,7 +19175,7 @@ level_number_in_area_a:
   }
 ;
 
-_dot_or_else_area_a_in_file_description:
+_dot_or_else_end_of_file_description:
   TOK_DOT
 | level_number_in_area_a
 | _file_description_end_delimiter
@@ -19189,20 +19186,16 @@ _dot_or_else_area_a_in_file_description:
   }
 ;
 
-_file_description_end_delimiter:
-  LEVEL_NUMBER
-| TOK_FILE | PROCEDURE;
+_dot_or_else_end_of_communication_description:
+_dot_or_else_end_of_record_description;
 
-_dot_or_else_area_a_in_communication_description:
-_dot_or_else_area_a_in_record_description;
+_dot_or_else_end_of_report_description:
+_dot_or_else_end_of_record_description;
 
-_dot_or_else_area_a_in_report_description:
-_dot_or_else_area_a_in_record_description;
+_dot_or_else_end_of_report_group_description:
+_dot_or_else_end_of_record_description;
 
-_dot_or_else_area_a_in_report_group_description:
-_dot_or_else_area_a_in_record_description;
-
-_dot_or_else_area_a_in_record_description:
+_dot_or_else_end_of_record_description:
   TOK_DOT
 | level_number_in_area_a
 | _record_description_end_delimiter
@@ -19213,9 +19206,14 @@ _dot_or_else_area_a_in_record_description:
   }
 ;
 
+_file_control_end_delimiter:
+  SELECT | I_O_CONTROL | DATA | PROCEDURE;
+
+_file_description_end_delimiter:
+  LEVEL_NUMBER | TOK_FILE | PROCEDURE;
+
 _record_description_end_delimiter:
-  LEVEL_NUMBER
-| PROCEDURE | COMMUNICATION | LOCAL_STORAGE
+  LEVEL_NUMBER | PROCEDURE | COMMUNICATION | LOCAL_STORAGE
 | LINKAGE | REPORT | SCREEN;
 
 _dot_or_else_area_a:		/* in PROCEDURE DIVISION */

--- a/tests/testsuite.src/syn_misc.at
+++ b/tests/testsuite.src/syn_misc.at
@@ -6195,7 +6195,7 @@ prog.cob:10: error: syntax error, unexpected Identifier
 AT_CHECK([$COMPILE_ONLY -std=mf-strict -freserved=CONSTANT prog.cob], [1], [],
 [prog.cob:6: error: 01 CONSTANT does not conform to Micro Focus COBOL
 prog.cob:7: error: 01 CONSTANT does not conform to Micro Focus COBOL
-prog.cob:7: error: syntax error, unexpected Identifier, expecting . or level-number (Area A)
+prog.cob:7: error: syntax error, unexpected Identifier
 ])
 
 AT_CHECK([$COMPILE_ONLY -std=mf prog.cob], [1], [],
@@ -9172,7 +9172,7 @@ prog.cob:19: error: start of statement in Area A
 AT_CLEANUP
 
 
-AT_SETUP([Optional dots])
+AT_SETUP([optional dots])
 AT_KEYWORDS([misc missing-periods])
 
 AT_DATA([prog.cob], [
@@ -9227,6 +9227,43 @@ cobol85.cob:14: warning: optional period used
 AT_CLEANUP
 
 
+AT_SETUP([optional dots before PROCEDURE DIVISION])
+AT_KEYWORDS([misc missing-periods])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION DIVISION
+       PROGRAM-ID. prog.
+       DATA DIVISION
+       WORKING-STORAGE SECTION
+       77 PMODE   PIC X
+       PROCEDURE DIVISION.
+          STOP RUN.
+])
+
+# The syntax error below is hard to avoid, and can be missleading.
+# The error is actually on the `77`, which is only parsed as a
+# LEVEL_NUMBER if the preceding token is a `.`.
+#
+# TODO: To avoid this, we need to unput the WORD/Literal when dealing
+# with optional periods outside of PROCEDURE DIVISION, and ensure it
+# is reparsed as a LEVEL_NUMBER.
+AT_CHECK([$COMPILE_ONLY prog.cob], [1], [],
+[prog.cob:3: warning: optional period used
+prog.cob:5: warning: optional period used
+prog.cob:6: error: syntax error, unexpected Literal
+])
+
+# Here the AREACHECK helps us recover from all missing periods
+AT_CHECK([$COMPILE_ONLY -fformat=cobol85 prog.cob], [0], [],
+[prog.cob:3: warning: optional period used
+prog.cob:5: warning: optional period used
+prog.cob:6: warning: optional period used
+prog.cob:7: warning: optional period used
+])
+
+AT_CLEANUP
+
+
 AT_SETUP([AREACHECK])
 AT_KEYWORDS([misc])
 
@@ -9266,3 +9303,4 @@ pgm1.cob:18: error: start of statement in Area A
 ])
 
 AT_CLEANUP
+

--- a/tests/testsuite.src/syn_occurs.at
+++ b/tests/testsuite.src/syn_occurs.at
@@ -94,7 +94,7 @@ AT_DATA([prog.cob], [
 ])
 
 AT_CHECK([$COMPILE_ONLY prog.cob], [1], [],
-[prog.cob:7: error: syntax error, unexpected OCCURS, expecting . or level-number (Area A)
+[prog.cob:7: error: syntax error, unexpected OCCURS
 ])
 
 AT_CLEANUP
@@ -112,7 +112,7 @@ AT_DATA([prog.cob], [
 ])
 
 AT_CHECK([$COMPILE_ONLY prog.cob], [1], [],
-[prog.cob:6: error: syntax error, unexpected OCCURS, expecting . or level-number (Area A)
+[prog.cob:6: error: syntax error, unexpected OCCURS
 ])
 
 AT_CLEANUP
@@ -131,7 +131,7 @@ AT_DATA([prog.cob], [
 ])
 
 AT_CHECK([$COMPILE_ONLY prog.cob], [1], [],
-[prog.cob:7: error: syntax error, unexpected OCCURS, expecting . or level-number (Area A)
+[prog.cob:7: error: syntax error, unexpected OCCURS
 ])
 
 AT_CLEANUP


### PR DESCRIPTION
This starts to become more and more *ad hoc*. However, that allows us to deal with much more cases of missing dots than before.