### PR TITLE
New default-colseq flag to configure program's default COLLATING SEQUENCE

### DIFF
--- a/cobc/ChangeLog
+++ b/cobc/ChangeLog
@@ -1,4 +1,12 @@
 
+2022-12-09  Nicolas Berthier <nicolas.berthier@ocamlpro.com>
+
+	* flag.def, cobc.c (process_command_line): add new default-colseq flag
+	* tree.h, typeck.c (cb_deciph_default_colseq_name): new helper function
+	* typeck.c (cb_declare_default_colseq, cb_init_default_colseq)
+	  (cb_validate_program_data): initialize default collating sequence for
+	  programs when the default-colseq flag is not NATIVE
+
 2022-12-05  Nicolas Berthier <nicolas.berthier@ocamlpro.com>
 
 	* cobc.c: replace some incorrect '%d' format indicators with '%lu'

--- a/cobc/ChangeLog
+++ b/cobc/ChangeLog
@@ -1,11 +1,12 @@
 
 2022-12-09  Nicolas Berthier <nicolas.berthier@ocamlpro.com>
 
+	FR 426 Default collation option
 	* flag.def, cobc.c (process_command_line): add new default-colseq flag
-	* tree.h, typeck.c (cb_deciph_default_colseq_name): new helper function
-	* typeck.c (cb_declare_default_colseq, cb_init_default_colseq)
-	  (cb_validate_program_data): initialize default collating sequence for
-	  programs when the default-colseq flag is not NATIVE
+	* tree.h, parser.y (cb_deciph_default_colseq_name): new helper function
+	* parser.y (build_default_colseq, setup_default_colseq, setup_program):
+	  initialize default collating sequence for programs when the
+	  default-colseq flag is not NATIVE
 
 2022-12-05  Nicolas Berthier <nicolas.berthier@ocamlpro.com>
 

--- a/cobc/cobc.c
+++ b/cobc/cobc.c
@@ -3596,6 +3596,13 @@ process_command_line (const int argc, char **argv)
 			}
 			break;
 
+		case 15:
+			/* -fdefault-colseq=<ASCII/EBCDIC/NATIVE> */
+			if (cb_deciph_default_colseq_name (cob_optarg)) {
+				cobc_err_exit (COBC_INV_PAR, "-fdefault-colseq");
+			}
+			break;
+
 		case 4:
 			/* -ffold-copy=<UPPER/LOWER> : COPY fold case */
 			if (!cb_strcasecmp (cob_optarg, "UPPER")) {

--- a/cobc/flag.def
+++ b/cobc/flag.def
@@ -99,6 +99,10 @@ CB_FLAG_NQ (1, "ebcdic-table", 14, /* cf cconv.h for all available tables */
 	  "                        * ibm: translation to restricted ASCII as per IBM\n"
 	  "                        * gcos: translation to extended ASCII as per GCOS7"))
 
+CB_FLAG_NQ (1, "default-colseq", 15,
+	_("  -fdefault-colseq=[ASCII|EBCDIC|NATIVE]\tdefine default collating sequence\n"
+	  "                        * default: NATIVE"))
+
 /* Binary flags */
 
 /* Flags with suppressed help */

--- a/cobc/parser.y
+++ b/cobc/parser.y
@@ -272,6 +272,7 @@ static cb_tree			xml_encoding;
 static int			with_xml_dec;
 static int			with_attrs;
 
+static cb_tree			default_collation;
 static cb_tree			alphanumeric_collation;
 static cb_tree			national_collation;
 
@@ -333,6 +334,64 @@ check_non_area_a (cb_tree stmt) {
 			(void) cb_syntax_check (_("start of statement in Area A"));
 	}
 }
+
+/* Collating sequences */
+
+/* Known collating sequences/alphabets */
+enum {
+	CB_COLSEQ_NATIVE,
+	CB_COLSEQ_ASCII,
+	CB_COLSEQ_EBCDIC,
+} cb_default_colseq = CB_COLSEQ_NATIVE;
+
+/* Decipher character conversion table names */
+int cb_deciph_default_colseq_name (const char * const name)
+{
+	if (! cb_strcasecmp (name, "ASCII")) {
+		cb_default_colseq = CB_COLSEQ_ASCII;
+	} else if (! cb_strcasecmp (name, "EBCDIC")) {
+		cb_default_colseq = CB_COLSEQ_EBCDIC;
+	} else if (! cb_strcasecmp (name, "NATIVE")) {
+		cb_default_colseq = CB_COLSEQ_NATIVE;
+	} else {
+		return 1;
+	}
+	return 0;
+}
+
+static void
+build_default_colseq (const char *alphabet_name,
+		      int alphabet_type,
+		      int alphabet_target)
+{
+	const cb_tree name = cb_build_reference (alphabet_name);
+	struct cb_alphabet_name * alpha;
+	alpha = CB_ALPHABET_NAME (cb_build_alphabet_name (name));
+	alpha->alphabet_type = alphabet_type;
+	alpha->alphabet_target = alphabet_target;
+	default_collation = name;
+}
+
+static void
+setup_default_colseq (void)
+{
+	switch (cb_default_colseq) {
+	case CB_COLSEQ_NATIVE:
+		default_collation = NULL;
+		break;
+	case CB_COLSEQ_ASCII:
+		build_default_colseq ("ASCII",
+				      CB_ALPHABET_ASCII,
+				      CB_ALPHABET_ALPHANUMERIC);
+		break;
+	case CB_COLSEQ_EBCDIC:
+		build_default_colseq ("EBCDIC",
+				      CB_ALPHABET_EBCDIC,
+				      CB_ALPHABET_ALPHANUMERIC);
+		break;
+	}
+}
+
 
 /* Statements */
 
@@ -1255,6 +1314,9 @@ setup_program (cb_tree id, cb_tree as_literal, const unsigned char type, const i
 	if (CB_REFERENCE_P (id)) {
 		cb_define (id, CB_TREE (current_program));
 	}
+
+	/* Initalize default COLLATING SEQUENCE */
+	setup_default_colseq ();
 
 	begin_scope_of_program_name (current_program);
 
@@ -5522,7 +5584,7 @@ collating_sequence_clause:
 collating_sequence:
   _collating SEQUENCE
   {
-	alphanumeric_collation = national_collation = NULL;
+	alphanumeric_collation = national_collation = default_collation;
   }
   coll_sequence_values
 ;
@@ -16088,7 +16150,7 @@ _sort_duplicates:
 _sort_collating:
   /* empty */
   {
-	alphanumeric_collation = national_collation = NULL;
+	alphanumeric_collation = national_collation = default_collation;
   }
 | collating_sequence
 ;

--- a/cobc/tree.c
+++ b/cobc/tree.c
@@ -626,7 +626,7 @@ cb_name_1 (char *s, cb_tree x, const int size)
 			size_element = cb_name_1 (buff, p->offset, COB_SMALL_BUFF);
 			if (size_real + size_element + 6 >= size) {
 				/* drop that " (X:Y) [in Z]" */
-				return size_real;	
+				return size_real;
 			}
 			if (p->length) {
 				size_refmod = sprintf (s, " (%s:", buff);

--- a/cobc/tree.h
+++ b/cobc/tree.h
@@ -2207,6 +2207,8 @@ extern cb_tree		cb_debug_sub_2;
 extern cb_tree		cb_debug_sub_3;
 extern cb_tree		cb_debug_contents;
 
+extern int		cb_deciph_default_colseq_name (const char *const);
+
 extern struct cb_program	*cb_build_program (struct cb_program *,
 						   const int);
 

--- a/cobc/typeck.c
+++ b/cobc/typeck.c
@@ -4047,74 +4047,10 @@ check_class_duplicates (cb_tree class_name)
 	}
 }
 
-/* Known collating sequences/alphabets */
-enum {
-	CB_COLSEQ_NATIVE,
-	CB_COLSEQ_ASCII,
-	CB_COLSEQ_EBCDIC,
-} cb_default_colseq = CB_COLSEQ_NATIVE;
-
-/* Decipher character conversion table names */
-int cb_deciph_default_colseq_name (const char * const name)
-{
-	if (! cb_strcasecmp (name, "ASCII")) {
-		cb_default_colseq = CB_COLSEQ_ASCII;
-	} else if (! cb_strcasecmp (name, "EBCDIC")) {
-		cb_default_colseq = CB_COLSEQ_EBCDIC;
-	} else if (! cb_strcasecmp (name, "NATIVE")) {
-		cb_default_colseq = CB_COLSEQ_NATIVE;
-	} else {
-		return 1;
-	}
-	return 0;
-}
-
-static void
-cb_declare_default_colseq (struct cb_program *prog,
-			   const char *alphabet_name,
-			   int alphabet_type,
-			   int alphabet_target)
-{
-	const cb_tree name = cb_build_reference (alphabet_name);
-	struct cb_alphabet_name * alpha;
-	alpha = CB_ALPHABET_NAME (cb_build_alphabet_name (name));
-	alpha->alphabet_type = alphabet_type;
-	alpha->alphabet_target = alphabet_target;
-	/* CHECKME: check it's already in the list? */
-	prog->alphabet_name_list = cb_list_add (prog->alphabet_name_list,
-						CB_TREE (alpha));
-	prog->collating_sequence = name;
-}
-
-static void
-cb_init_default_colseq (struct cb_program *prog)
-{
-	if (prog->collating_sequence) /* already set */
-		return;
-
-	switch (cb_default_colseq) {
-	case CB_COLSEQ_NATIVE:
-		break;
-	case CB_COLSEQ_ASCII:
-		cb_declare_default_colseq (prog, "ASCII",
-					   CB_ALPHABET_ASCII,
-					   CB_ALPHABET_ALPHANUMERIC);
-		break;
-	case CB_COLSEQ_EBCDIC:
-		cb_declare_default_colseq (prog, "EBCDIC",
-					   CB_ALPHABET_EBCDIC,
-					   CB_ALPHABET_ALPHANUMERIC);
-		break;
-	}
-}
-
 void
 cb_validate_program_environment (struct cb_program *prog)
 {
 	cb_tree			l;
-
-	/* Assign default collating sequence if needed: */
-	cb_init_default_colseq (prog);
 
 	/* Check ALPHABET clauses */
 	/* Complicated by difference between code set and collating sequence */

--- a/cobc/typeck.c
+++ b/cobc/typeck.c
@@ -4047,10 +4047,74 @@ check_class_duplicates (cb_tree class_name)
 	}
 }
 
+/* Known collating sequences/alphabets */
+enum {
+	CB_COLSEQ_NATIVE,
+	CB_COLSEQ_ASCII,
+	CB_COLSEQ_EBCDIC,
+} cb_default_colseq = CB_COLSEQ_NATIVE;
+
+/* Decipher character conversion table names */
+int cb_deciph_default_colseq_name (const char * const name)
+{
+	if (! cb_strcasecmp (name, "ASCII")) {
+		cb_default_colseq = CB_COLSEQ_ASCII;
+	} else if (! cb_strcasecmp (name, "EBCDIC")) {
+		cb_default_colseq = CB_COLSEQ_EBCDIC;
+	} else if (! cb_strcasecmp (name, "NATIVE")) {
+		cb_default_colseq = CB_COLSEQ_NATIVE;
+	} else {
+		return 1;
+	}
+	return 0;
+}
+
+static void
+cb_declare_default_colseq (struct cb_program *prog,
+			   const char *alphabet_name,
+			   int alphabet_type,
+			   int alphabet_target)
+{
+	const cb_tree name = cb_build_reference (alphabet_name);
+	struct cb_alphabet_name * alpha;
+	alpha = CB_ALPHABET_NAME (cb_build_alphabet_name (name));
+	alpha->alphabet_type = alphabet_type;
+	alpha->alphabet_target = alphabet_target;
+	/* CHECKME: check it's already in the list? */
+	prog->alphabet_name_list = cb_list_add (prog->alphabet_name_list,
+						CB_TREE (alpha));
+	prog->collating_sequence = name;
+}
+
+static void
+cb_init_default_colseq (struct cb_program *prog)
+{
+	if (prog->collating_sequence) /* already set */
+		return;
+
+	switch (cb_default_colseq) {
+	case CB_COLSEQ_NATIVE:
+		break;
+	case CB_COLSEQ_ASCII:
+		cb_declare_default_colseq (prog, "ASCII",
+					   CB_ALPHABET_ASCII,
+					   CB_ALPHABET_ALPHANUMERIC);
+		break;
+	case CB_COLSEQ_EBCDIC:
+		cb_declare_default_colseq (prog, "EBCDIC",
+					   CB_ALPHABET_EBCDIC,
+					   CB_ALPHABET_ALPHANUMERIC);
+		break;
+	}
+}
+
 void
 cb_validate_program_environment (struct cb_program *prog)
 {
 	cb_tree			l;
+
+	/* Assign default collating sequence if needed: */
+	cb_init_default_colseq (prog);
 
 	/* Check ALPHABET clauses */
 	/* Complicated by difference between code set and collating sequence */

--- a/tests/testsuite.src/run_misc.at
+++ b/tests/testsuite.src/run_misc.at
@@ -3518,6 +3518,42 @@ AT_CHECK([$COBCRUN_DIRECT ./prog2], [0], [], [])
 AT_CLEANUP
 
 
+AT_SETUP([SORT: table sort with default COLLATING SEQUENCE])
+AT_KEYWORDS([runmisc EBCDIC ASCII default-colseq])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      prog.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01 Z  PIC X(10)  VALUE "d4b2e1a3c5".
+       01 G             REDEFINES Z.
+         02 TBL         OCCURS 10.
+           03 X         PIC X.
+       PROCEDURE        DIVISION.
+           SORT TBL ASCENDING KEY X.
+      >>IF   EXPECT-ORDER  =  'ASCII'
+           IF G NOT = "12345abcde"
+      >>ELIF EXPECT-ORDER  =  'EBCDIC'
+           IF G NOT = "abcde12345"
+      >>ELSE           *>  =  'NATIVE'
+           IF NOT G = "12345abcde" OR "abcde12345"
+      >>END-IF
+              DISPLAY G END-DISPLAY
+           END-IF.
+           STOP RUN.
+])
+
+AT_CHECK([$COMPILE -fdefault-colseq=ascii -DEXPECT-ORDER=ASCII -o ascii prog.cob], [0], [], [])
+AT_CHECK([$COBCRUN_DIRECT ./ascii], [0], [], [])
+AT_CHECK([$COMPILE -fdefault-colseq=ebcdic -DEXPECT-ORDER=EBCDIC -o ebcdic prog.cob], [0], [], [])
+AT_CHECK([$COBCRUN_DIRECT ./ebcdic], [0], [], [])
+AT_CHECK([$COMPILE -fdefault-colseq=native -DEXPECT-ORDER=NATIVE -o native prog.cob], [0], [], [])
+AT_CHECK([$COBCRUN_DIRECT ./native], [0], [], [])
+
+AT_CLEANUP
+
+
 AT_SETUP([PIC ZZZ-, ZZZ+])
 AT_KEYWORDS([runmisc editing])
 


### PR DESCRIPTION
In the end this relies more on "alphabets" than "collating sequences", so I'm not sure yet whether the approach is appropriate, or if the option is properly named.