### PR TITLE
Add context to aliases in configuration

### DIFF
--- a/cobc/ChangeLog
+++ b/cobc/ChangeLog
@@ -1,3 +1,8 @@
+2023-03-08  Emilien Lemaire <emilien.lemaire@ocamlpro.com>
+
+	* reserved.c (get_user_specified_reserved_word): add check for
+	  context sensitivity in aliases
+
 
 2023-02-21  Simon Sobisch <simonsobisch@gnu.org>
 

--- a/cobc/reserved.c
+++ b/cobc/reserved.c
@@ -4234,6 +4234,11 @@ get_user_specified_reserved_word (struct amendment_list user_reserved)
 		p = find_default_reserved_word (user_reserved.alias_for, 0);
 		if (p) {
 			cobc_reserved.token = p->token;
+            if (user_reserved.is_context_sensitive) {
+                cobc_reserved.context_sens =
+                    !!user_reserved.is_context_sensitive;
+                cobc_reserved.context_test = p->context_test;
+            }
 		} else {
 			/* FIXME: can we point to the fname originally defining the word? */
 			configuration_error (NULL, 0, 1,

--- a/tests/ChangeLog
+++ b/tests/ChangeLog
@@ -1,3 +1,7 @@
+2023-03-08  Emilien Lemaire <emilien.lemaire@ocamlpro.com>
+
+	* testsuite.src/syn_misc.at: test context sensitive aliases
+
 
 2023-02-21  Fabrice Le Fessant <fabrice.le_fessant@ocamlpro.com>
 

--- a/tests/testsuite.src/syn_misc.at
+++ b/tests/testsuite.src/syn_misc.at
@@ -8178,3 +8178,25 @@ AT_CHECK([$COMPILE_ONLY -fformat=fixed fixed2.cob], [0], [], [])
 AT_CHECK([$COMPILE_ONLY -fformat=fixed domfixed.cob], [0], [], [])
 
 AT_CLEANUP
+
+AT_SETUP([context sensitive alias])
+AT_KEYWORDS([misc context alias])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      prog.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01  XX  PIC 9.
+       01  X            CONSTANT AS XX OF XX.
+       PROCEDURE        DIVISION.
+           MOVE X TO XX.
+           DISPLAY XX NO ADVANCING
+           END-DISPLAY.
+           STOP RUN.
+])
+
+AT_CHECK([$COMPILE -freserved="XX*=BYTE-LENGTH" prog.cob], [0], [], [])
+AT_CHECK([$COBCRUN_DIRECT ./prog], [0], [1])
+
+AT_CLEANUP


### PR DESCRIPTION
While working on configurations with @nberth, we discoverd that rules like `reserved: ALIAS*=CONTEXTUAL-WORD` in configuration files, the context sensitivity of `CONTEXTUAL-WORD` was never reported to the aliases.
A small example with the following code:
```cobol
       IDENTIFICATION   DIVISION.
       PROGRAM-ID.      prog.
       DATA             DIVISION.
       WORKING-STORAGE  SECTION.
       01  BYTE-LENGTH  PIC 9.
       01  X            CONSTANT AS BYTE-LENGTH OF BYTE-LENGTH.
       PROCEDURE        DIVISION.
           MOVE X TO BYTE-LENGTH.
           DISPLAY BYTE-LENGTH NO ADVANCING
           END-DISPLAY.
           STOP RUN.
```
If we run the compiler with `reserved: XX*=BYTE-LENGTH` and replace all `BYTE-LENGTH` in the code with `XX` we get the following errors:
```sh
test.cob:5: error: syntax error, unexpected BYTE-LENGTH
test.cob:6: error: syntax error, unexpected BYTE-LENGTH
test.cob:6: error: constant item 'X' requires a VALUE clause
test.cob:8: error: syntax error, unexpected BYTE-LENGTH
test.cob:9: error: syntax error, unexpected BYTE-LENGTH, expecting (
```
when the file is expected to compile.
After the changes introduced in this PR we can compile with contextual aliases.

This PR also fixes a small error in `config/ibm.conf`