### PR TITLE
Remove VALUES=VALUE in gcos.conf

### DIFF
--- a/config/ChangeLog
+++ b/config/ChangeLog
@@ -1,4 +1,9 @@
 
+2023-02-16  Fabrice Le Fessant <fabrice.le_fessant@ocamlpro.com>
+
+	* gcos.words: remove alias VALUES=VALUE, to correctly parse
+	  "VALUES ARE"
+
 2023-01-25  Simon Sobisch <simonsobisch@gnu.org>
 
 	* ibm.words, mvs.words: re-add BINARY

--- a/config/gcos.words
+++ b/config/gcos.words
@@ -490,7 +490,7 @@ reserved:	USAGE
 reserved:	USE
 reserved:	USING
 reserved:	VALUE
-reserved:	VALUES=VALUE
+reserved:	VALUES
 reserved:	VARYING
 reserved:	VIA
 reserved:	VIRTUAL


### PR DESCRIPTION
Probably forgotten when VALUES was added.