### PR TITLE
Allow use of external preprocessor

### DIFF
--- a/cobc/help.c
+++ b/cobc/help.c
@@ -128,6 +128,7 @@ cobc_print_usage_common_options (void)
 	puts (_("  --list-system         display system routines"));
 	puts (_("  --save-temps[=<dir>]  save intermediate files\n"
 	        "                        * default: current directory"));
+	puts (_("  --pp <cobc_pp>        use external cobc-aware preprocessor"));
 	puts (_("  -MT <target>          set/add target file used in dependency list"));
 	puts (_("  -MF <file>            place dependency list into <file>"));
 	puts (_("  -ext <extension>      add file extension for resolving COPY"));


### PR DESCRIPTION
* New option --pp <cobc_pp> to call an external cobc-aware preprocessor
* New env variable COB_PP to call an external cobc-aware preprocessor
* New env variable COB_SAVE_TEMPS to save temporary files

The external preprocessor has to be cobc-aware, i.e. add #area_a directives and remove some paragraphs from the IDENTIFICATION DIVISION.

The basic idea here is that GnuCOBOL preprocessor is not fully compliant to the standard, and making it compliant would require completely rewriting that part. Instead, we propose to give the user the possibility to use another external preprocessor in such cases.
