### PR TITLE
DEPENDING var for PIC L data-items can come after parent groups

### DIFF
--- a/cobc/ChangeLog
+++ b/cobc/ChangeLog
@@ -1,4 +1,9 @@
 
+2022-11-08  Nicolas Berthier <nicolas.berthier@ocamlpro.com>
+
+	* typeck.c (cb_validate_program_data): DEPENDING var
+	  for PIC L data-items can come after parent groups
+
 2022-10-21  Simon Sobisch <simonsobisch@gnu.org>
 
 	* codegen.c: rewritten codegen for INITIALIZE of table fields,

--- a/cobc/typeck.c
+++ b/cobc/typeck.c
@@ -4688,7 +4688,7 @@ cb_validate_program_data (struct cb_program *prog)
 			}
 			for (; p->sister; p = p->sister) {
 				if (p->sister->level == 66) continue;
-				if (p->sister == depfld && x != xerr) {
+				if (p->sister == depfld && !parent_is_pic_l && x != xerr) {
 					xerr = x;
 					cb_error_x (x,
 					    _("'%s' OCCURS DEPENDING ON field item invalid here"),

--- a/tests/testsuite.src/run_extensions.at
+++ b/tests/testsuite.src/run_extensions.at
@@ -5511,8 +5511,12 @@ AT_DATA([prog.cob], [
            3 X-V       PICTURE LX(10) DEPENDING ON LGX.
            3 X-1       PICTURE X VALUE "1".
        1 W-LGS.
-          2 LGX         USAGE COMP-1 VALUE 10.
-          2 LGY         PIC 9 VALUE 9.
+          2 LGX        USAGE COMP-1 VALUE 10.
+          2 LGY        PICTURE 9 VALUE 9.
+       1 W-NESTED2.
+         2 Z-GRP1.
+           3 Z-V       PICTURE LX(2) DEPENDING ON LGZ.
+         2 LGZ         PICTURE 9 VALUE 2.
        1 W-LEN          USAGE COMP-1.
        PROCEDURE        DIVISION.
        MAIN.
@@ -5815,6 +5819,13 @@ AT_DATA([redefines.cob], [
           2 LGY         PIC 9 VALUE 5.
           2 LGZ         PIC 9 VALUE 7.
           2 LGT         PIC 9 VALUE 5.
+       1 W-DATA2.
+          2 W-X.
+             3 W-TAB0.
+                4 W-PREFIX PIC X(5).
+                4          PIC X(5).
+             3 W-TAB1   REDEFINES W-TAB0 PIC LX(10) DEPENDING LG-TAB1.
+          2 LG-TAB1     COMP-1.
        PROCEDURE        DIVISION.
        MAIN.
            MOVE "......." TO Z-DAT
@@ -5849,6 +5860,12 @@ AT_DATA([redefines.cob], [
               DISPLAY "UNEXPECTED T-DAT/Z-DAT AFTER "
                        "'INITIALIZE Z-DAT': " T-DAT "/" Z-DAT "*"
               PERFORM SHOW-VARS
+           END-IF
+      *    Basic manipulation for late DEPENDING var
+           MOVE "aaaaaaaaaa" TO W-TAB0
+           MOVE 5 TO LG-TAB1
+           IF W-TAB1 NOT EQUAL "aaaaa"
+              DISPLAY "UNEXPECTED W-TAB1 WITH LATE L-VAR: *" W-TAB1 "*"
            END-IF
            STOP RUN
            .


### PR DESCRIPTION
As it turns out, this is supported on GCOS.