### PR TITLE
"FREE" source format means X/Open free-form under MF

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -156,12 +156,13 @@ NEWS - user visible changes				-*- outline -*-
    XCARD		ICOBOL xCard (extended card) format
    XOPEN		X/Open Free-form format
 
-   These formats come with Area A enforcement, that checks whether
-   division, section, and paragraph names start in Area A (i.e, before
-   margin B), and so do level indicators FD, SD, RD, and CD, and level
-   numbers 01, and 77.  The underlying checks are enabled or disabled
-   by default using dialect option `areacheck`, and then with `$SET
-   AREACHECK` and `$SET NOAREACHECK` compiler directives.
+   These formats come with Area A enforcement (except for XOPEN), that
+   checks whether division, section, and paragraph names start in Area
+   A (i.e, before margin B), and so do level indicators FD, SD, RD,
+   and CD, and level numbers 01, and 77.  The underlying checks are
+   enabled or disabled by default using dialect option `areacheck`,
+   and then with `$SET AREACHECK` and `$SET NOAREACHECK` compiler
+   directives.
 
    As a result of reference format being a dialect option, Area A
    enforcement is available and enabled by default for dialects BS2000

--- a/cobc/ChangeLog
+++ b/cobc/ChangeLog
@@ -1,7 +1,7 @@
 
 2022-11-18  Nicolas Berthier <nicolas.berthier@ocamlpro.com>
 
-	* cobc.c (print_line): fully honnor -fmfcomment by suppressing lines
+	* cobc.c (print_line): fully honor -fmfcomment by suppressing lines
 	  that start with an asterisk from listings
 
 2022-11-15  Nicolas Berthier <nicolas.berthier@ocamlpro.com>

--- a/cobc/ChangeLog
+++ b/cobc/ChangeLog
@@ -1,4 +1,9 @@
 
+2022-11-18  Nicolas Berthier <nicolas.berthier@ocamlpro.com>
+
+	* cobc.c (print_line): fully honnor -fmfcomment by suppressing lines
+	  that start with an asterisk from listings
+
 2022-11-15  Nicolas Berthier <nicolas.berthier@ocamlpro.com>
 
 	* pplex.l: allow spaces or tab characters after the `$` in MF-style

--- a/cobc/ChangeLog
+++ b/cobc/ChangeLog
@@ -3,6 +3,12 @@
 
 	* pplex.l: allow spaces or tab characters after the `$` in MF-style
 	  directives
+	* pplex.l (cobc_parse_source_format): select X/Open free-form under MF
+	* pplex.l (cobc_set_source_format): X/Open free-form format allows lines
+	  of up to 255 bytes, and may not be subject to Area A enforcement
+	* cobc.c (process_command_line): handling of `-free` is subject to
+	  `-std`: it is an alias of `-fformat=free` with the MF-specific
+	  semantics of "free" when `-std=mf`
 
 2022-11-08  Nicolas Berthier <nicolas.berthier@ocamlpro.com>
 

--- a/cobc/cobc.c
+++ b/cobc/cobc.c
@@ -2050,7 +2050,7 @@ clean_up_intermediates (struct filename *fn, const int status)
 		return;
 	}
 	if (fn->need_preprocess
-	 && (status 
+	 && (status
 		||  cb_compile_level > CB_LEVEL_PREPROCESS
 		|| (cb_compile_level == CB_LEVEL_PREPROCESS && save_temps))) {
 		cobc_check_action (fn->preprocess);
@@ -6428,6 +6428,11 @@ print_line (struct list_files *cfile, char *line, int line_num, int in_copy)
 		cfile->listing_on = on_off;
 		/* always print the directive itself */
 		do_print = 1;
+	} else if (cb_flag_mfcomment && CB_SF_FIXED (cfile->source_format) && \
+		   line[0] == '*') {
+		/* When MFCOMMENT holds, asterisk in column 1 means comment line
+		   with listing suppression in fixed format. */
+		do_print = 0;
 	} else if (line_has_page_eject (line, cfile->source_format)) {
 		force_new_page_for_next_line ();
 	} else if (line_has_listing_statement (line, cfile->source_format)) {

--- a/cobc/cobc.c
+++ b/cobc/cobc.c
@@ -6428,8 +6428,9 @@ print_line (struct list_files *cfile, char *line, int line_num, int in_copy)
 		cfile->listing_on = on_off;
 		/* always print the directive itself */
 		do_print = 1;
-	} else if (cb_flag_mfcomment && CB_SF_FIXED (cfile->source_format) && \
-		   line[0] == '*') {
+	} else if (line[0] == '*'
+		&& cb_flag_mfcomment
+		&& CB_MFCOMMENT_APPLIES (cfile->source_format)) {
 		/* When MFCOMMENT holds, asterisk in column 1 means comment line
 		   with listing suppression in fixed format. */
 		do_print = 0;

--- a/cobc/cobc.c
+++ b/cobc/cobc.c
@@ -3275,12 +3275,12 @@ process_command_line (const int argc, char **argv)
 
 		case 'F':
 			/* --free, alias of `-fformat=free` */
-			cobc_set_source_format (CB_FORMAT_FREE);
+			(void) cobc_deciph_source_format ("FREE");
 			break;
 
 		case 'f':
 			/* --fixed, alias of `-fformat=fixed` */
-			cobc_set_source_format (CB_FORMAT_FIXED);
+			(void) cobc_deciph_source_format ("FIXED");
 			break;
 
 		case 'q':

--- a/cobc/cobc.h
+++ b/cobc/cobc.h
@@ -113,6 +113,9 @@ enum cb_format {
 #define CB_SF_ALL_NAMES							\
 	"FIXED, FREE, COBOL85, VARIABLE, XOPEN, XCARD, CRT, TERMINAL, COBOLX"
 
+/* Macro to enable/disable features based on source reference-format */
+#define CB_MFCOMMENT_APPLIES(sf) (CB_SF_FIXED (sf) || sf == CB_FORMAT_VARIABLE)
+
 #if 0 /* ancient OSVS registers that need special runtime handling - low priority */
 /* format in CURRENT-DATE register */
 enum cb_current_date {

--- a/cobc/flag.def
+++ b/cobc/flag.def
@@ -169,7 +169,7 @@ CB_FLAG (cb_flag_write_after, 1, "write-after",
 	  "                        * default: BEFORE 1"))
 
 CB_FLAG (cb_flag_mfcomment, 1, "mfcomment",
-	_("  -fmfcomment           '*' or '/' in column 1 treated as comment\n"
+	_("  -fmfcomment           '*' or '/' in column 1 treated as comment with listing suppression\n"
 	  "                        * FIXED format only"))
 
 CB_FLAG (cb_flag_acucomment, 1, "acucomment",

--- a/cobc/flag.def
+++ b/cobc/flag.def
@@ -169,8 +169,8 @@ CB_FLAG (cb_flag_write_after, 1, "write-after",
 	  "                        * default: BEFORE 1"))
 
 CB_FLAG (cb_flag_mfcomment, 1, "mfcomment",
-	_("  -fmfcomment           '*' or '/' in column 1 treated as comment with listing suppression\n"
-	  "                        * FIXED format only"))
+	_("  -fmfcomment           '*' in column 1 treated as comment with listing suppression\n"
+	  "                        * FIXED/COBOL85/VARIABLE format only"))
 
 CB_FLAG (cb_flag_acucomment, 1, "acucomment",
 	_("  -facucomment          '$' in indicator area treated as '*',\n"

--- a/cobc/pplex.l
+++ b/cobc/pplex.l
@@ -2062,11 +2062,11 @@ start:
 			goto start;
 		}
 
-		if (cb_flag_mfcomment) {
-			if (buff[0] == '*' || buff[0] == '/') {
-				newline_count++;
-				goto start;
-			}
+		if (buff[0] == '*'
+		 && cb_flag_mfcomment
+		 && CB_MFCOMMENT_APPLIES (source_format)) {
+			newline_count++;
+			goto start;
 		}
 
 		/* Check if text is longer than text_column */

--- a/cobc/pplex.l
+++ b/cobc/pplex.l
@@ -1504,22 +1504,23 @@ cobc_set_source_format (const enum cb_format sf) {
 		/* This value matches most MF Visual COBOL 4.0 version. */
 		text_column = 250;
 		break;
-	case CB_FORMAT_XOPEN_FFF:
-		text_column = 80;
-		break;
 	case CB_FORMAT_ACUTERM:
 	case CB_FORMAT_ICOBOL_CRT:
 		/* CHECKME:
 		   https://sf.net/p/gnucobol/feature-requests/29/#c2d0/8d2f */
 		text_column = 320;
 		break;
+	case CB_FORMAT_XOPEN_FFF:
 	case CB_FORMAT_COBOLX:
 	case CB_FORMAT_ICOBOL_XCARD:
+		/* For X/Open, this is the number of "bytes" allowed on single
+		   source line as per the X/Open CAE Specification (1991),
+		   Section 7.4 "Limits". */
 		text_column = 255;
 		break;
 	case CB_FORMAT_FREE:
 		/* text-column should be ignored: put an invalid value to catch
-		   some bugs? */
+		   some bugs. */
 		text_column = -1;
 		break;
 	}
@@ -1527,6 +1528,7 @@ cobc_set_source_format (const enum cb_format sf) {
 	switch (source_format) {
 	case CB_FORMAT_FIXED:
 	case CB_FORMAT_FREE:
+	case CB_FORMAT_XOPEN_FFF:
 		emit_area_a_tokens = 0;
 		cobc_areacheck = 0;
 		break;
@@ -1559,7 +1561,11 @@ cobc_parse_source_format (enum cb_format *const out, const char *const sfname) {
 	if (!cb_strcasecmp (sfname, "FIXED")) {
 		format = CB_FORMAT_FIXED;
 	} else if (!cb_strcasecmp (sfname, "FREE")) {
-		format = CB_FORMAT_FREE;
+		/* Note: SOURCEFORMAT"FREE" in MicroFocus dialect actually
+		   selects an X/Open-derived free-form format. */
+		format = (cb_std_define == CB_STD_MF)
+			? CB_FORMAT_XOPEN_FFF
+			: CB_FORMAT_FREE;
 	} else if (!cb_strcasecmp (sfname, "COBOL85")) {
 		format = CB_FORMAT_COBOL85;
 	} else if (!cb_strcasecmp (sfname, "VARIABLE")) {

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,4 +1,9 @@
 
+2022-11-15  Nicolas Berthier <nicolas.berthier@ocamlpro.com>
+
+	* gnucobol.texi: X/Open free-form format allows lines of up to 255
+	  bytes, and may not be subject to Area A enforcement
+
 2022-09-23  Nicolas Berthier <nicolas.berthier@ocamlpro.com>
 
 	* gnucobol.texi: mention Area A enforcement

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -2,7 +2,8 @@
 2022-11-15  Nicolas Berthier <nicolas.berthier@ocamlpro.com>
 
 	* gnucobol.texi: X/Open free-form format allows lines of up to 255
-	  bytes, and may not be subject to Area A enforcement
+	  bytes, and may not be subject to Area A enforcement;
+	  substitute @samp for @code when relevant
 
 2022-09-23  Nicolas Berthier <nicolas.berthier@ocamlpro.com>
 

--- a/doc/gnucobol.texi
+++ b/doc/gnucobol.texi
@@ -445,26 +445,26 @@ Micro Focus' Variable format.  Identical to the fixed format above
 except for the program-text area which extends up to column 250 instead
 of 72.
 
-@item -fformat=xopen
-X/Open Free-form format.  The program-text area may start in column 1
-unless an indicator is present, and lines may contain up to 80
-characters.  Indicator for debugging lines is @code{D } instead of
-@code{D} or @code{d}.
-
 @item -fformat=xcard
 ICOBOL xCard format.  Variable format with right margin set at column
 255 instead of 250.
 
+@item -fformat=xopen
+X/Open Free-form format.  The program-text area may start in column 1
+unless an indicator is present, and lines may contain up to 255
+characters.  Indicator for debugging lines is ``@code{D }'' instead of
+``@code{D}'' or ``@code{d}''.
+
 @item -fformat=crt
 ICOBOL Free-form format (CRT).  Similar to the X/Open format above, with
 lines containing up to 320 characters and single-character debugging
-line indicators (@code{D} or @code{d}).
+line indicators (``@code{D}'' or ``@code{d}'').
 
 @item -fformat=terminal
 ACUCOBOL-GT Terminal format.  Similar to the CRT format above, with
-indicator for debugging lines being @code{\D} instead of @code{D} or
-@code{d}.  This format is mostly compatible with VAX COBOL terminal
-source format.
+indicator for debugging lines being ``@code{\D}'' instead of
+``@code{D}'' or ``@code{d}''.  This format is mostly compatible with VAX
+COBOL terminal source format.
 
 @item -fformat=cobolx
 COBOLX format.  This format is similar to the CRT format above, except
@@ -489,8 +489,8 @@ In general, division, section, and paragraph names must start in Area A.
 In the @code{DATA DIVISION}, level numbers @code{01} and @code{77}, must
 also start in Area A.  In the @code{PROCEDURE DIVISION}s, statements and
 separator periods must fit within Area B.  Every source format listed
-above may be subject to Area A enforcement, except @code{FIXED} and
-@code{FREE}.
+above may be subject to Area A enforcement, except @code{FIXED},
+@code{FREE}, and @code{XOPEN}.
 
 Note that Area A enforcement enables recovery from missing periods
 between paragraphs and sections.

--- a/doc/gnucobol.texi
+++ b/doc/gnucobol.texi
@@ -452,19 +452,19 @@ ICOBOL xCard format.  Variable format with right margin set at column
 @item -fformat=xopen
 X/Open Free-form format.  The program-text area may start in column 1
 unless an indicator is present, and lines may contain up to 255
-characters.  Indicator for debugging lines is ``@code{D }'' instead of
-``@code{D}'' or ``@code{d}''.
+characters.  Indicator for debugging lines is @samp{D } (D followed by
+a space) instead of @samp{D} or @samp{d}.
 
 @item -fformat=crt
 ICOBOL Free-form format (CRT).  Similar to the X/Open format above, with
 lines containing up to 320 characters and single-character debugging
-line indicators (``@code{D}'' or ``@code{d}'').
+line indicators (@samp{D} or @samp{d}).
 
 @item -fformat=terminal
 ACUCOBOL-GT Terminal format.  Similar to the CRT format above, with
-indicator for debugging lines being ``@code{\D}'' instead of
-``@code{D}'' or ``@code{d}''.  This format is mostly compatible with VAX
-COBOL terminal source format.
+indicator for debugging lines being @samp{\D} instead of @samp{D} or
+@samp{d}.  This format is mostly compatible with VAX COBOL terminal
+source format.
 
 @item -fformat=cobolx
 COBOLX format.  This format is similar to the CRT format above, except
@@ -486,7 +486,7 @@ developping COBOL programs that are portable to actual mainframe
 environments.
 
 In general, division, section, and paragraph names must start in Area A.
-In the @code{DATA DIVISION}, level numbers @code{01} and @code{77}, must
+In the @code{DATA DIVISION}, level numbers @samp{01} and @samp{77}, must
 also start in Area A.  In the @code{PROCEDURE DIVISION}s, statements and
 separator periods must fit within Area B.  Every source format listed
 above may be subject to Area A enforcement, except @code{FIXED},
@@ -543,10 +543,10 @@ rather than trying to keep going and printing further error messages.
 
 @end table
 @*
-You can request many specific warnings with options beginning with '@code{-W}',
+You can request many specific warnings with options beginning with @samp{-W},
 for example @option{-Wimplicit-define} to request warnings on implicit declarations.
 Each of these specific warning options also has a negative form beginning
-'@code{-Wno}' to turn off warnings; for example, @option{-Wno-implicit-define}.
+@samp{-Wno} to turn off warnings; for example, @option{-Wno-implicit-define}.
 This manual lists only one of the two forms, whichever is not the default.
 
 Some options, such as @option{-Wall} and @option{-Wextra}, turn on other options,
@@ -803,7 +803,7 @@ LINE    PG/LN  A...B...........................................................
 
 The first part of the listing lists the program text.  If the program text is
 a COPY the line number reflects the COPY line number and is appended with
-a '@code{C}'.
+a @samp{C}.
 
 When the wide list option @option{-T} is specified, the @code{SEQUENCE}
 columns (for fixed-form reference-format) are included in the listing.
@@ -837,7 +837,7 @@ SIZE TYPE           LVL  NAME                           PICTURE
 0004 ALPHANUMERIC   05     FLD4                         X(4)
 @end smallexample
 
-If the symbol redefines another variable the @code{TYPE} is marked with '@code{R}'.
+If the symbol redefines another variable the @code{TYPE} is marked with @samp{R}.
 If the symbol is an array the @code{OCCURS} phrase is in the @code{PICTURE} field.
 
 
@@ -879,7 +879,7 @@ Generate trace code (log executed procedures and statements,
 if tracing is enabled).
 
 @item -fdebugging-line
-Enable debugging lines (@code{D} in indicator column; >>D directive).
+Enable debugging lines (@samp{D} in indicator column; @samp{>>D} directive).
 
 @item -O
 Enable optimization of code size and execution speed.
@@ -905,11 +905,11 @@ Do not truncate binary fields according to PICTURE.
 Add default file extension.
 
 @item -fmfcomment
-Treat lines with @code{*} or @code{/} in column 1 as comment
+Treat lines with @samp{*} or @samp{/} in column 1 as comment
 (fixed-form reference-format only).
 
 @item -acucomment
-Treat @code{|} as an inline comment marker.
+Treat @samp{|} as an inline comment marker.
 
 @item -fsign=ASCII
 @comment{TODO: Clarify}
@@ -967,9 +967,9 @@ One way is to compile all the files in one command:
 $ cobc -x -o prog main.cob subr1.cob subr2.cob
 @end example
 
-Another way is to compile each file with the option @code{-c},
+Another way is to compile each file with the option @option{-c},
 and link them at the end.
-The top-level program must be compiled with the option @code{-x}.
+The top-level program must be compiled with the option @option{-x}.
 
 @example
 $ cobc -c subr1.cob
@@ -1009,7 +1009,7 @@ if (func != NULL)
   func (X);
 @end example
 
-With the compiler option @code{-fstatic-call}, more efficient code
+With the compiler option @option{-fstatic-call}, more efficient code
 will be generated:
 
 @example
@@ -1028,7 +1028,7 @@ the main program and subprograms separately.
 
 @subsubsection Driver program
 
-Compile all programs with the option @code{-m}:
+Compile all programs with the option @option{-m}:
 @example
 $ cobc -m main.cob subr.cob
 @end example
@@ -1062,7 +1062,7 @@ The main program is compiled as usual:
 $ cobc -x -o main main.cob
 @end example
 
-Subprograms are compiled with the option @code{-m}:
+Subprograms are compiled with the option @option{-m}:
 @example
 $ cobc -m subr.cob
 @end example
@@ -1456,7 +1456,7 @@ int say(char *hello, char *world)
 This program is equivalent to the program in @file{say.cob} above.
 
 Note that, unlike C, the arguments passed from COBOL programs are not
-terminated by the null character (i.e., @code{'\0'}).
+terminated by the null character (i.e., @samp{\0}).
 
 You can call this function in the same way you call COBOL programs:
 
@@ -1507,7 +1507,7 @@ $ ./hello
 Hello, world!
 @end example
 
-or with most C compilers by passing option @code{-shared} to the C compiler:
+or with most C compilers by passing option @option{-shared} to the C compiler:
 
 @example
 $ cc -shared -o say.so say.c
@@ -1634,7 +1634,7 @@ C compiler as is and used for C level optimization.
 @section Optimize call
 
 When a @code{CALL} statement is executed, the called program is linked at run
-time.  By specifying the compiler option @code{-fstatic-call}, you can
+time.  By specifying the compiler option @option{-fstatic-call}, you can
 statically link the program at compile time and call it efficiently.
 (@pxref{Static linking})
 

--- a/tests/testsuite.src/listings.at
+++ b/tests/testsuite.src/listings.at
@@ -3566,6 +3566,73 @@ AT_CHECK([diff prog20.lst prog.lis], [0], [], [])
 AT_CLEANUP
 
 
+AT_SETUP([MFCOMMENT])
+AT_KEYWORDS([listing])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      prog.
+       PROCEDURE        DIVISION.
+      *    DISPLAY 'COMMENTASTERISK'
+      /    DISPLAY 'COMMENTSLASH'
+*          DISPLAY 'MFCOMMENTASTERISK'
+/          DISPLAY 'MFCOMMENTSLASH'
+           STOP RUN.
+])
+AT_DATA([prog-nomfcomment.lst.expected],
+[GnuCOBOL V.R.P               prog.cob                   DDD MMM dd HH:MM:SS YYYY
+
+LINE    PG/LN  A...B............................................................
+
+000001
+000002         IDENTIFICATION   DIVISION.
+000003         PROGRAM-ID.      prog.
+000004         PROCEDURE        DIVISION.
+000005        *    DISPLAY 'COMMENTASTERISK'
+
+LINE    PG/LN  A...B............................................................
+
+000006        /    DISPLAY 'COMMENTSLASH'
+000007  *          DISPLAY 'MFCOMMENTASTERISK'
+000008  /          DISPLAY 'MFCOMMENTSLASH'
+000009             STOP RUN.
+
+
+0 warnings in compilation group
+0 errors in compilation group
+])
+AT_DATA([prog-mfcomment.lst.expected],
+[GnuCOBOL V.R.P               prog.cob                   DDD MMM dd HH:MM:SS YYYY
+
+LINE    PG/LN  A...B............................................................
+
+000001
+000002         IDENTIFICATION   DIVISION.
+000003         PROGRAM-ID.      prog.
+000004         PROCEDURE        DIVISION.
+000005        *    DISPLAY 'COMMENTASTERISK'
+
+LINE    PG/LN  A...B............................................................
+
+000006        /    DISPLAY 'COMMENTSLASH'
+000008  /          DISPLAY 'MFCOMMENTSLASH'
+000009             STOP RUN.
+
+
+0 warnings in compilation group
+0 errors in compilation group
+])
+
+AT_CHECK([$COMPILE_ONLY -t prog-nomfcomment.lst -tlines=0             prog.cob], [0], [], [])
+AT_CHECK([$COMPILE_ONLY -t   prog-mfcomment.lst -tlines=0 -fmfcomment prog.cob], [0], [], [])
+AT_CHECK([$UNIFY_LISTING prog-nomfcomment.lst prog-nomfcomment.lis once], [0], [], [])
+AT_CHECK([$UNIFY_LISTING   prog-mfcomment.lst   prog-mfcomment.lis once], [0], [], [])
+AT_CHECK([diff prog-nomfcomment.lst.expected prog-nomfcomment.lis], [0], [], [])
+AT_CHECK([diff   prog-mfcomment.lst.expected   prog-mfcomment.lis], [0], [], [])
+
+AT_CLEANUP
+
+
 AT_SETUP([LISTING directive])
 AT_KEYWORDS([listing])
 

--- a/tests/testsuite.src/run_extensions.at
+++ b/tests/testsuite.src/run_extensions.at
@@ -5176,6 +5176,56 @@ AT_CHECK([$COBCRUN_DIRECT ./fit], [0],
 AT_CLEANUP
 
 
+AT_SETUP([MF FREE format (X/Open)])
+AT_KEYWORDS([fundamental xopen extensions directives])
+
+AT_DATA([prog.cob], [
+IDENTIFICATION DIVISION.
+PROGRAM-ID. prog.
+DATA DIVISION.
+WORKING-STORAGE SECTION.
+1 X PIC 99.
+PROCEDURE DIVISION.
+MAIN.
+COMPUTE X = 6
+* 7
+DISPLAY X NO ADVANCING
+STOP RUN.
+])
+
+AT_CHECK([$COMPILE -free -o prog-free prog.cob], [0], [])
+AT_CHECK([$COBCRUN_DIRECT ./prog-free], [0], [42])
+
+AT_CHECK([$COMPILE -std=mf -fformat=free -o prog-mf-fformat-free prog.cob], [0], [])
+AT_CHECK([$COBCRUN_DIRECT ./prog-mf-fformat-free], [0], [06])
+
+AT_CHECK([$COMPILE -std=mf -free -o prog-mf-free prog.cob], [0], [])
+AT_CHECK([$COBCRUN_DIRECT ./prog-mf-free], [0], [06])
+
+AT_DATA([prog2.cob], [
+      $SET SOURCEFORMAT"FREE"
+IDENTIFICATION DIVISION.
+PROGRAM-ID. prog.
+DATA DIVISION.
+WORKING-STORAGE SECTION.
+1 X PIC 99.
+PROCEDURE DIVISION.
+MAIN.
+COMPUTE X = 6
+* 7
+DISPLAY X NO ADVANCING
+STOP RUN.
+])
+
+AT_CHECK([$COMPILE prog2.cob], [0], [], [])
+AT_CHECK([$COBCRUN_DIRECT ./prog2], [0], [42])
+
+AT_CHECK([$COMPILE -std=mf -o prog2-mf prog2.cob], [0], [])
+AT_CHECK([$COBCRUN_DIRECT ./prog2-mf], [0], [06])
+
+AT_CLEANUP
+
+
 AT_SETUP([Binary COMP-1 (1)])
 AT_KEYWORDS([extensions])
 

--- a/tests/testsuite.src/syn_misc.at
+++ b/tests/testsuite.src/syn_misc.at
@@ -2729,14 +2729,12 @@ AT_DATA([prog.cob], [
        DATA             DIVISION.
        WORKING-STORAGE  SECTION.
        PROCEDURE        DIVISION.
-      *    DISPLAY 'COMMENT'             END-DISPLAY
-      /    DISPLAY 'COMMENTSLASH'        END-DISPLAY
-*          DISPLAY 'MFCOMMENTASTERISK'   END-DISPLAY
-/          DISPLAY 'MFCOMMENTSLASH'      END-DISPLAY
- *         DISPLAY 'NOMFCOMMENTASTERISK' END-DISPLAY
- /         DISPLAY 'NOMFCOMMENTSLASH'    END-DISPLAY
-        *> DISPLAY 'FLOATING'            END-DISPLAY
- *>        DISPLAY 'NOFLOATING'          END-DISPLAY
+      *    DISPLAY 'COMMENT'      END-DISPLAY
+      /    DISPLAY 'COMMENTSLASH' END-DISPLAY
+*          DISPLAY 'MFCOMMENT'    END-DISPLAY
+ *         DISPLAY 'NOMFCOMMENT'  END-DISPLAY
+        *> DISPLAY 'FLOATING'     END-DISPLAY
+ *>        DISPLAY 'NOFLOATING'   END-DISPLAY
            STOP RUN.
 ])
 
@@ -2748,17 +2746,15 @@ AT_DATA([prog2.cob], [
        DATA             DIVISION.
        WORKING-STORAGE  SECTION.
        PROCEDURE        DIVISION.
-      *    DISPLAY 'COMMENT'             END-DISPLAY
-      /    DISPLAY 'COMMENTSLASH'        END-DISPLAY
-      $    DISPLAY 'COMMENTDOLLAR'       END-DISPLAY
-*          DISPLAY 'MFCOMMENTASTERISK'   END-DISPLAY
-/          DISPLAY 'MFCOMMENTSLASH'      END-DISPLAY
- *         DISPLAY 'NOMFCOMMENTASTERISK' END-DISPLAY
- /         DISPLAY 'NOMFCOMMENTSLASH'    END-DISPLAY
-        *> DISPLAY 'FLOATING'            END-DISPLAY
-        |  DISPLAY 'ACUFLOATING'         END-DISPLAY
- |         DISPLAY 'NOACUFLOATING'       END-DISPLAY
- *>        DISPLAY 'NOFLOATING'          END-DISPLAY
+      *    DISPLAY 'COMMENT'       END-DISPLAY
+      /    DISPLAY 'COMMENTSLASH'  END-DISPLAY
+      $    DISPLAY 'COMMENTDOLLAR' END-DISPLAY
+*          DISPLAY 'MFCOMMENT'     END-DISPLAY
+ *         DISPLAY 'NOMFCOMMENT'   END-DISPLAY
+        *> DISPLAY 'FLOATING'      END-DISPLAY
+        |  DISPLAY 'ACUFLOATING'   END-DISPLAY
+ |         DISPLAY 'NOACUFLOATING' END-DISPLAY
+ *>        DISPLAY 'NOFLOATING'    END-DISPLAY
            STOP RUN.
 ])
 
@@ -2770,30 +2766,27 @@ CONFIGURATION SECTION.
 DATA             DIVISION.
 WORKING-STORAGE  SECTION.
 PROCEDURE        DIVISION.
-      * DISPLAY 'NOCOMMENT'           END-DISPLAY
-      / DISPLAY 'NOCOMMENTSLASH'      END-DISPLAY
-$       DISPLAY 'ACUCOMMENTDOLLAR'    END-DISPLAY
-*       DISPLAY 'NOMFCOMMENTASTERISK' END-DISPLAY
-/       DISPLAY 'NOMFCOMMENTSLASH'    END-DISPLAY
- |      DISPLAY 'ACUFLOATING'         END-DISPLAY
- *>     DISPLAY 'FLOATING'            END-DISPLAY
-      x DISPLAY 'WRONGINDICATOR'      END-DISPLAY
+      * DISPLAY 'NOCOMMENT'        END-DISPLAY
+      / DISPLAY 'NOCOMMENTSLASH'   END-DISPLAY
+$       DISPLAY 'ACUCOMMENTDOLLAR' END-DISPLAY
+*       DISPLAY 'NOMFCOMMENT'      END-DISPLAY
+ |      DISPLAY 'ACUFLOATING'      END-DISPLAY
+ *>     DISPLAY 'FLOATING'         END-DISPLAY
+      x DISPLAY 'WRONGINDICATOR'   END-DISPLAY
         STOP RUN.
 ])
 
 AT_CHECK([$COMPILE prog.cob], [0], [], [])
 
 AT_CHECK([$COBCRUN_DIRECT ./prog], [0],
-[MFCOMMENTASTERISK
-MFCOMMENTSLASH
-NOMFCOMMENTASTERISK
-NOMFCOMMENTSLASH
+[MFCOMMENT
+NOMFCOMMENT
 NOFLOATING
 ], [])
 
 AT_CHECK([$COMPILE_ONLY prog2.cob], [1], [],
 [prog2.cob:11: error: invalid indicator '$' at column 7
-prog2.cob:17: error: invalid symbol '|' - skipping word
+prog2.cob:15: error: invalid symbol '|' - skipping word
 ])
 
 # note: for checking the result we actually either need to run the program
@@ -2804,24 +2797,21 @@ AT_CHECK([$COMPILE -fmfcomment prog.cob], [0], [],
 [])
 
 AT_CHECK([$COBCRUN_DIRECT ./prog], [0],
-[NOMFCOMMENTASTERISK
-NOMFCOMMENTSLASH
+[NOMFCOMMENT
 NOFLOATING
 ], [])
 
 AT_CHECK([$COMPILE_ONLY -fmfcomment prog2.cob], [1], [],
 [prog2.cob:11: error: invalid indicator '$' at column 7
-prog2.cob:17: error: invalid symbol '|' - skipping word
+prog2.cob:15: error: invalid symbol '|' - skipping word
 ])
 
 # COMPILE needed, see note above
 AT_CHECK([$COMPILE -facucomment prog.cob -o prog1], [0], [], [])
 
 AT_CHECK([$COBCRUN_DIRECT ./prog1], [0],
-[MFCOMMENTASTERISK
-MFCOMMENTSLASH
-NOMFCOMMENTASTERISK
-NOMFCOMMENTSLASH
+[MFCOMMENT
+NOMFCOMMENT
 NOFLOATING
 ], [])
 
@@ -2829,10 +2819,8 @@ NOFLOATING
 AT_CHECK([$COMPILE -facucomment prog2.cob], [0], [], [])
 
 AT_CHECK([$COBCRUN_DIRECT ./prog2], [0],
-[MFCOMMENTASTERISK
-MFCOMMENTSLASH
-NOMFCOMMENTASTERISK
-NOMFCOMMENTSLASH
+[MFCOMMENT
+NOMFCOMMENT
 NOACUFLOATING
 NOFLOATING
 ], [])
@@ -2843,31 +2831,28 @@ AT_CHECK([$COMPILE_ONLY -free prog3.cob], [1], [],
 prog3.cob:9: error: syntax error, unexpected *
 prog3.cob:10: error: syntax error, unexpected /
 prog3.cob:12: error: syntax error, unexpected *
-prog3.cob:13: error: syntax error, unexpected /
-prog3.cob:14: error: invalid symbol '|' - skipping word
-prog3.cob:16: error: syntax error, unexpected Identifier
+prog3.cob:13: error: invalid symbol '|' - skipping word
+prog3.cob:15: error: syntax error, unexpected Identifier
 ])
 AT_CHECK([$COMPILE_ONLY -free -fmfcomment prog3.cob], [1], [],
 [prog3.cob:11: warning: ignoring invalid directive: '$       DISPLAY'
 prog3.cob:9: error: syntax error, unexpected *
 prog3.cob:10: error: syntax error, unexpected /
 prog3.cob:12: error: syntax error, unexpected *
-prog3.cob:13: error: syntax error, unexpected /
-prog3.cob:14: error: invalid symbol '|' - skipping word
-prog3.cob:16: error: syntax error, unexpected Identifier
+prog3.cob:13: error: invalid symbol '|' - skipping word
+prog3.cob:15: error: syntax error, unexpected Identifier
 ])
 AT_CHECK([$COMPILE_ONLY -free -facucomment prog3.cob], [1], [],
 [prog3.cob:11: warning: ignoring invalid directive: '$       DISPLAY'
 prog3.cob:9: error: syntax error, unexpected *
 prog3.cob:10: error: syntax error, unexpected /
 prog3.cob:12: error: syntax error, unexpected *
-prog3.cob:13: error: syntax error, unexpected /
-prog3.cob:16: error: syntax error, unexpected Identifier
+prog3.cob:15: error: syntax error, unexpected Identifier
 ])
 AT_CHECK([$COMPILE_ONLY -fformat=terminal -facucomment prog3.cob], [1], [],
 [prog3.cob:9: error: syntax error, unexpected *
 prog3.cob:10: error: syntax error, unexpected /
-prog3.cob:16: error: syntax error, unexpected Identifier
+prog3.cob:15: error: syntax error, unexpected Identifier
 ])
 # Check that invalid indicator and doesn't abort preprocessing
 # and that errors in preprocessing doesn't abort compilation
@@ -2878,7 +2863,7 @@ prog3.cob:4: error: invalid indicator 'N' at column 7
 prog3.cob:5: error: invalid indicator 'U' at column 7
 prog3.cob:7: error: invalid indicator 'G' at column 7
 prog3.cob:8: error: invalid indicator 'U' at column 7
-prog3.cob:16: error: invalid indicator 'x' at column 7
+prog3.cob:15: error: invalid indicator 'x' at column 7
 prog3.cob:6: error: PROGRAM-ID header missing
 prog3.cob:6: error: PROCEDURE DIVISION header missing
 prog3.cob:6: error: syntax error, unexpected DIVISION


### PR DESCRIPTION
I've recently come across some COBOL source files *apparently* targeting MicroFocus, where comments could be seen as lines starting with a `*` after a `$ SET SOURCEFORMAT"FREE"` directive. This appears to be backed up by https://www.microfocus.com/documentation/visual-cobol/vc50pu7/VS2019/HRLHLHINTR01U008.html .
This PR is a suggestion to handle `*`|`/`-starting lines as comments when the `-fmfcomment` is given, even in FREE reference source format.

The space between `$` and `SET` in the directive is neither documented not supported by GnuCOBOL. I'm not sure whether this is actually allowed.