### PR TITLE
homogenization of testsuite syntax

### DIFF
--- a/tests/testsuite.src/configuration.at
+++ b/tests/testsuite.src/configuration.at
@@ -647,11 +647,11 @@ AT_SETUP([runtime configuration: entries])
 AT_KEYWORDS([configuration misc])
 
 AT_CHECK([echo "$PATHSEP"], [0], [;
-], [],
+], [], [
 
 # Previous test "failed" --> PATHSEP isn't ;
 
-AT_DATA([defunc.cfg], [
+  AT_DATA([defunc.cfg], [
 novar
 physical_cancel notwithme
 load_case  insensitive
@@ -664,7 +664,7 @@ trace_file /tmp:/temp
 ])
 
 # conf entries must be clean
-AT_CHECK([$COBCRUN -c defunc.cfg --runtime-conf], [1], [],
+  AT_CHECK([$COBCRUN -c defunc.cfg --runtime-conf], [1], [],
 [configuration error:
 defunc.cfg:2: unknown configuration tag 'novar'
 defunc.cfg:3: invalid value 'notwithme' for configuration tag 'physical_cancel';
@@ -682,12 +682,12 @@ defunc.cfg:9: WARNING - 'sort_chunk' without a value - ignored!
 defunc.cfg:10: invalid value '/tmp:/temp' for configuration tag 'trace_file';
 	should not contain ':'
 ])
-
+]
 ,
-
+[
 # Previous test "passed" --> PATHSEP is ;
 
-AT_DATA([defunc.cfg], [
+  AT_DATA([defunc.cfg], [
 novar
 physical_cancel notwithme
 load_case  insensitive
@@ -700,7 +700,7 @@ trace_file C:\tmp;C:\temp
 ])
 
 # conf entries must be clean
-AT_CHECK([$COBCRUN -c defunc.cfg --runtime-conf], [1], [],
+  AT_CHECK([$COBCRUN -c defunc.cfg --runtime-conf], [1], [],
 [configuration error:
 defunc.cfg:2: unknown configuration tag 'novar'
 defunc.cfg:3: invalid value 'notwithme' for configuration tag 'physical_cancel';
@@ -718,7 +718,7 @@ defunc.cfg:9: WARNING - 'sort_chunk' without a value - ignored!
 defunc.cfg:10: invalid value 'C:\tmp;C:\temp' for configuration tag 'trace_file';
 	should not contain ';'
 ])
-
+]
 )
 
 AT_CLEANUP

--- a/tests/testsuite.src/run_file.at
+++ b/tests/testsuite.src/run_file.at
@@ -251,7 +251,8 @@ AT_DATA([prog.cob], [
 
 AT_CHECK([$COMPILE prog.cob], [0], [], [])
 AT_CHECK([$COBCRUN_DIRECT ./prog], [0], [], [])
-[echo "Test" > ./nosubhere]
+AT_DATA([nosubhere], [Test
+])
 AT_CHECK([$COBCRUN_DIRECT ./prog], [0], [], [])
 
 AT_CLEANUP
@@ -435,7 +436,8 @@ AT_DATA([prog.cob], [
 
 AT_CHECK([$COMPILE prog.cob], [0], [], [])
 AT_CHECK([$COBCRUN_DIRECT ./prog], [0], [], [])
-[echo "Test" > ./nosubhere]
+AT_DATA([nosubhere], [Test
+])
 AT_CHECK([$COBCRUN_DIRECT ./prog], [0], [], [])
 
 AT_CLEANUP

--- a/tests/testsuite.src/syn_misc.at
+++ b/tests/testsuite.src/syn_misc.at
@@ -9605,7 +9605,7 @@ AT_DATA([fixed2.cob], [
 ])
 
 # Generate source files with DOM
-AT_CHECK([printf '\xEF\xBB\xBF' > header.dom])
+AT_CHECK([printf '\357\273\277' > header.dom])
 AT_CHECK([cat header.dom free.cob >> domfree.cob])
 AT_CHECK([cat header.dom fixed1.cob >> domfixed.cob])
 


### PR DESCRIPTION
The syntax of the testsuite is not homogeneous, so it makes it difficult to use other tools than `autoconf` to work with it.

The goal of this PR is to make it more homogeneous, and test/dev some other tooling to simplify running the testsuite and fixing issues (while still using `autoconf` testsuite for mainstream use).
