### PR TITLE
bin/cob-config: fix missing arguments and order of echos

### DIFF
--- a/bin/ChangeLog
+++ b/bin/ChangeLog
@@ -1,4 +1,9 @@
 
+2023-07-01  Fabrice Le Fessant <fabrice.le_fessant@ocamlpro.com>
+
+	* cob-config: echo in same order as arguments. Add missing
+	arguments (--bindir,--libdir,--datadir,--mandir,--includedir)
+
 2022-10-18  Simon Sobisch <simonsobisch@gnu.org>
 
 	* cobcrun.c: minor validation - check for empty parameters

--- a/bin/cob-config.in
+++ b/bin/cob-config.in
@@ -26,6 +26,10 @@ exec_prefix=${prefix}
 exec_prefix_set=no
 libdir=@libdir@
 includedir=@includedir@
+bindir=@bindir@
+datadir=@datadir@
+includedir=@includedir@
+mandir=@mandir@
 
 version="@VERSION@.@COB_PATCH_LEVEL@"
 cflags="@COB_CFLAGS@"
@@ -76,24 +80,39 @@ while test $# -gt 0; do
         exec_prefix=$optarg
       fi
       ;;
-    --prefix)
-      echo_prefix=yes
-      ;;
     --exec-prefix=*)
       exec_prefix=$optarg
       exec_prefix_set=yes
       ;;
+    --prefix)
+      echo ${prefix}
+      ;;
     --exec-prefix)
-      echo_exec_prefix=yes
+      echo ${exec_prefix}
       ;;
     --version)
-      echo $version
+      echo ${version}
       ;;
     --cflags)
-      echo_cflags=yes
+      echo ${cflags}
       ;;
     --libs)
-      echo_libs=yes
+      echo ${libs}
+      ;;
+    --bindir)
+      echo ${bindir}
+      ;;
+    --datadir)
+      echo ${datadir}
+      ;;
+    --includedir)
+      echo ${includedir}
+      ;;
+    --libdir)
+      echo ${libdir}
+      ;;
+    --mandir)
+      echo ${mandir}
       ;;
     --help)
 	cat <<EOF
@@ -109,19 +128,3 @@ EOF
   esac
   shift
 done
-
-if test "$echo_prefix" = "yes"; then
-	echo $prefix
-fi
-
-if test "$echo_exec_prefix" = "yes"; then
-	echo $exec_prefix
-fi
-
-if test "$echo_cflags" = "yes"; then
-      echo $cflags
-fi
-
-if test "$echo_libs" = "yes"; then
-      echo $libs
-fi


### PR DESCRIPTION
* Some arguments are printed in the help, but not implemented
* If multiple arguments are given, echo values in the same order as arguments