### PR TITLE
[GCOS] Allow REPLACE after CONTROL DIVISION

### DIFF
--- a/cobc/ChangeLog
+++ b/cobc/ChangeLog
@@ -1,4 +1,9 @@
 
+2023-02-20  Fabrice Le Fessant <fabrice.le_fessant@ocamlpro.com>
+
+	* pplex.l: allow REPLACE between Gcos `CONTROL DIVISION` and
+	  the`IDENTIFICATION DIVISION`
+
 2023-02-10  Simon Sobisch <simonsobisch@gnu.org>
 
 	* cobc.c (clean_up_intermediates): fix missing move of temporary files

--- a/cobc/pplex.l
+++ b/cobc/pplex.l
@@ -531,11 +531,14 @@ MAYBE_AREA_A	[ ]?#?
   }
 }
 
-<SUBSTITUTION_SECTION_STATE>{
+<SUBSTITUTION_SECTION_STATE,
+CONTROL_DIVISION_STATE>{
   "REPLACE"	       {
 	  yy_push_state (COPY_STATE);
 	  return REPLACE;
   }
+}
+<SUBSTITUTION_SECTION_STATE>{
   \. 			{
 	  /* Intercept dots within the SUBSTITUTION SECTION */
 	  return DOT;

--- a/tests/testsuite.src/syn_misc.at
+++ b/tests/testsuite.src/syn_misc.at
@@ -9086,6 +9086,23 @@ AT_CHECK([$COMPILE replace.cob], [1], [],
 [replace.cob:2: error: CONTROL DIVISION does not conform to GnuCOBOL
 ])
 
+AT_DATA([replace.cob], [
+       CONTROL          DIVISION.
+       REPLACE ==TEST-VAR== BY ==VAR==.
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      replace.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01 TEST-VAR PIC X(2) VALUE "OK".
+       PROCEDURE        DIVISION.
+           DISPLAY VAR NO ADVANCING
+           END-DISPLAY.
+           STOP RUN.
+])
+
+AT_CHECK([$COMPILE -fcontrol-division=ok replace.cob], [0], [], [])
+AT_CHECK([$COBCRUN_DIRECT ./replace], [0], [OK], [])
+
 AT_CLEANUP
 
 


### PR DESCRIPTION
`CONTROL DIVISION` in GCOS forbids `REPLACE` statements, but it is possible to have a `REPLACE` statement after the `CONTROL DIVISION` and before the `IDENTIFICATION DIVISION`. 