### PR TITLE
Add -fdiagnostics-show-caret to display the context of an error

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -321,7 +321,7 @@ NEWS - user visible changes				-*- outline -*-
    original version; note: their use will be adjusted where they don't match
    GCC's same options in later versions, including addition of -M and -MD
 
-** New -std options:
+** new -std options:
 
    gcos            GCOS compatibility
    gcos-strict     GCOS compatibility                - strict
@@ -329,6 +329,14 @@ NEWS - user visible changes				-*- outline -*-
    We define the GCOS dialect based on the COBOL85 standard, with new
    dialect configuration options accompanying each specificity
    introduced by the dialect.
+
+** new diagnostic format for errors: the diagnostics now print the source
+   code context with a left margin showing line numbers, configurable with
+   -fno-diagnostics-show-line-numbers, and possible to disable completely
+   with -fno-diagnostics-show-caret;
+
+   the option -fdiagnostics-plain-output was added to request that diagnostic
+   output look as plain as possible and stay more stable over time
 
 * Important Bugfixes:
 

--- a/cobc/ChangeLog
+++ b/cobc/ChangeLog
@@ -1,4 +1,18 @@
 
+2023-02-16  Fabrice Le Fessant <fabrice.le_fessant@ocamlpro.com>
+
+	* flag.def (cb_diagnostics_show_caret), error.c
+	  (diagnostics_show_caret): add argument -fno-diagnostics-show-caret
+	  to disable the display of the source context of the error/warning,
+	  2 lines before and after the location; add argument
+	  -fno-diagnostics-show-line-numbers to disable printing of
+	  line numbers in carets; rename cb_diagnostic_show_option into
+	  cb_diagnostics_show_option to match the argument name.
+	* error.c (cb_error_kind): replace all occurrences of a
+	  error/warning/note string by a symbolic enum.
+	* cobc.c: new argument -fdiagnostics-plain-output to make
+	  output as plain as possible (disabling carets for example)
+
 2023-05-31  Simon Sobisch <simonsobisch@gnu.org>
 
 	* codegen.c (output_init_comment_and_source_ref) [NO_INIT_SOURCE_LOC]:

--- a/cobc/cobc.c
+++ b/cobc/cobc.c
@@ -589,6 +589,7 @@ static const struct option long_options[] = {
 	{"P",			CB_OP_ARG, NULL, 'P'},
 	{"Xref",		CB_NO_ARG, NULL, 'X'},
 	{"use-extfh",		CB_RQ_ARG, NULL, 9},	/* this is used by COBOL-IT; Same is -fcallfh= */
+	{"fdiagnostics-plain-output",	CB_NO_ARG, NULL, '/'},
 	{"Wall",		CB_NO_ARG, NULL, 'W'},
 	{"Wextra",		CB_NO_ARG, NULL, 'Y'},		/* this option used to be called -W */
 #if 1
@@ -3457,6 +3458,12 @@ process_command_line (const int argc, char **argv)
 						cb_lines_per_page, 20);
 				cb_lines_per_page = 20;
 			}
+			break;
+
+		case '/':
+			/* -fdiagnostics-plain-output */
+			cb_diagnostics_show_caret = 0 ;
+			cb_diagnostics_show_line_numbers = 0;
 			break;
 
 		case 'P':

--- a/cobc/flag.def
+++ b/cobc/flag.def
@@ -232,6 +232,12 @@ CB_FLAG (cb_listing_symbols, 1, "tsymbols",
 CB_FLAG (cb_listing_cmd, 1, "tcmd",
 	_("  -ftcmd                specify command line in listing"))
 
-CB_FLAG_ON (cb_diagnostic_show_option, 1, "diagnostics-show-option",
+CB_FLAG_ON (cb_diagnostics_show_option, 1, "diagnostics-show-option",
 	_("  -fno-diagnostics-show-option\tsuppress output of option that directly\n"
 	  "                        controls the diagnostic"))
+
+CB_FLAG_ON (cb_diagnostics_show_caret, 1, "diagnostics-show-caret",
+	_("  -fno-diagnostics-show-caret\tdo not display source context on warning/error diagnostic"))
+
+CB_FLAG_ON (cb_diagnostics_show_line_numbers, 1, "diagnostics-show-line-numbers",
+	_("  -fno-diagnostics-show-line-numbers\tsuppress display of line numbers in diagnostics"))

--- a/cobc/help.c
+++ b/cobc/help.c
@@ -162,6 +162,7 @@ cobc_print_usage_warnings (void)
 #undef	CB_ONWARNDEF
 #undef	CB_NOWARNDEF
 #undef	CB_ERRWARNDEF
+	puts (_("  -fdiagnostics-plain-output\tmake diagnostic output as plain as possible"));
 	puts (_("  -Werror               treat all warnings as errors"));
 	puts (_("  -Wno-error            don't treat warnings as errors"));
 	puts (_("  -Werror=<warning>     treat specified <warning> as error"));

--- a/tests/atlocal.in
+++ b/tests/atlocal.in
@@ -72,6 +72,7 @@ fi
 # FLAGS="-debug -Wall ${COBOL_FLAGS}"
 FLAGS="-debug -Wall ${COBOL_FLAGS} -fno-diagnostics-show-option"
 
+COBC="${COBC} -fdiagnostics-plain-output"
 COMPILE="${COBC} -x ${FLAGS}"
 COMPILE_ONLY="${COBC} -fsyntax-only ${FLAGS} -Wno-unsupported"
 COMPILE_MODULE="${COBC} -m ${FLAGS}"

--- a/tests/testsuite.src/listings.at
+++ b/tests/testsuite.src/listings.at
@@ -2143,8 +2143,8 @@ LINE    PG/LN  A...B............................................................
 GnuCOBOL V.R.P          prog.cob             DDD MMM dd HH:MM:SS YYYY  Page 0002
 
 command line:
-  cobc -q -std=default -Wall -fno-tmessages -fsyntax-only -t prog.lst
-+ -fno-tsymbols -ftcmd prog.cob
+  cobc -fdiagnostics-plain-output -q -std=default -Wall -fno-tmessages
++ -fsyntax-only -t prog.lst -fno-tsymbols -ftcmd prog.cob
 ])
 
 AT_CHECK([$UNIFY_LISTING prog.lst prog.lis], [0], [], [])

--- a/tests/testsuite.src/used_binaries.at
+++ b/tests/testsuite.src/used_binaries.at
@@ -918,3 +918,65 @@ AT_CHECK([cat prog.cob | $COMPILE_MODULE -j -], [0], [job], [],
 )
 
 AT_CLEANUP
+
+
+AT_SETUP([cobc diagnostics show caret])
+# promoted on 2023-06-01T09:57
+AT_KEYWORDS([cobc diagnostics])
+AT_DATA([prog.cob],[
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      prog.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01 TEST-VAR PIC 9(2) VALUE 'A'.
+       COPY 'CRUD.CPY'.
+       PROCEDURE        DIVISION.
+           DISPLAY TEST-VAR NO ADVANCING
+           END-DISPLAY
+           MOVE 12 TO TEST-VAR
+           DISPLAY TEST-VAR NO ADVANCING
+           END-DISPLAY
+           STOP RUN.
+])
+AT_CHECK([$COBC -Wall -fsyntax-only prog.cob], [1], [],
+[prog.cob:7: error: CRUD.CPY: No such file or directory
+prog.cob:6: warning: numeric value is expected @<:@-Wothers@:>@
+])
+AT_CHECK([$COMPILE -fdiagnostics-show-caret -fdiagnostics-show-line-numbers -j prog.cob], [1], [],
+[prog.cob:7: error: CRUD.CPY: No such file or directory
+
+  0005          WORKING-STORAGE  SECTION.
+  0006          01 TEST-VAR PIC 9(2) VALUE 'A'.
+  0007 >        COPY 'CRUD.CPY'.
+  0008          PROCEDURE        DIVISION.
+  0009              DISPLAY TEST-VAR NO ADVANCING
+
+prog.cob:6: warning: numeric value is expected
+
+  0004          DATA             DIVISION.
+  0005          WORKING-STORAGE  SECTION.
+  0006 >        01 TEST-VAR PIC 9(2) VALUE 'A'.
+  0007          COPY 'CRUD.CPY'.
+  0008          PROCEDURE        DIVISION.
+
+])
+AT_CHECK([$COMPILE -fdiagnostics-show-caret -j prog.cob],[1], [],
+[prog.cob:7: error: CRUD.CPY: No such file or directory
+
+           WORKING-STORAGE  SECTION.
+           01 TEST-VAR PIC 9(2) VALUE 'A'.
+  >        COPY 'CRUD.CPY'.
+           PROCEDURE        DIVISION.
+               DISPLAY TEST-VAR NO ADVANCING
+
+prog.cob:6: warning: numeric value is expected
+
+           DATA             DIVISION.
+           WORKING-STORAGE  SECTION.
+  >        01 TEST-VAR PIC 9(2) VALUE 'A'.
+           COPY 'CRUD.CPY'.
+           PROCEDURE        DIVISION.
+
+])
+AT_CLEANUP
+


### PR DESCRIPTION
When a warning or error is printed, prints the source context with the line of the error, plus 2 lines before and after.
COBC_PREVIEW_ERROR can be used to set the option globally.