### PR TITLE
Add dialect option subscript-check to relax bound checks for ODO items (FR #437)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -255,11 +255,18 @@ NEWS - user visible changes				-*- outline -*-
    note that initialization for INDEXED BY items honors the defaultbyte
    configuration now, too
 
-** the dialect configuration option larger-redefines-ok was changed to
-   a support option larger-redefines; if specified on the command-line
+** the dialect configuration option larger-redefines-ok was replaced by
+   the support option larger-redefines; if specified on the command-line
    it is now -f[no-]larger-redefines instead of -f[no-]larger-redefines-ok,
    which allows to also raise a warning for those with -flarger-redefines=warn
    Note: the short one works both in current and older versions of cobc
+
+** the subscript checking enabled with -fec=bound-subscript (implied with
+   --debug) now generates checks depending on the new dialect configuration
+   option subscript-check if OCCURS DEPNDING ON is used;
+   the full check according to ISO COBOL, which checks against the ODO item
+   is still used in the default dialect, but several dialects now only check
+   against the maximum only
 
 ** the GnuCOBOL extension of auto-adding the RECURSIVE attribute
    if a program potentially calls its own PROGRAM-ID was moved
@@ -337,10 +344,6 @@ NEWS - user visible changes				-*- outline -*-
 
    the option -fdiagnostics-plain-output was added to request that diagnostic
    output look as plain as possible and stay more stable over time
-
-** the new dialect configuration option subscript-check is now used to either
-   check accesses to ODO items against runtime bounds ("full"), or
-   against the maximum only ("max")
 
 * Important Bugfixes:
 

--- a/NEWS
+++ b/NEWS
@@ -338,6 +338,10 @@ NEWS - user visible changes				-*- outline -*-
    the option -fdiagnostics-plain-output was added to request that diagnostic
    output look as plain as possible and stay more stable over time
 
+** the new dialect configuration option subscript-check is now used to either
+   check accesses to ODO items against runtime bounds ("full"), or
+   against the maximum only ("max")
+
 * Important Bugfixes:
 
 ** for dialects other than the GnuCOBOL default different reserved "alias" words

--- a/cobc/ChangeLog
+++ b/cobc/ChangeLog
@@ -1,4 +1,11 @@
 
+2023-06-20  Nicolas Berthier <nicolas.berthier@ocamlpro.com>
+
+	FR #437 - Dialect option to limit bound checks for ODO to maximum
+	* config.def, config.c (cb_config_entry), cobc.h (cb_sub_check),
+	  typeck.c (cb_build_identifier): new dialect configuration option
+	  subscript-check to limit bound checks for ODO items
+
 2023-06-20  Fabrice Le Fessant <fabrice.le_fessant@ocamlpro.com>
 
 	* typeck.c (cb_build_expr): remove cb_ prefix from static functions

--- a/cobc/cobc.h
+++ b/cobc/cobc.h
@@ -265,6 +265,13 @@ enum cb_dpc_in_data_options {
 	CB_DPC_IN_ALL
 };
 
+/* Subscript check */
+enum cb_sub_check {
+	CB_SUB_CHECK_FULL,
+	CB_SUB_CHECK_MAX,
+	CB_SUB_CHECK_RECORD,	/* PENDING */
+};
+
 /* Generic text list structure */
 struct cb_text_list {
 	struct cb_text_list	*next;			/* next pointer */

--- a/cobc/config.c
+++ b/cobc/config.c
@@ -771,6 +771,19 @@ cb_config_entry (char *buff, const char *fname, const int line)
 			}
 			break;
 
+		} else if (strcmp (name, "subscript-check") == 0) {
+			if (strcmp (val, "full") == 0) {
+				cb_subscript_check = CB_SUB_CHECK_FULL;
+			} else if (strcmp (val, "max") == 0) {
+				cb_subscript_check = CB_SUB_CHECK_MAX;
+			} else if (strcmp (val, "record") == 0) {
+				cb_subscript_check = CB_SUB_CHECK_RECORD;
+			} else {
+				invalid_value (fname, line, name, val, "full, max, record", 0, 0);
+				return -1;
+			}
+			break;
+
 		} else if (strcmp (name, "defaultbyte") == 0) {
 			if (strcmp (val, "init") == 0) {
 				/* generate default initialization per INITIALIZE rules */

--- a/cobc/config.c
+++ b/cobc/config.c
@@ -778,6 +778,11 @@ cb_config_entry (char *buff, const char *fname, const int line)
 				cb_subscript_check = CB_SUB_CHECK_MAX;
 			} else if (strcmp (val, "record") == 0) {
 				cb_subscript_check = CB_SUB_CHECK_RECORD;
+				unsupported_value (fname, line, name, val);
+#if 1				/* TODO: separate check/codegen with an additional entry point
+				   in libcob/common.c - see FR #437 for the details */
+				cb_subscript_check = CB_SUB_CHECK_MAX;	/* at least not check for ODO... */
+#endif
 			} else {
 				invalid_value (fname, line, name, val, "full, max, record", 0, 0);
 				return -1;

--- a/cobc/config.def
+++ b/cobc/config.def
@@ -97,6 +97,9 @@ CB_CONFIG_ANY (enum cb_screen_clauses_rules, cb_screen_section_clauses, "screen-
 CB_CONFIG_ANY (enum cb_dpc_in_data_options, cb_dpc_in_data, "dpc-in-data",
 	_("whether DECIMAL-POINT IS COMMA has effect in XML/JSON GENERATE, may be one of: none, xml, json, all"))
 
+CB_CONFIG_ANY (enum cb_sub_check, cb_subscript_check, "subscript-check",
+	_("checking for subscript (only done with EC-BOUND-SUBSCRIPT active), may be one of: full, max, record"))
+
 /* Normal boolean flags */
 
 CB_CONFIG_BOOLEAN (cb_filename_mapping, "filename-mapping",

--- a/cobc/typeck.c
+++ b/cobc/typeck.c
@@ -2521,7 +2521,9 @@ cb_build_identifier (cb_tree x, const int subchk)
 		   --> either cache field name here (dropping after each statement)
 		       or remove/skip later during codegen
 		   */
-		if (CB_EXCEPTION_ENABLE (COB_EC_BOUND_SUBSCRIPT) && f->odo_level != 0) {
+		if (cb_subscript_check == CB_SUB_CHECK_FULL
+		 && CB_EXCEPTION_ENABLE (COB_EC_BOUND_SUBSCRIPT)
+		 && f->odo_level != 0) {
 			for (p = f; p; p = p->children) {
 				if (CB_VALID_TREE (p->depending)
 				    /* Do not check length for implicit access to
@@ -2570,12 +2572,13 @@ cb_build_identifier (cb_tree x, const int subchk)
 
 				/* Run-time check for all non-literals */
 				if (CB_EXCEPTION_ENABLE (COB_EC_BOUND_SUBSCRIPT)) {
-					if (p->depending && p->depending != cb_error_node) {
+					if (cb_subscript_check != CB_SUB_CHECK_MAX
+					 && p->depending && p->depending != cb_error_node) {
 						e1 = CB_BUILD_FUNCALL_4 ("cob_check_subscript",
-							 cb_build_cast_int (sub),
-							 cb_build_cast_int (p->depending),
-							 CB_BUILD_STRING0 (name),
-							 cb_int1);
+									 cb_build_cast_int (sub),
+									 cb_build_cast_int (p->depending),
+									 CB_BUILD_STRING0 (name),
+									 cb_int1);
 						optimize_defs[COB_CHK_SUBSCRIPT] = 1;
 						r->check = cb_list_add (r->check, e1);
 					} else {

--- a/config/ChangeLog
+++ b/config/ChangeLog
@@ -1,4 +1,8 @@
 
+2023-06-20  Nicolas Berthier <nicolas.berthier@ocamlpro.com>
+
+	* general: add option subscript-check
+
 2023-03-22  Simon Sobisch <simonsobisch@gnu.org>
 
 	* rm-strict.conf: enable line-col-zero-default per RM-COBOL Language

--- a/config/acu-strict.conf
+++ b/config/acu-strict.conf
@@ -196,6 +196,9 @@ screen-section-rules:		acu
 # Whether DECIMAL-POINT IS COMMA has effect in XML/JSON GENERATE
 dpc-in-data:			xml # verify
 
+# Bounds against which to check subscripts (full, max, record)
+subscript-check:		max
+
 # Dialect features
 # Value: 'ok', 'warning', 'archaic', 'obsolete', 'skip', 'ignore', 'error',
 #        'unconformable'

--- a/config/bs2000-strict.conf
+++ b/config/bs2000-strict.conf
@@ -194,6 +194,9 @@ screen-section-rules:		std
 # Whether DECIMAL-POINT IS COMMA has effect in XML/JSON GENERATE
 dpc-in-data:			xml
 
+# Bounds against which to check subscripts (full, max, record)
+subscript-check:		max # not verified, may need "record"
+
 # Dialect features
 # Value: 'ok', 'warning', 'archaic', 'obsolete', 'skip', 'ignore', 'error',
 #        'unconformable'

--- a/config/cobol2002.conf
+++ b/config/cobol2002.conf
@@ -193,6 +193,9 @@ screen-section-rules:		std
 # Whether DECIMAL-POINT IS COMMA has effect in XML/JSON GENERATE
 dpc-in-data:			xml
 
+# Bounds against which to check subscripts (full, max, record)
+subscript-check:		full
+
 # Dialect features
 # Value: 'ok', 'warning', 'archaic', 'obsolete', 'skip', 'ignore', 'error',
 #        'unconformable'

--- a/config/cobol2014.conf
+++ b/config/cobol2014.conf
@@ -193,6 +193,9 @@ screen-section-rules:		std
 # Whether DECIMAL-POINT IS COMMA has effect in XML/JSON GENERATE
 dpc-in-data:			xml
 
+# Bounds against which to check subscripts (full, max, record)
+subscript-check:		full
+
 # Dialect features
 # Value: 'ok', 'warning', 'archaic', 'obsolete', 'skip', 'ignore', 'error',
 #        'unconformable'

--- a/config/cobol85.conf
+++ b/config/cobol85.conf
@@ -193,6 +193,9 @@ screen-section-rules:		std
 # Whether DECIMAL-POINT IS COMMA has effect in XML/JSON GENERATE
 dpc-in-data:			xml
 
+# Bounds against which to check subscripts (full, max, record)
+subscript-check:		full
+
 # Dialect features
 # Value: 'ok', 'warning', 'archaic', 'obsolete', 'skip', 'ignore', 'error',
 #        'unconformable'

--- a/config/default.conf
+++ b/config/default.conf
@@ -213,6 +213,9 @@ screen-section-rules:		gc
 # Whether DECIMAL-POINT IS COMMA has effect in XML/JSON GENERATE
 dpc-in-data:			xml
 
+# Bounds against which to check subscripts (full, max, record)
+subscript-check:		full
+
 # Dialect features
 # Value: 'ok', 'warning', 'archaic', 'obsolete', 'skip', 'ignore', 'error',
 #        'unconformable'

--- a/config/gcos-strict.conf
+++ b/config/gcos-strict.conf
@@ -192,6 +192,9 @@ screen-section-rules:		std
 # Whether DECIMAL-POINT IS COMMA has effect in XML/JSON GENERATE
 dpc-in-data:			xml
 
+# Bounds against which to check subscripts (full, max, record)
+subscript-check:		max # not verified, may need "record"
+
 # Dialect features
 # Value: 'ok', 'warning', 'archaic', 'obsolete', 'skip', 'ignore', 'error',
 #        'unconformable'

--- a/config/ibm-strict.conf
+++ b/config/ibm-strict.conf
@@ -192,6 +192,9 @@ screen-section-rules:		std
 # Whether DECIMAL-POINT IS COMMA has effect in XML/JSON GENERATE
 dpc-in-data:			xml
 
+# Bounds against which to check subscripts (full, max, record)
+subscript-check:		max # TODO: "record"
+
 # Dialect features
 # Value: 'ok', 'warning', 'archaic', 'obsolete', 'skip', 'ignore', 'error',
 #        'unconformable'

--- a/config/mf-strict.conf
+++ b/config/mf-strict.conf
@@ -195,6 +195,9 @@ screen-section-rules:		mf
 # Whether DECIMAL-POINT IS COMMA has effect in XML/JSON GENERATE
 dpc-in-data:			xml
 
+# Bounds against which to check subscripts (full, max, record)
+subscript-check:		max
+
 # Dialect features
 # Value: 'ok', 'warning', 'archaic', 'obsolete', 'skip', 'ignore', 'error',
 #        'unconformable'

--- a/config/mvs-strict.conf
+++ b/config/mvs-strict.conf
@@ -192,6 +192,9 @@ screen-section-rules:		std
 # Whether DECIMAL-POINT IS COMMA has effect in XML/JSON GENERATE
 dpc-in-data:			xml
 
+# Bounds against which to check subscripts (full, max, record)
+subscript-check:		max # TODO: "record"
+
 # Dialect features
 # Value: 'ok', 'warning', 'archaic', 'obsolete', 'skip', 'ignore', 'error',
 #        'unconformable'

--- a/config/realia-strict.conf
+++ b/config/realia-strict.conf
@@ -196,6 +196,9 @@ screen-section-rules:		xopen
 # Whether DECIMAL-POINT IS COMMA has effect in XML/JSON GENERATE
 dpc-in-data:			xml
 
+# Bounds against which to check subscripts (full, max, record)
+subscript-check:		full # not verified yet
+
 # Dialect features
 # Value: 'ok', 'warning', 'archaic', 'obsolete', 'skip', 'ignore', 'error',
 #        'unconformable'

--- a/config/rm-strict.conf
+++ b/config/rm-strict.conf
@@ -198,6 +198,9 @@ screen-section-rules:		rm
 # Whether DECIMAL-POINT IS COMMA has effect in XML/JSON GENERATE
 dpc-in-data:			xml
 
+# Bounds against which to check subscripts (full, max, record)
+subscript-check:		max
+
 # Dialect features
 # Value: 'ok', 'warning', 'archaic', 'obsolete', 'skip', 'ignore', 'error',
 #        'unconformable'

--- a/config/xopen.conf
+++ b/config/xopen.conf
@@ -206,6 +206,9 @@ screen-section-rules:		xopen
 # Whether DECIMAL-POINT IS COMMA has effect in XML/JSON GENERATE
 dpc-in-data:			xml
 
+# Bounds against which to check subscripts (full, max, record)
+subscript-check:		full
+
 # Dialect features
 # Value: 'ok', 'warning', 'archaic', 'obsolete', 'skip', 'ignore', 'error',
 #        'unconformable'

--- a/tests/testsuite.src/configuration.at
+++ b/tests/testsuite.src/configuration.at
@@ -427,6 +427,7 @@ test.conf: missing definitions:
 	no definition of 'assign-clause'
 	no definition of 'screen-section-rules'
 	no definition of 'dpc-in-data'
+	no definition of 'subscript-check'
 	no definition of 'filename-mapping'
 	no definition of 'pretty-display'
 	no definition of 'binary-truncate'

--- a/tests/testsuite.src/run_subscripts.at
+++ b/tests/testsuite.src/run_subscripts.at
@@ -393,6 +393,47 @@ note: maximum subscript for 'y': 5
 AT_CLEANUP
 
 
+AT_SETUP([enable / disable subscript check with ODO])
+AT_KEYWORDS([runsubscripts subscripts odo debug])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      prog.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01 TAB.
+         02 X           PIC X OCCURS 4 TO 6 DEPENDING ON N
+	                      VALUE "A".
+       01 N             PIC 9 VALUE 5.
+       PROCEDURE        DIVISION.
+           MOVE "B" TO X (6)
+	   IF X (6) NOT EQUAL TO "B" THEN
+	      DISPLAY "Got X (6) = " X (6) ", expected B"
+	   END-DISPLAY
+           STOP RUN.
+])
+
+AT_CHECK([$COMPILE prog.cob -o badprog1], [0], [], [])
+AT_CHECK([$COBCRUN_DIRECT ./badprog1], [1], [],
+[libcob: prog.cob:11: error: subscript of 'X' out of bounds: 6
+note: current maximum subscript for 'X': 5
+])
+
+AT_CHECK([$COMPILE prog.cob -fsubscript-check=full -o failprog1-check-full], [0], [], [])
+AT_CHECK([$COBCRUN_DIRECT ./failprog1-check-full], [1], [],
+[libcob: prog.cob:11: error: subscript of 'X' out of bounds: 6
+note: current maximum subscript for 'X': 5
+])
+
+AT_CHECK([$COMPILE prog.cob -fsubscript-check=max -o okprog1-check-max], [0], [], [])
+AT_CHECK([$COBCRUN_DIRECT ./okprog1-check-max], [0], [], [])
+
+AT_CHECK([$COMPILE prog.cob -fno-ec=bound -fsubscript-check=full -o okprog1-no-ec], [0], [], [])
+AT_CHECK([$COBCRUN_DIRECT ./okprog1-no-ec], [0], [], [])
+
+AT_CLEANUP
+
+
 AT_SETUP([BOUND and NOBOUND directives])
 AT_KEYWORDS([runsubscripts subscripts extensions directive])
 


### PR DESCRIPTION
Only ODO items for now, which actually makes this PR quite short.
I'm not sure what is to be relaxed about reference modifications.
If that stays like this, `-fcheck-record-bound` may not be the clearest of names; maybe `-frelax-odo-bound-checks` would suit better.

https://sourceforge.net/p/gnucobol/feature-requests/437/