### PR TITLE
New options to deal with character encodings

### DIFF
--- a/cobc/ChangeLog
+++ b/cobc/ChangeLog
@@ -1,4 +1,11 @@
 
+2023-01-20 David Declerck <david.declerck@ocamlpro.com>
+
+	* flag.def, cobc.c, cobc.h: new flags to deal with collating sequences
+	  and character encodings: -fnative-charset, -ftarget-charset,
+	  -fconvert-ascii, -fconvert-ebcdic, -fcodeset-ascii and -fcodeset-ebcdic
+	* codegen.c, parser.y: handle new character encoding options
+
 2023-01-16  Simon Sobisch <simonsobisch@gnu.org>
 
 	* parser.y (occurs_index): only set VALUE 1 for defaultbyte == INIT

--- a/cobc/cobc.c
+++ b/cobc/cobc.c
@@ -225,6 +225,12 @@ const char		*cob_config_dir = NULL;
 FILE			*cb_storage_file = NULL;
 FILE			*cb_listing_file = NULL;
 FILE			*cb_depend_file = NULL;
+const char		*cb_native_charset = NULL;
+const char		*cb_target_charset = NULL;
+const char		*cb_convert_ascii = NULL;
+const char		*cb_convert_ebcdic = NULL;
+const char		*cb_codeset_ascii = NULL;
+const char		*cb_codeset_ebcdic = NULL;
 
 /* Listing structures and externals */
 
@@ -3667,6 +3673,36 @@ process_command_line (const int argc, char **argv)
 			if (cb_deciph_default_colseq_name (cob_optarg)) {
 				cobc_err_exit (COBC_INV_PAR, "-fdefault-colseq");
 			}
+			break;
+
+		case 16:
+			/* -native-charset=<charset-name> */
+			cb_native_charset = cobc_main_strdup (cob_optarg);
+			break;
+
+		case 17:
+			/* -target-charset=<charset-name> */
+			cb_target_charset = cobc_main_strdup (cob_optarg);
+			break;
+
+		case 18:
+			/* -fconvert-ascii=<charset-name> */
+			cb_convert_ascii = cobc_main_strdup (cob_optarg);
+			break;
+
+		case 19:
+			/* -fconvert-ebcdic=<charset-name> */
+			cb_convert_ebcdic = cobc_main_strdup (cob_optarg);
+			break;
+
+		case 20:
+			/* -fcodeset-ascii=<charset-name> */
+			cb_codeset_ascii = cobc_main_strdup (cob_optarg);
+			break;
+
+		case 21:
+			/* -codeset-ebcdic=<charset-name> */
+			cb_codeset_ebcdic = cobc_main_strdup (cob_optarg);
 			break;
 
 		case 4:

--- a/cobc/cobc.h
+++ b/cobc/cobc.h
@@ -480,6 +480,13 @@ extern int			functions_are_all;
 extern struct cb_tree_common	*defined_prog_list;
 extern int			current_call_convention;
 
+extern const char		*cb_native_charset;
+extern const char		*cb_target_charset;
+extern const char		*cb_convert_ascii;
+extern const char		*cb_convert_ebcdic;
+extern const char		*cb_codeset_ascii;
+extern const char		*cb_codeset_ebcdic;
+
 /* Functions */
 
 /* cobc.c */

--- a/cobc/flag.def
+++ b/cobc/flag.def
@@ -103,6 +103,24 @@ CB_FLAG_NQ (1, "default-colseq", 15,
 	_("  -fdefault-colseq=[ASCII|EBCDIC|NATIVE]\tdefine default collating sequence\n"
 	  "                        * default: NATIVE"))
 
+CB_FLAG_NQ (1, "native-charset", 16,
+	_("  -fnative-charset=<charset-name>\tset the charset of the execution environment"))
+
+CB_FLAG_NQ (1, "target-charset", 17,
+	_("  -ftarget-charset=<charset-name>\tset the charset of the simulated environment"))
+
+CB_FLAG_NQ (1, "convert-ascii", 18,
+	_("  -fconvert-ascii=<charset-name>\tset the ASCII charset to use in CONVERT clauses"))
+
+CB_FLAG_NQ (1, "convert-ebcdic", 19,
+	_("  -fconvert-ebcdic=<charset-name>\tset the EBCDIC charset to use in CONVERT clauses"))
+
+CB_FLAG_NQ ( 1, "codeset-ascii", 20,
+	_("  -fcodeset-ascii=<charset-name>\tset the ASCII charset to use in CODE-SET clauses"))
+
+CB_FLAG_NQ (1, "codeset-ebcdic", 21,
+	_("  -fcodeset-ebcdic=<charset-name>\tset the EBCDIC charset to use in CODE-SET clauses"))
+
 /* Binary flags */
 
 /* Flags with suppressed help */

--- a/cobc/parser.y
+++ b/cobc/parser.y
@@ -6610,14 +6610,24 @@ code_set_clause:
 			CB_PENDING ("custom CODE-SET");
 			current_file->code_set = al;
 			break;
-#ifdef	COB_EBCDIC_MACHINE
 		case CB_ALPHABET_ASCII:
-#else
 		case CB_ALPHABET_EBCDIC:
+			if ((cb_native_charset != NULL &&
+			     ((al->alphabet_type == CB_ALPHABET_ASCII && cb_codeset_ascii != NULL
+			       && strcasecmp(cb_native_charset, cb_codeset_ascii) != 0) ||
+			      (al->alphabet_type == CB_ALPHABET_EBCDIC && cb_codeset_ebcdic != NULL
+			       && strcasecmp(cb_native_charset, cb_codeset_ebcdic) != 0))) ||
+#ifdef	COB_EBCDIC_MACHINE
+			    al->alphabet_type == CB_ALPHABET_ASCII
+#else
+			    al->alphabet_type == CB_ALPHABET_EBCDIC
 #endif
-			CB_UNFINISHED ("CODE-SET");
-			current_file->code_set = al;
-			break;
+			   ) {
+				CB_UNFINISHED ("CODE-SET");
+				current_file->code_set = al;
+				break;
+			}
+		/* fall through */
 		default:
 			if (get_warn_opt_value (cb_warn_additional) != COBC_WARN_DISABLED) {
 				cb_note_x (cb_warn_additional, $3, _("ignoring CODE-SET '%s'"),

--- a/libcob/ChangeLog
+++ b/libcob/ChangeLog
@@ -1,4 +1,11 @@
 
+2023-01-20 David Declerck <david.declerck@ocamlpro.com>
+
+	* cconv.c: new cob_build_collation and cob_build_conversion functions
+	  allowing to create collating sequence and character conversion tables
+	  that take character encodings into account
+	* common.h: declare the API for cob_build_collation and cob_build_conversion
+
 2023-01-16  Simon Sobisch <simonsobisch@gnu.org>
 
 	* statement.def (STMT_INIT_STORAGE): new internal statement
@@ -70,7 +77,7 @@
 
 2022-12-13 David Declerck <david.declerck@ocamlpro.com>
 
-	* conv.c: file moved from cobc to libcob
+	* cconv.c: file moved from cobc to libcob
 	* common.h: declare the new API for collating sequences
 
 2022-12-13  Simon Sobisch <simonsobisch@gnu.org>

--- a/libcob/common.h
+++ b/libcob/common.h
@@ -2804,6 +2804,25 @@ cob_get_collation_name (int);
 COB_EXPIMP int
 cob_get_collation_by_name (const char *, const cob_u8_t **, const cob_u8_t **);
 
+/* Build EBCDIC and ASCII collating sequences from the given collation
+   name, adding a conversion step from the specified `native` and `target`
+   encodings. These encodings must be recognize by `iconv`.
+   The `native_ascii` and `native_ebcdic` arguments must point to arrays
+   of at least 256 characters, or may be NULL if a table is not needed.
+   Return 0 on success and -1 on failure. */
+
+COB_EXPIMP int
+cob_build_collation(const char *, const char *, const char *, cob_u8_t *, cob_u8_t *);
+
+/* Build a pair of conversion tables between the two specified encodings.
+   These encodings must be recognize by `iconv`.
+   The `code1_code2` and `code2_code1` arguments must point to arrays
+   of at least 256 characters, or may be NULL if a table is not needed.
+   Return 0 on success and -1 on failure. */
+
+COB_EXPIMP int
+cob_build_conversion(const char *, const char *, cob_u8_t *, cob_u8_t *);
+
 /*******************************/
 
 /*******************************/


### PR DESCRIPTION
This PR adds some support for character encodings in different places, using iconv to build conversion tables.

Note to @GitMensch : I still have to add some tests, but you can start reviewing.

It introduces the following new options :
-fnative-charset
-ftarget-charset
-fcodeset-ascii
-fcodeset-ebcdic
-fconvert-ascii
-fconvert-ebcdic

The -fnative-charset and -ftarget-charset allow to specify the encodings used in the execution environment (native) and in the environment we are trying to simulate (target). When they are both set, the collating tables (for the purpose of sorting only) are built by combining these two encodings and the "vendor" EBCDIC/ASCII table.

Our typical use case is the following. We simulate a GCOS environment with EBCDIC-500 encoding (our target). We run on a standard Linux PC, where we decided that all the data we process would use the ISO-8859-1 encoding (we call this "native"). We have a file with some records we'd like to sort according to the EBCDIC collating sequence (the default one on this platform), so that our program sorts in the exact same order it would if it were run on our GCOS environment. If we use the "vendor" EBCDIC/ASCII table (the one from the GCOS documentation), this will fail: this table does not define an EBCDIC-500 <-> ISO-8859-1 translation (in particular, extended characters are just given consecutive values).

That's where the -fnative-charset and -ftarget-charset are useful. Here, we set -fnative-charset to ISO-8859-1 and -ftarget-charset to IBM500 (iconv's name for EBCDIC 500). As they are both set, we will call iconv to produce an ISO-8859-1 to EBCDIC-500 translation table (cob_colseq_native_ebcdic) and give that one instead of the vendor table to the sort function.

Now, what if the SORT instruction contained a COLLATING SEQUENCE IS ASCII clause ? Here, we would want to sort as our GCOS system would, hence using the vendor table. But iconv does not know about the specific ASCII encoding used by GCOS. What we want to do is thus to convert from ISO-8859-1 to EBCDIC-500 and then use the vendor table to translate that EBCDIC to the GCOS-specific ASCII. To avoid performing two conversions, we simply build a new conversion table (cob_colseq_native_ascii) that combines the two steps.

The implementation has been made generic enough so that it works on any combination of native/target encodings among the EBCDIC and ASCII encodings ; in particular, it will use the vendor table in one direction or the other depending on the actual target encoding (i.e. if the target encoding is EBCDIC, it will add a vendor EBCDIC -> ASCII translation when requesting an ASCII collating sequence, and symmetrically, if the target encoding is ASCII, it will add a vendor ASCII -> EBCDIC translation when requesting an EBCDIC collating sequence).

That's for the main stuff.

Now, since I had started digging about encodings, I thought it could also be useful to be able to specify the ASCII and EBCDIC encodings used in the CODE-SET and CONVERTING/REPLACING clauses. That's the purpose of the -fcodeset-ascii, -fcodeset-ebcdic, -fconvert-ascii and -fconvert-ebcdic options.

The -fcodeset-ascii and -fcodeset-ebcdic work together with the -fnative-charset option. When specified, and when a CODE-SET clause is active on a file, the necessary conversions will be performed by iconv using the specified encodings instead of instead of the vendor table. For instance, reading from a file that has CODE-SET IS EBCDIC will perform a translation from the encoding specified by the -fcodeset-ebcdic option to the encoding specified by the -fnative-charset option. Could be convenient if migrating an application from a mainframe while keeping data files in an EBCDIC encoding.

As for the -fconvert-ascii and -fconvert-ebcdic options, they allow to specify the conversions to perform in INSPECT CONVERTING / REPLACING and TRANSFORM CONVERTING.