### PR TITLE
Allow OPEN EXTEND/I-O to create file if missing

### DIFF
--- a/cobc/ChangeLog
+++ b/cobc/ChangeLog
@@ -1,4 +1,11 @@
 
+2023-06-16  David Declerck <david.declerck@ocamlpro.com>
+
+	* flag.def: new flag -fio-extend-create to allow file creation
+	  when trying to open a non-existent file in EXTEND or I-O mode
+	* codegen.c: populate the new flag_io_extend_create field with
+	  the value of the flag flag_io_extend_create
+
 2023-06-09  Simon Sobisch <simonsobisch@gnu.org>
 
 	* error.c (print_error, diagnostics_show_caret): fix for C89 compat

--- a/cobc/codegen.c
+++ b/cobc/codegen.c
@@ -11031,6 +11031,7 @@ output_module_init_function (struct cb_program *prog)
 	output_line ("module->flag_main = %d;", cobc_flag_main);
 	output_line ("module->flag_fold_call = %d;", cb_fold_call);
 	output_line ("module->flag_exit_program = 0;");
+	output_line ("module->flag_io_extend_create = %d;", cb_flag_io_extend_create);
 	{
 		int	opt = 0;
 		if (cb_flag_traceall) {

--- a/cobc/flag.def
+++ b/cobc/flag.def
@@ -201,6 +201,9 @@ CB_FLAG (cb_flag_optional_file, 1, "optional-file",
 	_("  -foptional-file       treat all files as OPTIONAL\n"
 	  "                        * unless NOT OPTIONAL specified"))
 
+CB_FLAG (cb_flag_io_extend_create, 1, "io-extend-create",
+	_("  -fio-extend-create    create files opened in IO or EXTEND mode if missing\n"))
+
 CB_FLAG (cb_flag_static_call, 1, "static-call",
 	_("  -fstatic-call         output static function calls for the CALL statement"))
 

--- a/libcob/ChangeLog
+++ b/libcob/ChangeLog
@@ -1,4 +1,10 @@
 
+2023-06-16  David Declerck <david.declerck@ocamlpro.com>
+
+	* common.h (cob_module): add a new flag_io_extend_create field
+	* fileio.c (cob_fd_file_open, cob_file_open, indexed_open): do not fail on
+	  opening files in EXTEND or I-O mode when flag_io_extend_create is set
+
 2023-06-03  Simon Sobisch <simonsobisch@gnu.org>
 
 	* Makefile.am (libcob_la_LDFLAGS): updated version-info - ABI fixed for 3.2

--- a/libcob/common.h
+++ b/libcob/common.h
@@ -1266,7 +1266,9 @@ typedef struct __cob_module {
 #define COB_MODULE_TRACE	2
 #define COB_MODULE_TRACEALL	4
 
-	unsigned char		unused[1];		/* Use these flags up later, added for alignment */
+	unsigned char		flag_io_extend_create;	/* Create file opened in IO or EXTEND mode if missing */
+
+//	unsigned char		unused[1];		/* Use these flags up later, added for alignment */
 
 	unsigned int		module_stmt;		/* Position of last statement executed
 											   as modulated source line

--- a/libcob/fileio.c
+++ b/libcob/fileio.c
@@ -1710,7 +1710,9 @@ cob_fd_file_open (cob_file *f, char *filename,
 		if (mode == COB_OPEN_EXTEND || mode == COB_OPEN_OUTPUT) {
 			return COB_STATUS_30_PERMANENT_ERROR;
 		}
-		if (f->flag_optional) {
+		if (f->flag_optional ||
+		    COB_MODULE_PTR->flag_io_extend_create &&
+		    (mode == COB_OPEN_EXTEND || mode == COB_OPEN_I_O)) {
 			f->fd = fd;
 			f->open_mode = mode;
 			f->flag_nonexistent = 1;
@@ -1819,7 +1821,10 @@ cob_file_open (cob_file *f, char *filename,
 		errno = 0;
 		if (access (filename, F_OK) && errno == ENOENT) {
 			if (mode != COB_OPEN_OUTPUT && f->flag_optional == 0) {
-				return COB_STATUS_35_NOT_EXISTS;
+				if (mode != COB_OPEN_EXTEND && mode != COB_OPEN_I_O ||
+					COB_MODULE_PTR->flag_io_extend_create == 0) {
+					return COB_STATUS_35_NOT_EXISTS;
+				}
 			}
 		}
 		break;
@@ -1834,7 +1839,9 @@ cob_file_open (cob_file *f, char *filename,
 		f->open_mode = mode;
 		break;
 	case COB_STATUS_35_NOT_EXISTS:
-		if (f->flag_optional) {
+		if (f->flag_optional ||
+		    COB_MODULE_PTR->flag_io_extend_create &&
+		    (mode == COB_OPEN_EXTEND || mode == COB_OPEN_I_O)) {
 			f->open_mode = mode;
 			f->flag_nonexistent = 1;
 			f->flag_end_of_file = 1;
@@ -1862,7 +1869,10 @@ cob_file_open (cob_file *f, char *filename,
 	if (access (filename, F_OK)) {
 		if (errno == ENOENT) {
 			if (mode != COB_OPEN_OUTPUT && f->flag_optional == 0) {
-				return COB_STATUS_35_NOT_EXISTS;
+				if (mode != COB_OPEN_EXTEND && mode != COB_OPEN_I_O ||
+					COB_MODULE_PTR->flag_io_extend_create == 0) {
+					return COB_STATUS_35_NOT_EXISTS;
+				}
 			}
 			nonexistent = 1;
 #if 0 /* CHECKME: how to handle stuff like ENOTDIR here ?*/
@@ -1943,7 +1953,9 @@ cob_file_open (cob_file *f, char *filename,
 		if (mode == COB_OPEN_EXTEND || mode == COB_OPEN_OUTPUT) {
 			return COB_STATUS_30_PERMANENT_ERROR;
 		}
-		if (f->flag_optional) {
+		if (f->flag_optional ||
+		    COB_MODULE_PTR->flag_io_extend_create &&
+		    (mode == COB_OPEN_EXTEND || mode == COB_OPEN_I_O)) {
 			f->file = NULL;
 			f->fd = -1;
 			f->open_mode = mode;
@@ -4164,7 +4176,10 @@ indexed_open (cob_file *f, char *filename,
 		errno = 0;
 		if (access (filename, F_OK) && errno == ENOENT) {
 			if (mode != COB_OPEN_OUTPUT && f->flag_optional == 0) {
-				return COB_STATUS_35_NOT_EXISTS;
+				if (mode != COB_OPEN_EXTEND && mode != COB_OPEN_I_O ||
+					COB_MODULE_PTR->flag_io_extend_create == 0) {
+					return COB_STATUS_35_NOT_EXISTS;
+				}
 			}
 		}
 		break;
@@ -4179,7 +4194,9 @@ indexed_open (cob_file *f, char *filename,
 		f->open_mode = mode;
 		break;
 	case COB_STATUS_35_NOT_EXISTS:
-		if (f->flag_optional) {
+		if (f->flag_optional ||
+		    COB_MODULE_PTR->flag_io_extend_create &&
+		    (mode == COB_OPEN_EXTEND || mode == COB_OPEN_I_O)) {
 			f->open_mode = mode;
 			f->flag_nonexistent = 1;
 			f->flag_end_of_file = 1;
@@ -4219,7 +4236,9 @@ indexed_open (cob_file *f, char *filename,
 	errno = 0;
 	if (access (file_open_buff, checkvalue)) {
 		if (!(errno == ENOENT &&
-		      (mode == COB_OPEN_OUTPUT || f->flag_optional == 1))) {
+		      (mode == COB_OPEN_OUTPUT || f->flag_optional == 1 ||
+                       (COB_MODULE_PTR->flag_io_extend_create &&
+                        (mode == COB_OPEN_EXTEND || mode == COB_OPEN_I_O))))) {
 			switch (errno) {
 			case ENOENT:
 				return COB_STATUS_35_NOT_EXISTS;
@@ -4236,7 +4255,9 @@ indexed_open (cob_file *f, char *filename,
 	errno = 0;
 	if (access (file_open_buff, checkvalue)) {
 		if (!(errno == ENOENT &&
-		      (mode == COB_OPEN_OUTPUT || f->flag_optional == 1))) {
+		      (mode == COB_OPEN_OUTPUT || f->flag_optional == 1 ||
+                       (COB_MODULE_PTR->flag_io_extend_create &&
+                        (mode == COB_OPEN_EXTEND || mode == COB_OPEN_I_O))))) {
 			switch (errno) {
 			case ENOENT:
 				return COB_STATUS_35_NOT_EXISTS;
@@ -4341,7 +4362,9 @@ dobuild:
 		if (isfd < 0) {
 			if (ISERRNO == EFLOCKED)
 				return COB_STATUS_61_FILE_SHARING;
-			if (f->flag_optional) {
+			if (f->flag_optional ||
+			    COB_MODULE_PTR->flag_io_extend_create &&
+			    (mode == COB_OPEN_EXTEND || mode == COB_OPEN_I_O)) {
 				if (mode == COB_OPEN_EXTEND
 				 || mode == COB_OPEN_I_O) {
 					dobld = 1;
@@ -4473,7 +4496,10 @@ dobuild:
 	if (bdb_nofile (filename)) {
 		nonexistent = 1;
 		if (mode != COB_OPEN_OUTPUT && f->flag_optional == 0) {
-			return COB_STATUS_35_NOT_EXISTS;
+			if (mode != COB_OPEN_EXTEND && mode != COB_OPEN_I_O ||
+				COB_MODULE_PTR->flag_io_extend_create == 0) {
+				return COB_STATUS_35_NOT_EXISTS;
+			}
 		}
 	}
 
@@ -4550,7 +4576,9 @@ dobuild:
 		ret = access (runtime_buffer, checkvalue);
 		if (ret != 0) {
 			if (errno == ENOENT &&
-			    (mode == COB_OPEN_OUTPUT || f->flag_optional == 1)) {
+			    (mode == COB_OPEN_OUTPUT || f->flag_optional == 1 ||
+			     (COB_MODULE_PTR->flag_io_extend_create &&
+			      (mode == COB_OPEN_EXTEND || mode == COB_OPEN_I_O))) {
 				ret = 0;
 				/* Check here if the directory exists ? */
 #if	0	/* RXWRXW - Check dir */

--- a/tests/testsuite.src/run_file.at
+++ b/tests/testsuite.src/run_file.at
@@ -86,6 +86,66 @@ AT_CHECK([$COBCRUN_DIRECT ./prog], [0], [], [])
 AT_CLEANUP
 
 
+AT_SETUP([OPEN EXTEND and CLOSE, SEQUENTIAL, create if non-existent])
+AT_KEYWORDS([runfile empty CLOSE WRITE READ])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. prog.
+       ENVIRONMENT DIVISION.
+       CONFIGURATION SECTION.
+       INPUT-OUTPUT SECTION.
+       FILE-CONTROL.
+           SELECT  FILE0         ASSIGN TO "testfile"
+                   ORGANIZATION  IS SEQUENTIAL
+                   FILE STATUS   IS WSFS.
+       DATA DIVISION.
+       FILE SECTION.
+       FD  FILE0.
+       01  F0REC             PIC X(80).
+       WORKING-STORAGE SECTION.
+       01  WSFS              PIC X(2).
+       PROCEDURE DIVISION.
+      *
+           OPEN EXTEND FILE0
+           IF WSFS NOT = "00"
+              DISPLAY "STATUS EXTEND:" WSFS.
+           MOVE ALL "A" TO F0REC
+           WRITE F0REC
+           IF WSFS NOT = "00"
+              DISPLAY "STATUS WRITE A:" WSFS.
+           CLOSE FILE0
+           IF WSFS NOT = "00"
+              DISPLAY "STATUS CLOSE:" WSFS.
+           OPEN EXTEND FILE0
+           IF WSFS NOT = "00"
+              DISPLAY "STATUS EXTEND, empty file:" WSFS.
+           MOVE ALL "B" TO F0REC
+           WRITE F0REC
+           IF WSFS NOT = "00"
+              DISPLAY "STATUS WRITE B:" WSFS.
+           CLOSE FILE0
+      *
+           OPEN INPUT FILE0
+           IF WSFS NOT = "00"
+              DISPLAY "STATUS INPUT:" WSFS.
+           READ FILE0 NEXT
+           IF WSFS NOT = "00"
+              DISPLAY "STATUS READ A:" WSFS.
+           READ FILE0 NEXT
+           IF WSFS NOT = "00"
+              DISPLAY "STATUS READ B:" WSFS.
+           CLOSE FILE0
+      *
+           STOP RUN.
+])
+
+AT_CHECK([$COMPILE -fio-extend-create prog.cob], [0], [], [])
+AT_CHECK([$COBCRUN_DIRECT ./prog], [0], [], [])
+
+AT_CLEANUP
+
+
 AT_SETUP([variable-length SEQUENTIAL data integrity])
 AT_KEYWORDS([runfile record OPEN])
 


### PR DESCRIPTION
This PR adds a `-fio-extend-create` flag that, when set, allows `OPEN EXTEND` and `OPEN I-O` to go on and create the file instead of failing.