### PR TITLE
Fix REDEFINES GLOBAL

### DIFF
--- a/cobc/ChangeLog
+++ b/cobc/ChangeLog
@@ -847,6 +847,11 @@
 	* tree.c: fix bug #772 check for report field missing PIC
 	  when using SUM clause
 
+2021-12-21  Samuel Belondrade <samuel.belondrade@atos.net>
+
+	* codegen.c (output_base): fix undeclared variable with REDEFINE GLOBAL
+	  [bugs:#777]
+
 2021-12-14  Simon Sobisch <simonsobisch@gnu.org>
 
 	* cobc.c (print_fields), codegen.c (output_field_display): only check for

--- a/cobc/codegen.c
+++ b/cobc/codegen.c
@@ -1059,7 +1059,7 @@ output_base (struct cb_field *f, const cob_u32_t no_output)
 				bl = cobc_parse_malloc (sizeof (struct base_list));
 				bl->f = f01;
 				bl->curr_prog = excp_current_program_id;
-				if (f01->flag_is_global ||
+				if (f01->flag_is_global || f->flag_is_global ||
 				    current_prog->flag_file_global) {
 					bl->next = base_cache;
 					base_cache = bl;

--- a/tests/testsuite.src/run_extensions.at
+++ b/tests/testsuite.src/run_extensions.at
@@ -3043,6 +3043,25 @@ AT_CHECK([$COBCRUN_DIRECT ./prog], [0], [], [])
 AT_CLEANUP
 
 
+AT_SETUP([REDEFINES: as GLOBAL item])
+AT_KEYWORDS([extensions redefines])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. prog.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01 T0 PIC X VALUE "X".
+       01 T1 REDEFINES T0 PIC X GLOBAL.
+       PROCEDURE DIVISION.
+          DISPLAY T1.
+])
+
+AT_CHECK([$COMPILE prog.cob], [0], [], [])
+
+AT_CLEANUP
+
+
 AT_SETUP([Obsolete 2002 keywords with COBOL2014])
 AT_KEYWORDS([extensions])
 

--- a/tests/testsuite.src/run_extensions.at
+++ b/tests/testsuite.src/run_extensions.at
@@ -3043,25 +3043,6 @@ AT_CHECK([$COBCRUN_DIRECT ./prog], [0], [], [])
 AT_CLEANUP
 
 
-AT_SETUP([REDEFINES: as GLOBAL item])
-AT_KEYWORDS([extensions redefines])
-
-AT_DATA([prog.cob], [
-       IDENTIFICATION DIVISION.
-       PROGRAM-ID. prog.
-       DATA DIVISION.
-       WORKING-STORAGE SECTION.
-       01 T0 PIC X VALUE "X".
-       01 T1 REDEFINES T0 PIC X GLOBAL.
-       PROCEDURE DIVISION.
-          DISPLAY T1.
-])
-
-AT_CHECK([$COMPILE prog.cob], [0], [], [])
-
-AT_CLEANUP
-
-
 AT_SETUP([Obsolete 2002 keywords with COBOL2014])
 AT_KEYWORDS([extensions])
 

--- a/tests/testsuite.src/run_fundamental.at
+++ b/tests/testsuite.src/run_fundamental.at
@@ -1272,6 +1272,25 @@ AT_CHECK([$COBCRUN_DIRECT ./prog], [0],
 AT_CLEANUP
 
 
+AT_SETUP([GLOBAL REDEFINES])
+AT_KEYWORDS([fundamental])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. prog.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01 T0 PIC X VALUE "X".
+       01 T1 REDEFINES T0 PIC X GLOBAL.
+       PROCEDURE DIVISION.
+          DISPLAY T1.
+])
+
+AT_CHECK([$COMPILE prog.cob], [0], [], [])
+
+AT_CLEANUP
+
+
 AT_SETUP([function with variable-length RETURNING item])
 AT_KEYWORDS([fundamental udf])
 


### PR DESCRIPTION
To assess whether the test is appropriately placed if into `run_extensions.at`. It's not just syntax-related, so I'm not sure it'd fit into `syn_redefines.at`.