### PR TITLE
Fix wrong invalid conditional expression

### DIFF
--- a/cobc/ChangeLog
+++ b/cobc/ChangeLog
@@ -25,6 +25,13 @@
 
 2023-06-20  Fabrice Le Fessant <fabrice.le_fessant@ocamlpro.com>
 
+	* typeck.c (cb_build_expr): fix bug #875 "V IS ZERO AND
+	... generate 'invalid conditional expression' error",
+	fix bug #880 error compiling abbreviated conditions in GC3.2 RC2
+        (NOT comparison should be translated to inversed comparison)
+
+2023-06-20  Fabrice Le Fessant <fabrice.le_fessant@ocamlpro.com>
+
 	* typeck.c (cb_build_expr): remove cb_ prefix from static functions
 	  and comment algorithm
 

--- a/cobc/tree.c
+++ b/cobc/tree.c
@@ -6048,12 +6048,12 @@ cb_build_binary_op (cb_tree x, const enum cb_binary_op_op op, cb_tree y)
 		rel_bin_op = 1;
 		if ((CB_REF_OR_FIELD_P (x))
 		 && CB_FIELD_PTR (x)->level == 88) {
-			cb_error_x (e, _("invalid expression"));
+			cb_error_x (e, _("invalid expression: conditional on the left of numeric operator"));
 			return cb_error_node;
 		}
 		if ((CB_REF_OR_FIELD_P (y))
 		 && CB_FIELD_PTR (y)->level == 88) {
-			cb_error_x (e, _("invalid expression"));
+			cb_error_x (e, _("invalid expression: conditional on the right of numeric operator"));
 			return cb_error_node;
 		}
 
@@ -6281,7 +6281,7 @@ cb_build_binary_op (cb_tree x, const enum cb_binary_op_op op, cb_tree y)
 				cb_error_x (e, _("invalid expression: %s %s %s"),
 					llit, explain_operator (op), rlit);
 			} else {
-				cb_error_x (e, _("invalid expression"));
+				cb_error_x (e, _("invalid expression: boolean expected with logical operator"));
 			}
 			return cb_error_node;
 		}

--- a/cobc/tree.c
+++ b/cobc/tree.c
@@ -6046,16 +6046,20 @@ cb_build_binary_op (cb_tree x, const enum cb_binary_op_op op, cb_tree y)
 	case ']':
 		/* Relational operators */
 		rel_bin_op = 1;
+#if 0	/* note: already tested in the parser with (check_not_88_level) */
 		if ((CB_REF_OR_FIELD_P (x))
 		 && CB_FIELD_PTR (x)->level == 88) {
-			cb_error_x (e, _("invalid expression: conditional on the left of numeric operator"));
+			/* because this code is not active and the translation would be new,
+			   we don't have that gettextized */
+			cb_error_x (e, "invalid expression: conditional on the left of numeric operator");
 			return cb_error_node;
 		}
 		if ((CB_REF_OR_FIELD_P (y))
 		 && CB_FIELD_PTR (y)->level == 88) {
-			cb_error_x (e, _("invalid expression: conditional on the right of numeric operator"));
+			cb_error_x (e, "invalid expression: conditional on the right of numeric operator");
 			return cb_error_node;
 		}
+#endif
 
 		if (x == cb_zero) {
 			xl = CB_LITERAL(cb_zero_lit);

--- a/cobc/typeck.c
+++ b/cobc/typeck.c
@@ -6282,7 +6282,8 @@ decimal_compute (const int op, cb_tree x, cb_tree y)
 }
 
 /**
- * expand tree x to the previously allocated decimal tree d
+ * expand tree x to the previously allocated decimal tree d.
+ * Returns either d or cb_error_node in case of error.
  */
 static cb_tree
 decimal_expand (cb_tree d, cb_tree x)
@@ -6302,7 +6303,7 @@ decimal_expand (cb_tree d, cb_tree x)
 		/* LCOV_EXCL_START */
 		if (x != cb_zero) {
 			cobc_err_msg (_("unexpected constant expansion"));
-			return cb_error_node;
+			COBC_ABORT ();
 		}
 		/* LCOV_EXCL_STOP */
 		dpush (CB_BUILD_FUNCALL_2 ("cob_decimal_set_llint", d, cb_int0));
@@ -6373,7 +6374,8 @@ decimal_expand (cb_tree d, cb_tree x)
 		switch (p->op){
 		case '=': case '~': case '<': case '>': case '[': case ']':
 		case '!': case '&': case '|':
-			cb_error_x (x, _("condition expression found where decimal expression was expected"));
+			cb_error_x (x, "condition expression found where decimal expression was expected");
+			error_statement = current_statement;
 			return cb_error_node;
 		case 'c':
 		case 'd':

--- a/tests/testsuite.src/run_fundamental.at
+++ b/tests/testsuite.src/run_fundamental.at
@@ -6392,10 +6392,11 @@ AT_CHECK([$COBCRUN_DIRECT ./packed], [0],
 
 AT_CLEANUP
 
-# bug Sourceforge 875
 
 AT_SETUP([Condition IS ZERO AND])
 AT_KEYWORDS([IF])
+
+# for more details see bug #875
 
 AT_DATA([prog.cob], [
        IDENTIFICATION   DIVISION.
@@ -6442,10 +6443,11 @@ V EQUAL 0 AND W IS POSITIVE
 
 AT_CLEANUP
 
-# bug Sourceforge 880
 
 AT_SETUP([abbreviated conditions with multiple words operators])
 AT_KEYWORDS([IF])
+
+# for more details see bug #880
 
 AT_DATA([prog.cob], [
        IDENTIFICATION DIVISION.

--- a/tests/testsuite.src/run_fundamental.at
+++ b/tests/testsuite.src/run_fundamental.at
@@ -6391,3 +6391,118 @@ AT_CHECK([$COBCRUN_DIRECT ./packed], [0],
 ], [])
 
 AT_CLEANUP
+
+# bug Sourceforge 875
+
+AT_SETUP([Condition IS ZERO AND])
+AT_KEYWORDS([IF])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      prog.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01  V            PIC 9 VALUE 0.
+       01  W            PIC 9 VALUE 1.
+       PROCEDURE        DIVISION.
+           IF V IS ZERO
+              DISPLAY "V IS ZERO"
+           END-IF.
+           IF V IS ZERO AND W EQUAL 1
+              DISPLAY "V IS ZERO AND W EQUAL 1"
+           END-IF.
+           IF W EQUAL 1 AND V IS ZERO
+              DISPLAY "W EQUAL 1 AND V IS ZERO"
+           END-IF.
+           IF W IS POSITIVE
+              DISPLAY "W IS POSITIVE"
+           END-IF.
+           IF W IS NEGATIVE
+              DISPLAY "W IS NEGATIVE"
+           END-IF.
+           IF W IS POSITIVE AND V EQUAL 0
+              DISPLAY "W IS POSITIVE AND V EQUAL 0"
+           END-IF.
+           IF V EQUAL 0 AND W IS POSITIVE
+              DISPLAY "V EQUAL 0 AND W IS POSITIVE"
+           END-IF.
+])
+
+AT_CHECK([$COMPILE prog.cob], [0], [],
+[prog.cob:21: warning: unsigned 'W' may not be LESS THAN ZERO
+])
+
+AT_CHECK([./prog], [0], [V IS ZERO
+V IS ZERO AND W EQUAL 1
+W EQUAL 1 AND V IS ZERO
+W IS POSITIVE
+W IS POSITIVE AND V EQUAL 0
+V EQUAL 0 AND W IS POSITIVE
+], [])
+
+AT_CLEANUP
+
+# bug Sourceforge 880
+
+AT_SETUP([abbreviated conditions with multiple words operators])
+AT_KEYWORDS([IF])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID.    CHECKBOOL.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01  VAR1                    PIC X(16) VALUE "#0001".
+       01  VAR2                    PIC X(16) VALUE "#0002".
+       01  VAR3                    PIC X(16) VALUE "#0003".
+       01  VAR4                    PIC X(16) VALUE "#0004".
+       PROCEDURE DIVISION.
+       MAIN-PROGRAM SECTION.
+       INIZIO.
+           IF VAR1 = (VAR2 AND VAR3 AND VAR4)
+              DISPLAY "TRUE 1"
+	   END-IF
+           IF VAR1 NOT = (VAR2 AND VAR3 AND VAR4)
+              DISPLAY "TRUE 2"
+           END-IF
+           IF VAR1 NOT > (VAR2 AND VAR3 AND VAR4)
+              DISPLAY "TRUE 3"
+           END-IF
+           GOBACK.
+])
+
+AT_CHECK([$COMPILE prog.cob], [0], [], [])
+
+AT_CHECK([./prog], [0], [TRUE 2
+TRUE 3
+], [])
+
+AT_CLEANUP
+
+
+AT_SETUP([abbreviated conditions with multiple words operators])
+AT_KEYWORDS([IF])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID.    CHECKCOND.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01  VAR1                    PIC X.
+                88 VAR1-K VALUE 'K'
+       01  VAR2                    PIC X.
+                88 VAR2-K VALUE 'K'
+
+       PROCEDURE DIVISION.
+       MAIN-PROGRAM SECTION.
+       BUG.
+           IF VAR1-K AND NOT = VAR2-K
+              DISPLAY "INVALID" UPON STDERR.
+           GOBACK.
+])
+
+AT_CHECK([$COMPILE_ONLY prog.cob], [1], [],
+[prog.cob:8: error: syntax error, unexpected Identifier
+])
+
+AT_CLEANUP

--- a/tests/testsuite.src/syn_definition.at
+++ b/tests/testsuite.src/syn_definition.at
@@ -319,9 +319,10 @@ prog.cob:30: error: syntax error, unexpected Identifier
 prog.cob:36: error: 'NOT-DEFINED' is not defined
 prog.cob:42: error: syntax error, unexpected ELSE
 prog.cob:42: error: syntax error, unexpected Identifier
-prog.cob:42: error: invalid expression
+prog.cob:42: error: incomplete expression
 prog.cob:47: error: 'broken' is not defined
 ])
+
 AT_CLEANUP
 
 

--- a/tests/testsuite.src/syn_misc.at
+++ b/tests/testsuite.src/syn_misc.at
@@ -589,6 +589,12 @@ AT_DATA([prog.cob], [
                    >= (456 + 16)
               DISPLAY "And another brew! " WRKN
             END-IF.
+            IF ( WRKN-IS-ZERO + 3  ) > 0
+	      DISPLAY "Weird if compiled"
+	    END-IF.
+            IF ( 3 + WRKN-IS-ZERO  ) > 0
+	      DISPLAY "Weird if compiled"
+	    END-IF.
             IF ( WRKN-IS-ZERO AND WRKN-IS-ZERO ) > 0
               DISPLAY "Weird if compiled"
             END-IF.
@@ -602,7 +608,9 @@ prog.cob:18: error: condition expression found where decimal expression was expe
 prog.cob:21: error: condition expression found where decimal expression was expected
 prog.cob:30: error: condition expression found where decimal expression was expected
 prog.cob:33: error: invalid expression: unfinished expression
-prog.cob:40: error: condition expression found where decimal expression was expected
+prog.cob:40: error: condition-name not allowed here: 'WRKN-IS-ZERO'
+prog.cob:43: error: condition-name not allowed here: 'WRKN-IS-ZERO'
+prog.cob:46: error: condition expression found where decimal expression was expected
 ])
 
 AT_CLEANUP

--- a/tests/testsuite.src/syn_misc.at
+++ b/tests/testsuite.src/syn_misc.at
@@ -379,6 +379,7 @@ prog.cob:159: warning: 'PIC-9-SIGNED-DECIMAL' may not be GREATER THAN 99.99
 prog.cob:160: warning: 'PIC-9-SIGNED-DECIMAL' may not be LESS THAN -99.99
 prog.cob:161: warning: 'PIC-9-SIGNED-DECIMAL' may not be LESS THAN -99.99
 prog.cob:162: warning: literal '-99.991' has more decimals than 'PIC-9-SIGNED-DECIMAL'
+prog.cob:164: warning: 'XX' may not be GREATER THAN 99
 ])
 
 AT_CLEANUP
@@ -524,23 +525,23 @@ AT_DATA([prog.cob], [
 ])
 
 AT_CHECK([$COMPILE_ONLY prog.cob], [1], [],
-[prog.cob:10: error: invalid expression
-prog.cob:14: error: invalid expression
-prog.cob:18: error: invalid expression
-prog.cob:22: error: invalid expression
-prog.cob:26: error: invalid expression
+[prog.cob:10: error: incomplete expression
+prog.cob:14: error: incomplete expression
+prog.cob:18: error: incomplete expression
+prog.cob:22: error: incomplete expression
+prog.cob:26: error: incomplete expression
 prog.cob:30: error: invalid conditional expression
-prog.cob:35: error: invalid expression
-prog.cob:38: error: invalid expression
-prog.cob:41: error: invalid expression
-prog.cob:44: error: invalid expression
-prog.cob:47: error: invalid expression
-prog.cob:54: error: invalid expression
-prog.cob:60: error: invalid expression
-prog.cob:66: error: invalid expression
-prog.cob:72: error: invalid expression
+prog.cob:35: error: incomplete expression
+prog.cob:38: error: incomplete expression
+prog.cob:41: error: incomplete expression
+prog.cob:44: error: incomplete expression
+prog.cob:47: error: incomplete expression
+prog.cob:54: error: incomplete expression
+prog.cob:60: error: incomplete expression
+prog.cob:66: error: incomplete expression
+prog.cob:72: error: incomplete expression
 prog.cob:76: error: 'NOTDEFINED' is not defined
-prog.cob:80: error: invalid expression
+prog.cob:80: error: invalid expression: boolean expected with logical operator
 ])
 
 AT_CLEANUP
@@ -555,6 +556,7 @@ AT_DATA([prog.cob], [
         DATA DIVISION.
         WORKING-STORAGE SECTION.
         01 WRKN  PIC S999 VALUE 123.
+           88 WRKN-IS-ZERO VALUE 0.
         01 WRKX  PIC X(8) VALUE 'House'.
         PROCEDURE DIVISION.
         MAIN.
@@ -587,16 +589,20 @@ AT_DATA([prog.cob], [
                    >= (456 + 16)
               DISPLAY "And another brew! " WRKN
             END-IF.
+            IF ( WRKN-IS-ZERO AND WRKN-IS-ZERO ) > 0
+              DISPLAY "Weird if compiled"
+            END-IF.
             STOP RUN.
 ])
 
 AT_CHECK([$COMPILE_ONLY prog.cob], [1], [],
 [prog.cob: in paragraph 'MAIN':
-prog.cob:10: error: GREATER THAN operator may be misplaced
-prog.cob:17: error: EQUALS operator may be misplaced
-prog.cob:20: error: NOT EQUAL operator may be misplaced
-prog.cob:29: error: LESS OR EQUAL operator may be misplaced
-prog.cob:32: error: invalid expression
+prog.cob:13: error: condition expression found where decimal expression was expected
+prog.cob:18: error: condition expression found where decimal expression was expected
+prog.cob:21: error: condition expression found where decimal expression was expected
+prog.cob:30: error: condition expression found where decimal expression was expected
+prog.cob:33: error: invalid expression: unfinished expression
+prog.cob:40: error: condition expression found where decimal expression was expected
 ])
 
 AT_CLEANUP
@@ -660,7 +666,7 @@ AT_CHECK([$COMPILE_ONLY prog.cob], [1], [],
 [prog.cob:15: error: invalid conditional expression
 prog.cob:20: error: invalid conditional expression
 prog.cob:25: error: invalid conditional expression
-prog.cob:35: error: invalid expression
+prog.cob:35: error: invalid expression: boolean expected with logical operator
 ])
 
 AT_CLEANUP
@@ -2489,7 +2495,7 @@ prog.cob:20: error: 'handle' is not defined, but is a reserved word in another d
 prog.cob:21: error: 'handle' is not defined, but is a reserved word in another dialect
 prog.cob: in paragraph 'MAIN':
 prog.cob:35: error: 'handle IN mywindow' is not defined
-prog.cob:34: error: invalid expression
+prog.cob:34: error: invalid expression: unfinished expression
 prog.cob:38: error: syntax error, unexpected END-PERFORM
 prog.cob:39: error: 'thread' is not defined, but is a reserved word in another dialect
 prog.cob:39: error: syntax error, unexpected Identifier
@@ -3530,13 +3536,12 @@ AT_DATA([prog.cob], [
 
 AT_CHECK([$COMPILE_ONLY prog.cob], [1], [],
 [prog.cob:19: error: invalid conditional expression
-prog.cob:16: error: invalid expression
+prog.cob:16: error: invalid expression: boolean expected with logical operator
 prog.cob:28: error: wrong number of WHEN parameters
 prog.cob:31: error: wrong number of WHEN parameters
 ])
 
 AT_CLEANUP
-
 
 AT_SETUP([COBOL-WORDS directive])
 AT_KEYWORDS([misc reserved words])
@@ -6648,8 +6653,8 @@ AT_DATA([prog.cob], [
            .
 ])
 
-AT_CHECK([$COMPILE prog.cob], [1], [],
-[prog.cob:9: error: invalid expression
+AT_CHECK([$COMPILE prog.cob], [1], [], 
+[prog.cob:9: error: invalid expression: unfinished expression
 ])
 AT_CLEANUP
 
@@ -8200,3 +8205,4 @@ AT_CHECK([$COMPILE -freserved="XX*=BYTE-LENGTH" prog.cob], [0], [], [])
 AT_CHECK([$COBCRUN_DIRECT ./prog], [0], [1])
 
 AT_CLEANUP
+


### PR DESCRIPTION
`IF V ZERO AND W EQUAL 1` is interpreted as invalid when it should be legal

The test added in the testsuite fails with previous versions.