### PR TITLE
Add a profiling tool in GnuCOBOL

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -13,6 +13,13 @@ NEWS - user visible changes				-*- outline -*-
 ** support the COLLATING SEQUENCE clause on indexed files
    (currently only with the BDB backend)
 
+** Support for time profiling of modules, sections, paragraphs, entries
+   and external CALLs. This feature is activated by compiling the modules
+   to be profiled with -fprof, and then executing the code with environment
+   variable COB_PROF_ENABLE. The output is stored in a CSV file. Further
+   customization can be done using COB_PROF_FILE, COB_PROF_MAX_DEPTH and
+   COB_PROF_FORMAT
+
   more work in progress
 
 * Important Bugfixes
@@ -54,6 +61,12 @@ NEWS - user visible changes				-*- outline -*-
 	comparison between numeric DISPLAY or BCD variable to zero
 	INSPECT CONVERTING (and "simple" INSPECT REPLACING), in general
 	   and especially if both from and to are constants
+
+* Changes in the COBOL runtime
+
+** more substitutions in environment variables: $f for executable filename,
+   $b for executable basename, $d for date in YYYYMMDD format, $t for time
+   in HHMMSS format (before, only $$ was available for pid)
 
 * Known issues in 3.x
 

--- a/cobc/ChangeLog
+++ b/cobc/ChangeLog
@@ -1,4 +1,23 @@
 
+2024-03-17  Fabrice Le Fessant <fabrice.le_fessant@ocamlpro.com>
+	    Emilien Lemaire <emilien.lemaire@ocamlpro.com>
+
+	* parser.y: generate calls to "cob_prof_function_call" in the
+	  parsetree when profiling is unabled, when entering/leaving
+	  profiled blocks
+	* flag.def: add `-fprof` to enable profiling
+	* tree.h: add a flags field to cb_goto, add profiling
+	  fields to cb_program, add cb_prof_call enum and export
+	  cb_build_prof_call and cb_prof_procedure_fivision functions
+	* tree.c (cb_build_program): initialize the new profiling
+	  fields of the cb_program structure
+	* tree.c (cb_build_goto): add a "flags" argument
+	  (stored in the cb_program structure)
+	* typeck.c (cb_emit_goto): add a "flags" argument
+	  (passed to cb_build_goto)
+	* codegen.c: handle profiling code generation under the
+	  cb_flag_prof guard
+
 2024-02-19  Boris Eng <boris.eng@ocamlpro.com>
 
 	* parser.y (screen_value_clause): replaced basic literals by literals

--- a/cobc/codegen.c
+++ b/cobc/codegen.c
@@ -4374,24 +4374,24 @@ output_funcall (cb_tree x)
 			output ("cob_prof_enter_procedure (prof_info, %d);", proc_idx);
 			output_newline ();
 			output_prefix ();
-			output ("cob_prof_fallthrough_label = 0");
+			output ("fallthrough_label = 0");
 			break;
 		case COB_PROF_USE_PARAGRAPH_ENTRY: {
 			int paragraph_idx = CB_INTEGER(p->argv[1])->val;
 			int entry_idx = CB_INTEGER(p->argv[2])->val;
-			output ("if (!cob_prof_fallthrough_label)");
+			output ("if (!fallthrough_label)");
 			output_block_open ();
 			output_line ("cob_prof_use_paragraph_entry (prof_info, %d, %d);",
 				     paragraph_idx, entry_idx);
 			output_block_close ();
 			output_line ("else");
 			output_block_open ();
-			output_line ("cob_prof_fallthrough_label = 0;");
+			output_line ("fallthrough_label = 0;");
 			output_block_close ();
 			break;
 		}
 		case COB_PROF_STAYIN_PARAGRAPH:
-			output ("cob_prof_fallthrough_label = 1");
+			output ("fallthrough_label = 1");
 			break;
 		}
 		return;
@@ -13782,7 +13782,7 @@ output_cob_prof_data ( struct cb_program * program )
 		}
 		output_local ("};\n");
 
-		output_local ("static int cob_prof_fallthrough_label = 0;\n");
+		output_local ("static int fallthrough_label = 0;\n");
 		output_local ("static struct cob_prof_module *prof_info;\n");
 
 		output_local ("\n/* End of cob_prof data */\n");

--- a/cobc/flag.def
+++ b/cobc/flag.def
@@ -262,3 +262,7 @@ CB_FLAG_ON (cb_diagnostics_show_line_numbers, 1, "diagnostics-show-line-numbers"
 
 CB_FLAG (cb_diagnostics_absolute_paths, 1, "diagnostics-absolute-paths",
 	_("  -fdiagnostics-absolute-paths\tprint absolute paths in diagnostics"))
+
+CB_FLAG (cb_flag_prof, 1, "prof",
+	_("  -fprof                enable profiling of the COBOL program"))
+

--- a/cobc/tree.c
+++ b/cobc/tree.c
@@ -2196,6 +2196,11 @@ cb_build_program (struct cb_program *last_program, const int nest_level)
 	if (cb_call_extfh) {
 		p->extfh = cobc_parse_strdup (cb_call_extfh);
 	}
+
+	p->prof_current_section = -1;
+	p->prof_current_paragraph = -1;
+	p->prof_current_call = -1;
+
 	/* Save current program as actual at it's level */
 	container_progs[nest_level] = p;
 	if (nest_level
@@ -6671,7 +6676,7 @@ cb_build_alter (const cb_tree source, const cb_tree target)
 /* GO TO */
 
 cb_tree
-cb_build_goto (const cb_tree target, const cb_tree depending)
+cb_build_goto (const cb_tree target, const cb_tree depending, int flags)
 {
 	struct cb_goto *p;
 
@@ -6679,6 +6684,7 @@ cb_build_goto (const cb_tree target, const cb_tree depending)
 		       sizeof (struct cb_goto));
 	p->target = target;
 	p->depending = depending;
+	p->flags = flags;
 	return CB_TREE (p);
 }
 
@@ -7460,6 +7466,183 @@ cb_deciph_default_file_colseq_name (const char * const name)
 	return cb_deciph_colseq_name (name, &cb_default_file_colseq);
 }
 
+/* Use constant strings to replace string comparisons by more
+ * efficient pointer comparisons */
+const char *cob_prof_function_call_str = "cob_prof_function_call";
+
+void
+cb_prof_procedure_division (struct cb_program *program,
+			    const char *source_file,
+			    int source_line)
+{
+	/* invariant: program always has index 0 */
+	procedure_list_add (
+		program,
+		COB_PROF_PROCEDURE_MODULE,
+		program->orig_program_id,
+		0,
+		source_file,
+		source_line);
+}
+
+/* Returns a tree node for a funcall to one of the profiling
+ functions, with the index of the procedure as argument (and a second
+ argument for the entry point if meaningful). If the program, section
+ or paragraph are being entered for the first time, register them into
+ the procedure_list of the program.
+
+ To avoid lookups, the current section and current paragraph are kept
+ in the program record for immediate use when exiting.
+*/
+cb_tree
+cb_build_prof_call (enum cb_prof_call prof_call,
+		    struct cb_program  *program,
+		    struct cb_label  *section,
+		    struct cb_label  *paragraph,
+		    const char  *entry,
+		    cb_tree location)
+{
+	const char  *func_name = cob_prof_function_call_str;
+	int          func_arg1 = -1;
+	int          func_arg2 = -1;
+
+	switch (prof_call){
+
+	case COB_PROF_ENTER_SECTION:
+
+		/* allocate section record and remember current section */
+		program->prof_current_section =
+			procedure_list_add (
+				program,
+				COB_PROF_PROCEDURE_SECTION,
+				section->name,
+				/* the current section will have
+				 * procedure_list_list as index */
+				program->procedure_list_len,
+				section->common.source_file,
+				section->common.source_line);
+		program->prof_current_paragraph = -1;
+		func_arg1 = program->prof_current_section;
+		break;
+
+	case COB_PROF_ENTER_PARAGRAPH:
+
+		/* allocate section record and remember current section */
+		program->prof_current_paragraph =
+			procedure_list_add (
+				program,
+				COB_PROF_PROCEDURE_PARAGRAPH,
+				paragraph->name,
+				program->prof_current_section,
+				paragraph->common.source_file,
+				paragraph->common.source_line);
+		func_arg1 = program->prof_current_paragraph;
+		break;
+
+		/* In the case of an ENTRY statement, add code before
+		 * to the falling-through paragraph to avoid
+		 * re-registering the entry into the paragraph. */
+	case COB_PROF_STAYIN_PARAGRAPH:
+
+		func_arg1 = program->prof_current_paragraph;
+		break;
+
+	case COB_PROF_USE_PARAGRAPH_ENTRY:
+
+		func_arg1 = program->prof_current_paragraph;
+		func_arg2 =
+			procedure_list_add (
+				program,
+				COB_PROF_PROCEDURE_ENTRY,
+				entry,
+				/* section field of entry is in fact its paragraph */
+				program->prof_current_paragraph,
+				location->source_file,
+				location->source_line);
+		break;
+
+	case COB_PROF_EXIT_PARAGRAPH:
+
+		func_arg1 = program->prof_current_paragraph;
+		/* Do not reinitialize, because we may have several of these
+		   EXIT_PARAGRAPH, for example at EXIT SECTION.
+		   program->prof_current_paragraph = -1; */
+		break;
+
+	case COB_PROF_EXIT_SECTION:
+
+		func_arg1 = program->prof_current_section;
+		/* reset current paragraph and section */
+		program->prof_current_section = -1;
+		program->prof_current_paragraph = -1;
+		break;
+
+	case COB_PROF_ENTER_CALL:
+
+		/* allocate call record and remember current call */
+		program->prof_current_call =
+			procedure_list_add (
+				program,
+				COB_PROF_PROCEDURE_CALL,
+				NULL,
+				program->prof_current_paragraph,
+				paragraph->common.source_file,
+				paragraph->common.source_line);
+		func_arg1 = program->prof_current_call;
+		break;
+
+	case COB_PROF_EXIT_CALL:
+
+		/* We need to patch the last procedure to add the callee name and loc */
+		program->procedure_list_last->proc.text = cobc_main_strdup (entry);
+		program->procedure_list_last->proc.file = location->source_file;
+		program->procedure_list_last->proc.line = location->source_line;
+
+		func_arg1 = program->prof_current_call;
+		program->prof_current_call = -1;
+		break;
+
+	}
+	if (func_arg2 < 0){
+		return CB_BUILD_FUNCALL_2 (func_name, cb_int (prof_call), cb_int (func_arg1));
+	}
+	return CB_BUILD_FUNCALL_3 (func_name, cb_int (prof_call), cb_int (func_arg1), cb_int (func_arg2));
+}
+
+/* Allocate a procedure description record and add it at the end of
+ * the procedure_list of the current program. The index of the
+ * procedure will be the position in the list. There is an invariant
+ * that 0 is reserved for the record of the program module. */
+int
+procedure_list_add (
+	struct cb_program *program,
+	enum cob_prof_procedure_kind kind,
+	const char *text,
+	int section,
+	const char *file,
+	int line)
+{
+	struct cb_procedure_list	*p;
+	int ret = program->procedure_list_len ;
+
+	p = cobc_main_malloc (sizeof (struct cb_procedure_list));
+	if (text){ p->proc.text = cobc_main_strdup (text); }
+	p->proc.kind = kind;
+	p->proc.file = file;
+	p->proc.line = line;
+	p->proc.section = section;
+	p->next = NULL;
+
+	if (program->procedure_list == NULL){
+		program->procedure_list = p;
+	} else {
+		program->procedure_list_last->next = p;
+	}
+	program->procedure_list_last = p;
+
+	program->procedure_list_len++;
+	return ret;
+}
 
 #ifndef	HAVE_DESIGNATED_INITS
 void

--- a/cobc/typeck.c
+++ b/cobc/typeck.c
@@ -10054,7 +10054,7 @@ cb_emit_free (cb_tree vars)
 /* GO TO statement */
 
 void
-cb_emit_goto (cb_tree target, cb_tree depending)
+cb_emit_goto (cb_tree target, cb_tree depending, int flags)
 {
 	if (target == cb_error_node) {
 		return;
@@ -10065,14 +10065,14 @@ cb_emit_goto (cb_tree target, cb_tree depending)
 		/* GO TO procedure-name ...   DEPENDING ON numeric-identifier  and
 		   GO TO ENTRY entry-name ... DEPENDING ON numeric-identifier */
 		cb_emit_incompat_data_checks (depending);
-		cb_emit (cb_build_goto (target, depending));
+		cb_emit (cb_build_goto (target, depending, flags));
 	} else if (CB_CHAIN (target)) {
 			cb_error_x (CB_TREE (current_statement),
 				    _("GO TO with multiple procedure-names"));
 	} else {
 		/* GO TO procedure-name   and
 		   GO TO ENTRY entry-name */
-		cb_emit (cb_build_goto (CB_VALUE (target), NULL));
+		cb_emit (cb_build_goto (CB_VALUE (target), NULL, flags));
 	}
 }
 
@@ -10080,9 +10080,9 @@ void
 cb_emit_exit (const unsigned int goback)
 {
 	if (goback) {
-		cb_emit (cb_build_goto (cb_int1, NULL));
+		cb_emit (cb_build_goto (cb_int1, NULL, CB_GOTO_FLAG_NONE));
 	} else {
-		cb_emit (cb_build_goto (NULL, NULL));
+		cb_emit (cb_build_goto (NULL, NULL, CB_GOTO_FLAG_NONE));
 	}
 }
 

--- a/config/ChangeLog
+++ b/config/ChangeLog
@@ -3,6 +3,10 @@
 
 	* rm-strict.conf (perform-osvs): enabled as noted in MF docs
 
+2023-09-07  Emilien Lemaire <emilien.lemaire@ocamlpro.com>
+
+	* runtime.cfg: add COB_PROF_FILE
+
 2023-07-25  Simon Sobisch <simonsobisch@gnu.org>
 
 	* general: add option using-optional

--- a/config/runtime.cfg
+++ b/config/runtime.cfg
@@ -69,6 +69,15 @@
 # A 'size' value is an unsigned integer optionally followed by K, M, or G
 # for kilo, mega or giga.
 
+# Variables of type string can be of three different kinds:
+# regular string, file name, and path list
+# All those may contain the following escape sequences:
+# 	$$	process id
+# 	$f	executable filename (full path)
+# 	$b	executable basename (anything after the last separator)
+#	$d	date (yyyymmdd)
+# 	$t	time (hhmmss)
+
 # For convenience a parameter in the runtime.cfg file may be defined by using
 # either the environment variable name or the parameter name.
 # In most cases the environment variable name is the parameter name (in upper
@@ -119,7 +128,7 @@
 # Environment name:  COB_TRACE_FILE
 #   Parameter name:  trace_file
 #          Purpose:  to define where COBOL trace output should go
-#             Type:  string       : $$ is replaced by process id
+#             Type:  string (file) ; may use $-sequences
 #             Note:  file is opened for append if name starts with "+"
 #          Default:  stderr
 #          Example:  TRACE_FILE  ${HOME}/mytrace.$$
@@ -195,7 +204,7 @@
 #             Note:  the -fdump=all compile option prepares for dump;
 #                    file is opened for append if name starts with "+";
 #                    may be disabled by setting it to "NONE"
-#             Type:  string       : $$ is replaced by process id
+#             Type:  string (file) ; may use $-sequences
 #          Default:  stderr
 #          Example:  DUMP_FILE  ${HOME}/mytrace.log
 
@@ -217,6 +226,41 @@
 #          Example:  COB_CURRENT_DATE "2026/03/16 16:40:52"
 #                    current_date YYYYMMDDHHMMSS+01:00
 
+# Environment name:  COB_PROF_FILE
+#   Parameter name:  prof_file
+#          Purpose:  to define where COBOL profiling output should go
+#             Type:  string (file) ; may use $-sequences
+#          Default:  cob-prof-$b-$$-$d-$t.csv
+#          Example:  PROF_FILE  ${HOME}/$$-prof.csv
+
+# Environment name:  COB_PROF_ENABLE
+#   Parameter name:  prof_enable
+#          Purpose:  to enable profiling for modules compiled with profiling;
+#                    note that this disables physical cancel
+#             Type:  boolean
+#          Default:  false
+#          Example:  PROF_ENABLE yes
+
+# Environment name:  COB_PROF_MAX_DEPTH
+#   Parameter name:  prof_max_depth
+#          Purpose:  the number of sections and paragraphs that can be nested;
+#                    if the nesting level is higher than this threshold,
+#                    profiling is disabled automatically
+#             Type:  integer
+#          Default:  8192
+#          Example:  PROF_MAX_DEPTH  8192
+
+# Environment name:  COB_PROF_FORMAT
+#   Parameter name:  prof_format
+#          Purpose:  to define the format of the columns in the profiling CSV file.
+#             Type:  string a comma separated list of fields, with %m for module,
+#                    %s for section, %p for paragraph, %e for entry, %w for
+#                    location, %k for kind (PROGRAM,SECTION,PARAGRAPH,ENTRY)
+#                    %f for file, %i for PID, %t for time in nano-seconds,
+#                    %h for human-readable time, %n for number of calls
+#          Default:  %m,%s,%p,%e,%w,%k,%t,%h,%n
+#          Example:  COB_PROF_FORMAT %m,%s,%p,%e,%w,%k,%t,%h,%n
+
 #
 ## Call environment
 #
@@ -224,7 +268,7 @@
 # Environment name:  COB_LIBRARY_PATH
 #   Parameter name:  library_path
 #          Purpose:  paths for dynamically-loadable modules
-#             Type:  string
+#             Type:  string (path list)
 #             Note:  the default paths .:/installpath/extras are always
 #                    added to the given paths
 #          Example:  LIBRARY_PATH    /opt/myapp/test:/opt/myapp/production
@@ -467,7 +511,7 @@
 #   Parameter name:  display_print_file
 #          Purpose:  Defines file to be appended to by DISPLAY UPON PRINTER
 #             Note:  Each DISPLAY UPON PRINTER opens, appends and closes the file.
-#             Type:  string       : $$ is replaced by process id
+#             Type:  string ; may use $-sequences
 #          Default:  not set
 #          Example:  display_printer '/tmp/myprt.log'
 
@@ -476,7 +520,7 @@
 #          Purpose:  Defines file to be created on first
 #                    DISPLAY UPON SYSPUNCH/SYSPCH
 #             Note:  The file will be only be closed on runtime exit.
-#             Type:  string       : $$ is replaced by process id
+#             Type:  string ; may use $-sequences
 #          Default:  not set
 #          Example:  display_punch './punch_$$.out'
 

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,4 +1,8 @@
 
+2023-09-07  Emilien Lemaire <emilien.lemaire@ocamlpro.com>
+
+	* gnucobol.texi: document the profiling feature
+
 2023-07-10  Simon Sobisch <simonsobisch@gnu.org>
 
 	* gnucobol.texi: updated "Build target" (change of -P / -E),

--- a/doc/gnucobol.texi
+++ b/doc/gnucobol.texi
@@ -87,6 +87,7 @@ Welcome to the GnuCOBOL @value{VERSION} manual.
 * Customize::                   Customizing the compiler
 * Optimize::                    Optimizing your program
 * Debug::                       Debugging your program
+* Profiling::                   Profiling your program
 * Extensions::                  Non-standard extensions
 * System Routines::             Additional routines
 * Appendices::                  List of supported features and options,
@@ -155,6 +156,10 @@ Debug
 * Memory Dumps::                Memory Dumps
 * Core Dumps::                  Core Dumps
 * Trace::                       Tracing execution
+
+Profiling
+* Profiling options::           Profiling options
+* Profiling results::           Profiling results
 
 Extensions
 
@@ -1734,7 +1739,7 @@ machine.  Set the config option @code{binary-byteorder} to
 In addition, setting the option @code{binary-size} to @code{2-4-8} or
 @code{1-2-4-8} is more efficient than others.
 
-@node Debug, Extensions, Optimize, Top
+@node Debug, Profiling, Optimize, Top
 @chapter Debug
 
 @menu
@@ -1795,7 +1800,100 @@ Tracing program execution, either in general or in specific parts can be enabled
 
 @exampleindent 0
 
-@node Extensions, System Routines, Debug, Top
+@node Profiling, Extensions, Debug, Top
+@chapter Profiling COBOL
+@cindex Profiling
+@cindex Profiling your program
+
+@menu
+* Profiling options::           Profiling options
+* Profiling results::           Profiling results
+@end menu
+
+@node Profiling options
+@section Profiling options
+
+Profiling is enabled with the @code{-fprof} flag while compiling a
+COBOL module. Only modules that have been compiled with profiling
+enabled can be later profiled.
+
+Then executing your program with @env{COB_PROF_ENABLE=1} will
+automatically profile the module(s) and generate a CSV result file.
+Note that physical @code{CANCEL} is disabled when profiling is
+enabled, because some profiling information in the module needs to
+remain available until the end of the program.
+
+By default, this file is called
+@code{cob-prof-<program-id>-<pid>.csv}, but this name can be
+configured using @env{COB_PROF_FILE}.
+
+Some environment variables (and the corresponding options in the
+runtime configuration) can be used to tune the behavior of profiling
+during execution: @code{COB_PROF_FILE}, @code{COB_PROF_ENABLE}
+and @code{COB_PROF_MAX_DEPTH}, @code{COB_PROF_FORMAT}
+@pxref{Appendix I, Runtime Configuration, Runtime Configuration} for
+more information.
+
+
+@node Profiling results
+@section Profiling results
+@cindex Profiling results
+@cindex How to interpret the profiling results
+
+By default, the generated CSV file has 8 columns for each line (it can
+be customized with the @code{COB_PROF_FORMAT} environment/runtime
+configuration):
+
+@table @code
+
+@item program-id
+
+The program identifier of the module.
+
+@item section
+
+The name of the section. The time of a section is not computed
+directly, but as the sum of the time spent in its paragraphs.
+
+@item paragraph
+
+The name of the paragraph. If a section has no paragraph, or does not
+start with a paragraph, a default paragraph called
+@code{MAIN PARAGRAPH} is created.
+
+@item entry
+
+The name of the entry for @code{ENTRY} statements, or the name of the
+target for @code{CALL} statements. No time is associated with
+@code{ENTRY} statements, as the time is directly included in the
+including paragraph. However, the number of calls is still recorded.
+
+@item location
+
+The file and line number of the corresponding entry point (section or
+paragraph)
+
+@item kind
+
+The kind is either @code{PROGRAM}, @code{SECTION}, @code{PARAGRAPH},
+@code{CALL} or @code{ENTRY}.
+
+@item time-ns
+
+The time spent in the module/section/paragraph/call in nanoseconds
+
+@item time
+
+The time spent in the module/section/paragraph/call in a human
+readable form (currently, the time in seconds and milliseconds)
+
+@item ncalls
+
+The number of calls to this section/paragraph
+
+@end table
+
+@node Extensions, System Routines, Profiling, Top
 @chapter Non-standard extensions
 @cindex Extensions
 @cindex Non-standard extensions

--- a/libcob/ChangeLog
+++ b/libcob/ChangeLog
@@ -1,4 +1,17 @@
 
+2024-03-17  Fabrice Le Fessant <fabrice.le_fessant@ocamlpro.com>
+	    Emilien Lemaire <emilien.lemaire@ocamlpro.com>
+
+	* Makefile.am: add `profiling.c` to sources
+	* profiling.c: implement profiling functions
+	  (time spent in each procedure of the program)
+	* common.c: add 4 environments variables COB_PROF_FILE,
+	  COB_PROF_MAX_DEPTH,COB_PROF_ENABLE and COB_PROF_FORMAT
+	* common.c (cob_expand_env_string): add $b (executable basename),
+	  $f (executable filename), $d (date in yyyymmdd) and
+	  $t (time in hhmmss)
+	* common.c (cob_set_main_argv0): extracted from cob_init
+
 2024-01-25  David Declerck <david.declerck@ocamlpro.com>
 
 	FR #459: support COLLATING SEQUENCE clause on SELECT / INDEXED files

--- a/libcob/ChangeLog
+++ b/libcob/ChangeLog
@@ -11,6 +11,8 @@
 	  $f (executable filename), $d (date in yyyymmdd) and
 	  $t (time in hhmmss)
 	* common.c (cob_set_main_argv0): extracted from cob_init
+	* fileio.c (cob_path_to_absolute): extracted from insert
+	  and cob_set_main_argv0
 
 2024-01-25  David Declerck <david.declerck@ocamlpro.com>
 

--- a/libcob/Makefile.am
+++ b/libcob/Makefile.am
@@ -22,7 +22,7 @@
 lib_LTLIBRARIES = libcob.la
 libcob_la_SOURCES = common.c move.c numeric.c strings.c \
 	fileio.c call.c intrinsic.c termio.c screenio.c reportio.c cobgetopt.c \
-	mlio.c coblocal.h cconv.c system.def
+	mlio.c coblocal.h cconv.c system.def profiling.c
 
 if LOCAL_CJSON
 nodist_libcob_la_SOURCES = cJSON.c

--- a/libcob/call.c
+++ b/libcob/call.c
@@ -661,25 +661,9 @@ insert (const char *name, void *func, lt_dlhandle handle,
 	p->func = func;
 	p->handle = handle;
 	p->module = module;
-	if (path) {
-#if	defined(HAVE_CANONICALIZE_FILE_NAME)
-		/* Malloced path or NULL */
-		p->path = canonicalize_file_name (path);
-#elif	defined(HAVE_REALPATH)
-		char	*s;
 
-		s = cob_malloc ((size_t)COB_NORMAL_BUFF);
-		if (realpath (path, s) != NULL) {
-			p->path = cob_strdup (s);
-		}
-		cob_free (s);
-#elif	defined	(_WIN32)
-		/* Malloced path or NULL */
-		p->path = _fullpath (NULL, path, 1);
-#endif
-		if (!p->path) {
-			p->path = cob_strdup (path);
-		}
+	if (path) {
+		p->path = cob_path_to_absolute (path);
 	}
 	p->no_phys_cancel = nocanc;
 	val = hash ((const unsigned char *)name);

--- a/libcob/coblocal.h
+++ b/libcob/coblocal.h
@@ -347,6 +347,10 @@ typedef struct __cob_settings {
 	FILE		*cob_dump_file;		/* FILE* to write DUMP information to */
 
 	char		*cob_dump_filename;	/* Place to write dump of variables */
+	char		*cob_prof_filename;	/* Place to write profiling data */
+	int		cob_prof_enable;	/* Whether profiling is enabled */
+	int		cob_prof_max_depth;	/* Max stack depth during profiling (255 by default) */
+	char		*cob_prof_format;	/* Format of prof CSV line */
 	int		cob_dump_width;		/* Max line width for dump */
 	unsigned int	cob_core_on_error;		/* signal handling and possible raise of SIGABRT
 											   / creation of coredumps on runtime errors */
@@ -441,6 +445,7 @@ COB_HIDDEN void		cob_init_call		(cob_global *, cob_settings *, const int);
 COB_HIDDEN void		cob_init_intrinsic	(cob_global *);
 COB_HIDDEN void		cob_init_strings	(cob_global *);
 COB_HIDDEN void		cob_init_move		(cob_global *, cob_settings *);
+COB_HIDDEN void		cob_init_prof		(cob_global *, cob_settings *);
 COB_HIDDEN void		cob_init_screenio	(cob_global *, cob_settings *);
 COB_HIDDEN void		cob_init_mlio		(cob_global * const);
 
@@ -504,6 +509,9 @@ COB_HIDDEN int		cob_field_to_string	(const cob_field *, void *,
 COB_HIDDEN cob_settings *cob_get_settings_ptr	(void);
 COB_HIDDEN char	*cob_strndup		(const char *, const size_t);
 
+/* Function called by the runtime at the end of execution to save the
+ * profiling information in a file. */
+COB_HIDDEN void cob_prof_end (void);
 
 enum cob_datetime_res {
 	DTR_DATE,
@@ -572,6 +580,8 @@ cob_max_int (const int x, const int y)
 
 COB_HIDDEN int		cob_cmps	(const unsigned char *, const unsigned char *,
 					 const size_t, const unsigned char *);
+
+COB_HIDDEN FILE *	cob_open_logfile (const char *filename);
 
 #undef	COB_HIDDEN
 

--- a/libcob/coblocal.h
+++ b/libcob/coblocal.h
@@ -583,6 +583,9 @@ COB_HIDDEN int		cob_cmps	(const unsigned char *, const unsigned char *,
 
 COB_HIDDEN FILE *	cob_open_logfile (const char *filename);
 
+/* Whether we are in testsuite mode */
+COB_HIDDEN int is_test;
+
 #undef	COB_HIDDEN
 
 #endif	/* COB_LOCAL_H */

--- a/libcob/common.h
+++ b/libcob/common.h
@@ -2680,6 +2680,8 @@ COB_EXPIMP void	cob_file_sort_giving_extfh	(cob_file *, const size_t, ...);
 COB_EXPIMP void	cob_file_release	(cob_file *);
 COB_EXPIMP void	cob_file_return		(cob_file *);
 
+COB_EXPIMP char * cob_path_to_absolute (const char *path);
+
 /***************************/
 /* Functions in reportio.c */
 /***************************/

--- a/libcob/common.h
+++ b/libcob/common.h
@@ -1722,7 +1722,7 @@ COB_EXPIMP void	cob_set_locale			(cob_field *, const int);
 COB_EXPIMP int 	cob_setenv		(const char *, const char *, int);
 COB_EXPIMP int 	cob_unsetenv		(const char *);
 COB_EXPIMP char	*cob_getenv_direct		(const char *);
-COB_EXPIMP char *cob_expand_env_string	(char *);
+COB_EXPIMP char *cob_expand_env_string	(const char *);
 COB_EXPIMP char	*cob_getenv			(const char *);
 COB_EXPIMP int	cob_putenv			(char *);
 
@@ -2953,5 +2953,65 @@ typedef	char *		cobchar_t;
 #define cobput_sxn_compx(d,n,v)	(void)	cob_put_s64_compx(v, d, n)
 
 /*******************************/
+
+
+/* Type to store nanoseconds */
+typedef unsigned long long cob_ns_time;
+
+enum cob_prof_procedure_kind {
+	COB_PROF_PROCEDURE_MODULE,
+	COB_PROF_PROCEDURE_SECTION,
+	COB_PROF_PROCEDURE_PARAGRAPH,
+	COB_PROF_PROCEDURE_ENTRY,
+	COB_PROF_PROCEDURE_CALL
+};
+
+struct cob_prof_procedure {
+	/* Name of the module or section or paragraph or entry */
+	const char		        *text;
+	/* File Location */
+	const char                      *file;
+	int                              line;
+	/* Index of the section record of this procedure. In the case
+	   of COB_PROF_PROCEDURE_ENTRY, the "section" field is in fact
+	   the paragraph, not the section */
+	int		                 section;
+	/* Kind of procedure. */
+	enum cob_prof_procedure_kind     kind;
+};
+
+/* Structure storing profiling information about each COBOL module */
+struct cob_prof_module {
+	/* Array of execution times */
+	cob_ns_time                     *total_times;
+	/* Array of execution counts */
+	unsigned int                    *called_count;
+	/* Array of current recursions per procedure  */
+	unsigned int                    *procedure_recursions;
+	/* Array of procedure descriptions */
+	struct cob_prof_procedure       *procedures ;
+	/* Number of procedures */
+	size_t                           procedure_count;
+};
+
+/* Function called to start profiling a COBOL module. Allocates the
+   cob_prof_module structure that will be used to store the counters and
+   times. */
+COB_EXPIMP struct cob_prof_module *cob_prof_init_module (
+	cob_module *module,
+	struct cob_prof_procedure  *procedure_names,
+	size_t      procedure_count);
+
+/* Functions used to instrument the generated C code and measure
+ * counters and times */
+COB_EXPIMP void cob_prof_enter_procedure  	(struct cob_prof_module *, int);
+COB_EXPIMP void cob_prof_exit_procedure   	(struct cob_prof_module *, int);
+COB_EXPIMP void cob_prof_enter_section  	(struct cob_prof_module *, int);
+COB_EXPIMP void cob_prof_exit_section   	(struct cob_prof_module *, int);
+
+/* Enter a paragraph in the middle, using an ENTRY statement */
+COB_EXPIMP void cob_prof_use_paragraph_entry	(struct cob_prof_module *, int, int);
+/* Exit a paragraph using a GO TO */
+COB_EXPIMP void cob_prof_goto			(struct cob_prof_module *);
 
 #endif	/* COB_COMMON_H */

--- a/libcob/fileio.c
+++ b/libcob/fileio.c
@@ -10754,3 +10754,31 @@ org_handling:
 	}
 	return sts;
 }
+
+
+char *
+cob_path_to_absolute (const char *path)
+{
+	char *abs_path = NULL;
+	if (path) {
+#if	defined(HAVE_CANONICALIZE_FILE_NAME)
+		/* Returns malloced path or NULL */
+		abs_path = canonicalize_file_name (path);
+#elif	defined(HAVE_REALPATH)
+		char	*s;
+
+		s = cob_malloc ((size_t)COB_NORMAL_BUFF);
+		if (realpath (path, s) != NULL) {
+			abs_path = cob_strdup (s);
+		}
+		cob_free (s);
+#elif	defined	(_WIN32)
+		/* Returns malloced path or NULL */
+		abs_path = _fullpath (NULL, path, 1);
+#endif
+		if (!abs_path) {
+			abs_path = cob_strdup (path);
+		}
+	}
+	return abs_path;
+}

--- a/libcob/profiling.c
+++ b/libcob/profiling.c
@@ -1,0 +1,558 @@
+/*
+   Copyright (C) 2023-2024 Free Software Foundation, Inc.
+   Written by Emilien Lemaire and Fabrice Le Fessant.
+
+   This file is part of GnuCOBOL.
+
+   The GnuCOBOL compiler is free software: you can redistribute it
+   and/or modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation, either version 3 of the
+   License, or (at your option) any later version.
+
+   GnuCOBOL is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with GnuCOBOL.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include "config.h"
+
+/* include internal and external libcob definitions, forcing exports */
+#define COB_LIB_EXPIMP
+#include "coblocal.h"
+
+#include "tarstamp.h"
+#include "common.h"
+
+#include <sys/types.h>
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+
+#ifdef	_WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#endif
+
+/* Local types and variables */
+
+struct cob_prof_module_list {
+	struct cob_prof_module *info ;
+	struct cob_prof_module_list *next;
+};
+
+static struct cob_prof_module_list *prof_info_list ;
+
+/* We maintain a stack of the procedures entered as 3 different
+ * arrays, with "current_idx" being the stack pointer. */
+static cob_ns_time              *start_times;
+static int                      *called_procedures;
+static struct cob_prof_module*  *called_runtimes;
+/* Current size of previous arrays */
+static int max_prof_depth;
+static int current_idx = -1;
+
+/* Whether profiling is active or not. */
+static int is_active = 0;
+/* Whether we are in testsuite mode */
+static int is_test = 0;
+
+/* Which clock to use for clock_gettime (if available) */
+#if !defined (_WIN32) && defined (HAVE_CLOCK_GETTIME)
+static clockid_t clockid = CLOCK_REALTIME;
+#endif
+
+/* Cached clock frequency on Windows */
+#ifdef _WIN32
+static LONGLONG qpc_freq = 0;
+#endif
+
+/* Remember static and dynamic configuration */
+static cob_global               *cobglobptr = NULL;
+static cob_settings             *cobsetptr = NULL;
+
+
+
+/* Return the current time in nanoseconds. The result is guarranteed
+ * to be monotonic, by using an internal storage of the previous
+ * time. */
+static cob_ns_time
+get_ns_time (void)
+{
+	if (is_test){
+		static cob_ns_time ns_time = 0;
+		ns_time += 1000000;
+		return ns_time;
+	} else {
+		cob_ns_time ns_time = 0;
+		unsigned long long nanoseconds;
+#ifdef _WIN32
+		if (qpc_freq) {
+			LARGE_INTEGER performance_counter;
+			QueryPerformanceCounter(&performance_counter);
+			performance_counter.QuadPart *= 1000000000;
+			performance_counter.QuadPart /= qpc_freq;
+			nanoseconds = performance_counter.QuadPart;
+		} else {
+#endif /* _WIN32 */
+#ifdef HAVE_CLOCK_GETTIME
+			struct timespec ts;
+			clock_gettime(clockid, &ts);
+			nanoseconds = ts.tv_sec * 1000000000 + ts.tv_nsec;
+#else
+			nanoseconds = clock() * 1000000000 / CLOCKS_PER_SEC;
+#endif /* HAVE_CLOCK_GETTIME */
+#ifdef _WIN32
+		}
+#endif /* _WIN32 */
+		if (nanoseconds > ns_time) ns_time = nanoseconds;
+		return ns_time;
+	}
+}
+
+static void
+prof_init_static ()
+{
+	static int init_done = 0;
+
+	if (!init_done && cobsetptr){
+#ifdef HAVE_CLOCK_GETTIME
+		struct timespec ts;
+		if (clock_gettime(CLOCK_MONOTONIC_RAW, &ts) == 0) {
+			clockid = CLOCK_MONOTONIC_RAW;
+		} else if (clock_gettime(CLOCK_MONOTONIC, &ts) == 0) {
+			clockid = CLOCK_MONOTONIC;
+		}
+#endif
+#ifdef _WIN32
+		/* Should always succeed on Windows XP and above, but might
+		   fail on Windows 2000. Not available on Windows 9x & NT. */
+		LARGE_INTEGER performance_frequency;
+		if (QueryPerformanceFrequency(&performance_frequency)) {
+			qpc_freq = performance_frequency.QuadPart;
+		}
+#endif
+		init_done = 1;
+		is_active = cobsetptr->cob_prof_enable;
+		if (is_active) {
+			is_test = !!getenv ("COB_IS_RUNNING_IN_TESTMODE");
+		}
+	}
+}
+
+void
+cob_init_prof (cob_global *lptr, cob_settings *sptr)
+{
+	cobglobptr = lptr;
+        cobsetptr  = sptr;
+}
+
+struct cob_prof_module *
+cob_prof_init_module (cob_module *module,
+		      struct cob_prof_procedure *procedures,
+		      size_t procedure_count)
+{
+	prof_init_static();
+	if (is_active){
+		struct cob_prof_module *info;
+		struct cob_prof_module_list *item;
+
+		info = cob_malloc (sizeof(struct cob_prof_module));
+		info->total_times = cob_malloc ( procedure_count * sizeof(cob_ns_time) );
+		info->called_count = cob_malloc ( procedure_count * sizeof(unsigned int) );
+		info->procedure_recursions = cob_malloc ( procedure_count * sizeof(unsigned int) );
+		info->procedures = procedures;
+		info->procedure_count = procedure_count;
+
+		item = cob_malloc (sizeof(struct cob_prof_module_list));
+		item->info = info;
+		item->next = prof_info_list;
+		prof_info_list = item;
+		return info;
+	}
+	return NULL;
+}
+
+static void
+cob_prof_realloc_arrays (void)
+{
+	int new_size = max_prof_depth * 2 + 16;
+
+	if (new_size > cobsetptr->cob_prof_max_depth)
+		new_size = cobsetptr->cob_prof_max_depth;
+
+	if (max_prof_depth >= new_size){
+		int i;
+		cob_runtime_warning (_("[cob_prof] Profiling overflow at %d calls, aborting profiling."), current_idx);
+		cob_runtime_warning (_("  Last 10 calls on stack:"));
+		for (i = 0; i < cob_min_int(10, current_idx); i++){
+			struct cob_prof_module *info = called_runtimes[current_idx-1-i];
+			int proc_idx = called_procedures[current_idx-1-i];
+			struct cob_prof_procedure *proc = info->procedures + proc_idx;
+			cob_runtime_warning (_("  * %s at %s:%d"), proc->text,
+					     proc->file, proc->line);
+		}
+		is_active = 0;
+		return;
+	}
+
+	if (max_prof_depth){
+		start_times = cob_realloc (
+			start_times,
+			max_prof_depth * sizeof(cob_ns_time),
+			new_size * sizeof(cob_ns_time)
+			);
+		called_procedures = cob_realloc (
+			called_procedures,
+			max_prof_depth * sizeof(int),
+			new_size * sizeof(int)
+			);
+		called_runtimes = cob_realloc (
+			called_runtimes,
+			max_prof_depth * sizeof(struct cob_prof_module*),
+			new_size * sizeof(struct cob_prof_module*)
+			);
+
+	} else {
+		start_times = cob_malloc (new_size * sizeof(cob_ns_time));
+		called_procedures = cob_malloc (new_size * sizeof(int));
+		called_runtimes = cob_malloc (new_size * sizeof(struct cob_prof_module*));
+	}
+	max_prof_depth = new_size;
+}
+
+void
+cob_prof_enter_procedure (struct cob_prof_module *info, int proc_idx)
+{
+	cob_ns_time t;
+
+	if (!is_active) return;
+
+	t = get_ns_time ();
+
+	current_idx++;
+	if (current_idx >= max_prof_depth) {
+		cob_prof_realloc_arrays();
+		if (!is_active) return;
+	}
+
+	called_procedures[current_idx] = proc_idx;
+	called_runtimes[current_idx] = info;
+	start_times[current_idx] = t;
+
+	info->procedure_recursions[proc_idx] ++;
+	info->called_count[proc_idx] ++;
+}
+
+void
+cob_prof_exit_procedure (struct cob_prof_module *info, int proc_idx)
+{
+	/* Exit all the sections/paragraphs */
+	cob_ns_time t;
+
+	if (!is_active) return;
+
+	t = get_ns_time ();
+
+	while (current_idx >= 0) {
+		int curr_proc = called_procedures[current_idx];
+		struct cob_prof_module *curr_info = called_runtimes[current_idx];
+
+		curr_info->procedure_recursions[curr_proc]--;
+		if (curr_info->procedure_recursions[curr_proc]==0){
+			curr_info->total_times[curr_proc] += t - start_times[current_idx];
+		}
+		current_idx--;
+		if (curr_proc == proc_idx && curr_info == info) {
+			return;
+		}
+	}
+}
+
+void
+cob_prof_enter_section (struct cob_prof_module *info, int proc_idx)
+{
+	if (!is_active) return;
+	/* We do not measure time on section enter/exit, we use the cumulative time
+	   of all paragraphs of the section */
+	info->called_count[proc_idx] ++;
+}
+
+void
+cob_prof_use_paragraph_entry (struct cob_prof_module *info,
+			      int paragraph_idx, int entry_idx){
+	if (!is_active) return;
+	info->called_count[entry_idx] ++;
+	cob_prof_enter_procedure (info, paragraph_idx);
+}
+
+void
+cob_prof_exit_section (struct cob_prof_module *info, int proc_idx)
+{
+	/* For now, nothing to do */
+}
+
+void
+cob_prof_goto (struct cob_prof_module *info)
+{
+	int curr_proc;
+	struct cob_prof_module *curr_info;
+
+	if (!is_active) return;
+
+	curr_proc = called_procedures[current_idx];
+	curr_info = called_runtimes[current_idx];
+
+	if (curr_info->procedures[curr_proc].kind == COB_PROF_PROCEDURE_PARAGRAPH){
+		cob_prof_exit_procedure (curr_info, curr_proc);
+	}
+}
+
+static void
+print_monotonic_time (FILE *file, cob_ns_time t) {
+
+	cob_ns_time nanoseconds = t ;
+	cob_ns_time milliseconds = nanoseconds / 1000000;
+	unsigned int seconds = milliseconds / 1000;
+	milliseconds = milliseconds - 1000 * seconds;
+
+	if (seconds > 1000) {
+		fprintf (file, "%d s", seconds);
+	} else {
+		fprintf (file, "%d.%03Ld s", seconds, milliseconds);
+	}
+}
+
+/* Default format is: "%m,%s,%p,%e,%w,%k,%t,%h,%n" (in common.c) */
+static void
+cob_prof_print_line (
+	FILE *file,
+	struct cob_prof_module *info,
+	int proc_idx)
+{
+	int i;
+	const char *module = NULL;
+	const char *section = NULL;
+	const char *paragraph = NULL;
+	const char *entry = NULL;
+	const char *kind = NULL;
+	const char *source_file;
+	int         line;
+	int         ncalls;
+	cob_ns_time time = 0;
+	struct cob_prof_procedure *proc;
+
+	if (info){
+		time = info->total_times[proc_idx];
+		ncalls = info->called_count[proc_idx];
+		proc = info->procedures + proc_idx;
+
+		source_file = proc->file;
+		line = proc->line;
+		switch (proc->kind){
+
+		case COB_PROF_PROCEDURE_MODULE:
+			module = proc->text;
+			section = "";
+			paragraph = "";
+			entry = "";
+			kind = "PROGRAM";
+			break;
+
+		case COB_PROF_PROCEDURE_SECTION:
+			module = info->procedures[0].text;
+			section = proc->text;
+			paragraph = "";
+			entry = "";
+			kind = "SECTION";
+			break;
+
+		case COB_PROF_PROCEDURE_PARAGRAPH:
+			module = info->procedures[0].text;
+			section = info->procedures[proc->section].text;
+			paragraph = proc->text;
+			entry = "";
+			kind = "PARAGRAPH";
+			break;
+
+		case COB_PROF_PROCEDURE_ENTRY:
+			module = info->procedures[0].text;
+			section = info->procedures[
+				info->procedures[proc->section].section].text;
+			paragraph = info->procedures[proc->section].text;
+			entry = proc->text;
+			kind = "ENTRY";
+			break;
+		case COB_PROF_PROCEDURE_CALL:
+			module = info->procedures[0].text;
+			section = info->procedures[
+				info->procedures[proc->section].section].text;
+			paragraph = info->procedures[proc->section].text;
+			entry = proc->text;
+			kind = "CALL";
+			break;
+		}
+	} else {
+		module = "program-id";
+		section = "section";
+		paragraph = "paragraph";
+		entry = "entry";
+		kind = "kind";
+		source_file = "file";
+		ncalls = 0;
+	}
+
+	for (i = 0; cobsetptr->cob_prof_format[i] != 0; i++) {
+		if (cobsetptr->cob_prof_format[i] == '%') {
+			i++;
+			switch (cobsetptr->cob_prof_format[i]) {
+			case 'M':
+			case 'm':
+				fputs (module, file);
+				break;
+			case 'S':
+			case 's':
+				fputs (section, file);
+				break;
+			case 'P':
+			case 'p':
+				fputs (paragraph, file);
+				break;
+			case 'E':
+			case 'e':
+				fputs (entry, file);
+				break;
+			case 'F':
+			case 'f':
+				fputs (source_file, file);
+				break;
+			case 'L':
+			case 'l':
+				if (info){
+					fprintf (file, "%d", line);
+				} else {
+					fputs ("line", file);
+				}
+				break;
+			case 'I':
+			case 'i':
+				if (info){
+					if (is_test){
+						fprintf (file, "%d", 42);
+					} else {
+						fprintf (file, "%d", cob_sys_getpid());
+					}
+				} else {
+					fputs ("pid", file);
+				}
+				break;
+			case 'W':
+			case 'w':
+				if (info){
+					fprintf (file, "%s:%d", source_file, line);
+				} else {
+					fputs ("location", file);
+				}
+				break;
+			case 'K':
+			case 'k':
+				fputs (kind, file);
+				break;
+			case 'T':
+			case 't':
+				if (info){
+					fprintf (file, "%lld", time);
+				} else {
+					fputs ("time-ns", file);
+				}
+				break;
+			case 'H':
+			case 'h':
+				if (info){
+					print_monotonic_time (file, time);
+				} else {
+					fputs ("time", file);
+				}
+				break;
+			case 'N':
+			case 'n':
+				if (info){
+					fprintf (file, "%d", ncalls);
+				} else {
+					fputs ("ncalls", file);
+				}
+				break;
+			default:
+				fputc ('%', file);
+				fputc (cobsetptr->cob_prof_format[i], file);
+			}
+		} else {
+			fputc (cobsetptr->cob_prof_format[i], file);
+		}
+	}
+	fputc ('\n', file);
+	fflush (file);
+}
+
+
+void
+cob_prof_end ()
+{
+	FILE *file;
+	struct cob_prof_module_list *l;
+
+	prof_init_static ();
+
+	if (!cobsetptr || !is_active || !prof_info_list) return;
+
+	while (current_idx >= 0) {
+		cob_prof_exit_procedure (called_runtimes[current_idx],
+					 called_procedures[current_idx]);
+	}
+
+	file = cob_open_logfile (cobsetptr->cob_prof_filename);
+
+	if (!!file) {
+
+		/* First pass: accumulate section times */
+		for (l = prof_info_list ; l != NULL; l=l->next){
+
+			struct cob_prof_module *info = l->info;
+			int i;
+
+			for (i = 0; i < info->procedure_count; i++) {
+				if (info->procedures[i].kind == COB_PROF_PROCEDURE_PARAGRAPH){
+					info->total_times[info->procedures[i].section]
+						+= info->total_times[i];
+				}
+			}
+		}
+
+		cob_prof_print_line (file, NULL, 0);
+		for (l = prof_info_list ; l != NULL; l=l->next){
+
+			struct cob_prof_module *info = l->info;
+			int i;
+
+			for (i = 0; i < info->procedure_count; i++) {
+				cob_prof_print_line (file, info, i);
+			}
+		}
+		fclose (file);
+		fprintf(stderr, "File %s generated\n", cobsetptr->cob_prof_filename);
+	} else {
+		cob_runtime_warning (_("error '%s' opening COB_PROF_FILE '%s'"),
+				     cob_get_strerror (), cobsetptr->cob_prof_filename);
+	}
+	current_idx = -1;
+	is_active = 0;
+}

--- a/libcob/profiling.c
+++ b/libcob/profiling.c
@@ -63,8 +63,6 @@ static int current_idx = -1;
 
 /* Whether profiling is active or not. */
 static int is_active = 0;
-/* Whether we are in testsuite mode */
-static int is_test = 0;
 
 /* Which clock to use for clock_gettime (if available) */
 #ifdef HAVE_CLOCK_GETTIME
@@ -155,9 +153,6 @@ prof_init_static ()
 	if (!init_done && cobsetptr) {
 		prof_setup_clock ();
 		is_active = cobsetptr->cob_prof_enable;
-		if (is_active) {
-			is_test = !!getenv ("COB_IS_RUNNING_IN_TESTMODE");
-		}
 		init_done = 1;
 	}
 }
@@ -460,7 +455,7 @@ cob_prof_print_line (
 			case 'i':
 				if (info){
 					if (is_test){
-						fprintf (file, "%d", 42);
+						fprintf (file, "%d", 123456);
 					} else {
 						fprintf (file, "%d", cob_sys_getpid());
 					}

--- a/tests/testsuite.src/run_misc.at
+++ b/tests/testsuite.src/run_misc.at
@@ -14631,3 +14631,410 @@ AT_DATA([prog.cob], [
 AT_CHECK([$COMPILE_MODULE prog.cob], [0], [], [])
 AT_CHECK([$COBCRUN prog], [0], [OKOKOKOKOK], [])
 AT_CLEANUP
+
+
+AT_SETUP([run profiling])
+AT_KEYWORDS([cobc profiling])
+
+AT_DATA([prog.cob], [
+        IDENTIFICATION DIVISION.
+        PROGRAM-ID.    prog.
+        PROCEDURE      DIVISION.
+        1ST SECTION.
+        PARA-0001.
+            PERFORM PARA-0003.
+        PARA-0002.
+            CONTINUE.
+        PARA-0003.
+            GO TO 2ND.
+        PARA-0004.
+            CONTINUE.
+        2ND SECTION.
+        PARA-0005.
+            PERFORM PARA-0006.
+        PARA-0006.
+            CONTINUE.
+        PARA-0007.
+            STOP RUN.
+])
+AT_CAPTURE_FILE([prof-prog.csv])
+
+AT_CHECK([$COMPILE prog.cob], [0], [],
+[prog.cob: in section '1ST':
+prog.cob: in paragraph 'PARA-0003':
+prog.cob:11: warning: GO TO SECTION '2ND'
+])
+
+AT_CHECK([COB_PROF_ENABLE=1 COB_PROF_FILE='prof-$b.csv' $COBCRUN_DIRECT ./prog], [0], [], [])
+
+AT_CHECK([$COMPILE -fprof prog.cob], [0], [],
+[prog.cob: in section '1ST':
+prog.cob: in paragraph 'PARA-0003':
+prog.cob:11: warning: GO TO SECTION '2ND'
+])
+
+AT_CHECK([COB_PROF_ENABLE=0 COB_PROF_FILE='prof-$b.csv' $COBCRUN_DIRECT ./prog], [0], [], [])
+
+AT_CHECK([COB_PROF_ENABLE=1 COB_PROF_FILE='prof-$b.csv' COB_PROF_FORMAT=%i,%m,%s,%p,%e,%f,%l,%w,%k,%t,%h,%n,%x $COBCRUN_DIRECT ./prog], [0], [],
+[File prof-prog.csv generated
+])
+
+# note: The time here is actually the number of times the procedure has
+# been run, to avoid any indeterminism in the running time of the
+# procedure.
+
+AT_CHECK([cat prof-prog.csv], [0],
+[pid,program-id,section,paragraph,entry,file,line,location,kind,time-ns,time,ncalls,%x
+42,prog,,,,prog.cob,4,prog.cob:4,PROGRAM,13000000,0.013 s,1,%x
+42,prog,1ST,,,prog.cob,5,prog.cob:5,SECTION,12000000,0.012 s,1,%x
+42,prog,1ST,PARA-0001,,prog.cob,6,prog.cob:6,PARAGRAPH,11000000,0.011 s,1,%x
+42,prog,1ST,PARA-0002,,prog.cob,8,prog.cob:8,PARAGRAPH,0,0.000 s,0,%x
+42,prog,1ST,PARA-0003,,prog.cob,10,prog.cob:10,PARAGRAPH,1000000,0.001 s,1,%x
+42,prog,1ST,PARA-0004,,prog.cob,12,prog.cob:12,PARAGRAPH,0,0.000 s,0,%x
+42,prog,2ND,,,prog.cob,14,prog.cob:14,SECTION,6000000,0.006 s,1,%x
+42,prog,2ND,PARA-0005,,prog.cob,15,prog.cob:15,PARAGRAPH,3000000,0.003 s,1,%x
+42,prog,2ND,PARA-0006,,prog.cob,17,prog.cob:17,PARAGRAPH,2000000,0.002 s,2,%x
+42,prog,2ND,PARA-0007,,prog.cob,19,prog.cob:19,PARAGRAPH,1000000,0.001 s,1,%x
+])
+
+AT_CLEANUP
+
+
+AT_SETUP([run profiling with no paragraph/section names])
+AT_KEYWORDS([cobc profiling])
+
+AT_DATA([prog.cob], [
+        IDENTIFICATION DIVISION.
+        PROGRAM-ID.    prog.
+        PROCEDURE      DIVISION.
+          DISPLAY "HELLO".
+          DISPLAY "WORLD".
+])
+AT_CAPTURE_FILE([prof.csv])
+
+AT_CHECK([$COMPILE -fprof prog.cob])
+
+AT_CHECK([COB_PROF_ENABLE=1 COB_PROF_FILE=prof.csv $COBCRUN_DIRECT ./prog], [0], [HELLO
+WORLD
+],
+[File prof.csv generated
+])
+
+AT_CHECK([cat prof.csv], [0],
+[program-id,section,paragraph,entry,location,kind,time-ns,time,ncalls
+prog,,,,prog.cob:4,PROGRAM,3000000,0.003 s,1
+prog,MAIN SECTION,,,prog.cob:5,SECTION,1000000,0.001 s,1
+prog,MAIN SECTION,MAIN PARAGRAPH,,prog.cob:5,PARAGRAPH,1000000,0.001 s,1
+])
+
+AT_CLEANUP
+
+
+AT_SETUP([run profiling with no section names])
+AT_KEYWORDS([cobc profiling])
+
+AT_DATA([prog.cob], [
+        IDENTIFICATION DIVISION.
+        PROGRAM-ID.    prog.
+        PROCEDURE      DIVISION.
+        1ST.
+          DISPLAY "HELLO".
+        2ND.
+          DISPLAY "WORLD".
+])
+AT_CAPTURE_FILE([prof.csv])
+
+AT_CHECK([$COMPILE -fprof prog.cob])
+
+AT_CHECK([COB_PROF_ENABLE=1 COB_PROF_FILE=prof.csv $COBCRUN_DIRECT ./prog], [0], [HELLO
+WORLD
+],
+[File prof.csv generated
+])
+
+AT_CHECK([cat prof.csv], [0],
+[program-id,section,paragraph,entry,location,kind,time-ns,time,ncalls
+prog,,,,prog.cob:4,PROGRAM,5000000,0.005 s,1
+prog,MAIN SECTION,,,prog.cob:5,SECTION,2000000,0.002 s,1
+prog,MAIN SECTION,1ST,,prog.cob:5,PARAGRAPH,1000000,0.001 s,1
+prog,MAIN SECTION,2ND,,prog.cob:7,PARAGRAPH,1000000,0.001 s,1
+])
+
+AT_CLEANUP
+
+
+AT_SETUP([profiling depth overflow])
+AT_KEYWORDS([cobc])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. prog.
+       PROCEDURE DIVISION.
+       MAIN.
+          PERFORM PARA.
+          STOP RUN.
+       PARA.
+          DISPLAY "OK" WITH NO ADVANCING.
+])
+
+AT_CHECK([$COMPILE -fprof prog.cob])
+
+AT_CHECK([COB_PROF_MAX_DEPTH=2 COB_PROF_ENABLE=1 COB_PROF_FILE=prof.csv $COBCRUN_DIRECT ./prog], [0], [OK],
+[libcob: prog.cob:8: warning: [[cob_prof]] Profiling overflow at 2 calls, aborting profiling.
+libcob: prog.cob:8: warning:   Last 10 calls on stack:
+libcob: prog.cob:8: warning:   * MAIN at prog.cob:5
+libcob: prog.cob:8: warning:   * prog at prog.cob:4
+])
+
+AT_CLEANUP
+
+
+AT_SETUP([run profiling with recursion, entries and CALL])
+AT_KEYWORDS([cobc])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. prog RECURSIVE.
+       PROCEDURE DIVISION.
+          DISPLAY "HELLO WORLD".
+          CALL "entry".
+          GOBACK.
+          ENTRY "entry".
+          CALL "inside-program".
+       PROGRAM-ID. inside-program.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01 COUNTER PIC 9(4).
+       PROCEDURE DIVISION.
+       MAIN SECTION.
+           MOVE 100 TO COUNTER.
+       INSIDE SECTION.
+           PERFORM ITER.
+           EXIT SECTION.
+       ITER.
+           IF COUNTER = 0
+             DISPLAY "end iter"
+             EXIT PARAGRAPH.
+           SUBTRACT 1 FROM COUNTER.
+           PERFORM INSIDE.
+       END PROGRAM inside-program.
+       END PROGRAM prog.
+])
+AT_CAPTURE_FILE([prof.csv])
+
+AT_CHECK([$COMPILE -fprof prog.cob])
+
+AT_CHECK([COB_PROF_ENABLE=1 COB_PROF_FILE=prof.csv $COBCRUN_DIRECT ./prog], [0],
+[HELLO WORLD
+end iter
+],
+[File prof.csv generated
+])
+
+AT_CHECK([cat prof.csv], [0],
+[program-id,section,paragraph,entry,location,kind,time-ns,time,ncalls
+inside-program,,,,prog.cob:14,PROGRAM,407000000,0.407 s,1
+inside-program,MAIN,,,prog.cob:15,SECTION,1000000,0.001 s,1
+inside-program,MAIN,MAIN PARAGRAPH,,prog.cob:15,PARAGRAPH,1000000,0.001 s,1
+inside-program,INSIDE,,,prog.cob:17,SECTION,804000000,0.804 s,101
+inside-program,INSIDE,MAIN PARAGRAPH,,prog.cob:17,PARAGRAPH,403000000,0.403 s,101
+inside-program,INSIDE,ITER,,prog.cob:20,PARAGRAPH,401000000,0.401 s,101
+prog,,,,prog.cob:4,PROGRAM,419000000,0.419 s,2
+prog,MAIN SECTION,,,prog.cob:5,SECTION,417000000,0.417 s,1
+prog,MAIN SECTION,MAIN PARAGRAPH,,prog.cob:5,PARAGRAPH,417000000,0.417 s,2
+prog,MAIN SECTION,MAIN PARAGRAPH,entry,prog.cob:6,CALL,415000000,0.415 s,1
+prog,MAIN SECTION,MAIN PARAGRAPH,entry,prog.cob:8,ENTRY,0,0.000 s,1
+prog,MAIN SECTION,MAIN PARAGRAPH,inside-program,prog.cob:9,CALL,409000000,0.409 s,1
+])
+
+AT_CLEANUP
+
+
+AT_SETUP([profiling two modules with CALL])
+AT_KEYWORDS([cobc])
+
+AT_DATA([prog1.cob], [
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. prog1.
+       DATA DIVISION.
+       LOCAL-STORAGE SECTION.
+       01 COUNTER PIC 9(4).
+       01 PARAM PIC 9.
+       01 CALL-NAME PIC X(10).
+       PROCEDURE DIVISION.
+          MOVE 'prog2' TO CALL-NAME.
+          PERFORM CALL-PROG2
+             VARYING COUNTER FROM 0 BY 1
+             UNTIL COUNTER = 300.
+          GOBACK.
+       CALL-PROG2.
+            MOVE 1 TO PARAM.
+            CALL "prog2" USING PARAM.
+            MOVE 2 TO PARAM.
+            CALL CALL-NAME USING PARAM.
+       END PROGRAM prog1.
+])
+AT_DATA([prog2.cob], [
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. prog2.
+       DATA DIVISION.
+       LINKAGE SECTION.
+       01 PARAM PIC 9.
+       PROCEDURE DIVISION USING PARAM.
+       DISPLAYER SECTION.
+          IF PARAM = 1
+             DISPLAY "X" NO ADVANCING
+	  ELSE
+	     PERFORM OTHER-DISPLAY.
+	  GOBACK.
+       OTHER-DISPLAY SECTION.
+          DISPLAY "Y" NO ADVANCING.
+       END PROGRAM prog2.
+])
+AT_CAPTURE_FILE([prof.csv])
+
+AT_CHECK([$COMPILE -fprof prog1.cob])
+
+AT_CHECK([$COMPILE_MODULE prog2.cob])
+
+AT_CHECK([COB_PROF_ENABLE=1 COB_PROF_FILE=prof.csv $COBCRUN_DIRECT ./prog1], [0],
+[XYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXY],
+[File prof.csv generated
+])
+
+AT_CHECK([cat prof.csv], [0],
+[program-id,section,paragraph,entry,location,kind,time-ns,time,ncalls
+prog1,,,,prog1.cob:9,PROGRAM,1803000000,1.803 s,1
+prog1,MAIN SECTION,,,prog1.cob:10,SECTION,3301000000,3.301 s,1
+prog1,MAIN SECTION,MAIN PARAGRAPH,,prog1.cob:10,PARAGRAPH,1801000000,1.801 s,1
+prog1,MAIN SECTION,CALL-PROG2,,prog1.cob:15,PARAGRAPH,1500000000,1.500 s,300
+prog1,MAIN SECTION,CALL-PROG2,prog2,prog1.cob:17,CALL,300000000,0.300 s,300
+prog1,MAIN SECTION,CALL-PROG2,(dynamic),prog1.cob:19,CALL,300000000,0.300 s,300
+])
+
+AT_CHECK([$COMPILE_MODULE -fprof prog2.cob])
+
+AT_CHECK([COB_PROF_ENABLE=1 COB_PROF_FILE=prof.csv $COBCRUN_DIRECT ./prog1], [0],
+[XYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXYXY],
+[File prof.csv generated
+])
+
+AT_CHECK([cat prof.csv], [0],
+[program-id,section,paragraph,entry,location,kind,time-ns,time,ncalls
+prog2,,,,prog2.cob:7,PROGRAM,2400000000,2.400 s,600
+prog2,DISPLAYER,,,prog2.cob:8,SECTION,1200000000,1.200 s,600
+prog2,DISPLAYER,MAIN PARAGRAPH,,prog2.cob:8,PARAGRAPH,1200000000,1.200 s,600
+prog2,OTHER-DISPLAY,,,prog2.cob:14,SECTION,300000000,0.300 s,300
+prog2,OTHER-DISPLAY,MAIN PARAGRAPH,,prog2.cob:14,PARAGRAPH,300000000,0.300 s,300
+prog1,,,,prog1.cob:9,PROGRAM,4803000000,4.803 s,1
+prog1,MAIN SECTION,,,prog1.cob:10,SECTION,9301000000,9.301 s,1
+prog1,MAIN SECTION,MAIN PARAGRAPH,,prog1.cob:10,PARAGRAPH,4801000000,4.801 s,1
+prog1,MAIN SECTION,CALL-PROG2,,prog1.cob:15,PARAGRAPH,4500000000,4.500 s,300
+prog1,MAIN SECTION,CALL-PROG2,prog2,prog1.cob:17,CALL,1500000000,1.500 s,300
+prog1,MAIN SECTION,CALL-PROG2,(dynamic),prog1.cob:19,CALL,2100000000,2.100 s,300
+])
+
+AT_CLEANUP
+
+
+AT_SETUP([profiling multiple programs])
+AT_KEYWORDS([cobc])
+
+AT_DATA([prog1.cob], [
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. prog1.
+       DATA DIVISION.
+       PROCEDURE DIVISION.
+          CALL "SYSTEM" USING "./prog2"
+          GOBACK.
+])
+AT_DATA([prog2.cob], [
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. prog2.
+       PROCEDURE DIVISION.
+       MAIN.
+          SET ENVIRONMENT "COB_PROF_FILE" TO "prof2.csv"
+	  PERFORM PARA 5 TIMES.
+	  GOBACK.
+       PARA.
+          CONTINUE.
+])
+AT_CAPTURE_FILE([prof1.csv])
+AT_CAPTURE_FILE([prof2.csv])
+
+AT_CHECK([$COMPILE_MODULE -fprof prog1.cob])
+
+AT_CHECK([$COMPILE -fprof prog2.cob])
+
+AT_CHECK([COB_PROF_ENABLE=1 COB_PROF_FILE=prof1.csv $COBCRUN ./prog1], [0], [],
+[File prof2.csv generated
+File prof1.csv generated
+])
+
+AT_CHECK([cat prof1.csv], [0],
+[program-id,section,paragraph,entry,location,kind,time-ns,time,ncalls
+prog1,,,,prog1.cob:5,PROGRAM,5000000,0.005 s,1
+prog1,MAIN SECTION,,,prog1.cob:6,SECTION,3000000,0.003 s,1
+prog1,MAIN SECTION,MAIN PARAGRAPH,,prog1.cob:6,PARAGRAPH,3000000,0.003 s,1
+prog1,MAIN SECTION,MAIN PARAGRAPH,SYSTEM,prog1.cob:6,CALL,1000000,0.001 s,1
+])
+
+AT_CHECK([cat prof2.csv], [0],
+[program-id,section,paragraph,entry,location,kind,time-ns,time,ncalls
+prog2,,,,prog2.cob:4,PROGRAM,13000000,0.013 s,1
+prog2,MAIN SECTION,,,prog2.cob:5,SECTION,16000000,0.016 s,1
+prog2,MAIN SECTION,MAIN,,prog2.cob:5,PARAGRAPH,11000000,0.011 s,1
+prog2,MAIN SECTION,PARA,,prog2.cob:9,PARAGRAPH,5000000,0.005 s,5
+])
+
+AT_CLEANUP
+
+
+AT_SETUP([profiling out of test mode])
+AT_KEYWORDS([cobc])
+
+AT_DATA([caller.c], [[
+#include <stdlib.h>
+#include <libcob.h>
+
+#ifndef NULL
+#define NULL (void*)0
+#endif
+
+int
+main (int argc, char **argv)
+{
+   int i;
+
+   unsetenv("COB_IS_RUNNING_IN_TESTMODE");
+
+   cob_init (argc, argv);
+
+   for (i = 0; i < 300; ++i) {
+      cob_call ("callee", 0, NULL);
+   }
+
+   cob_tidy ();
+
+   return 0;
+}
+]])
+
+AT_DATA([callee.cob], [
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. callee.
+       PROCEDURE DIVISION.
+       MAIN.
+	  PERFORM PARA 5 TIMES.
+	  GOBACK.
+       PARA.
+          CONTINUE.
+])
+AT_CAPTURE_FILE([prof.csv])
+
+AT_CHECK([$COMPILE caller.c])
+AT_CHECK([$COMPILE_MODULE -fprof callee.cob])
+AT_CHECK([COB_PROF_ENABLE=1 COB_PROF_FILE=prof.csv $COBCRUN_DIRECT ./caller], [0], [], [File prof.csv generated
+])
+
+AT_CLEANUP

--- a/tests/testsuite.src/run_misc.at
+++ b/tests/testsuite.src/run_misc.at
@@ -14675,26 +14675,30 @@ prog.cob:11: warning: GO TO SECTION '2ND'
 
 AT_CHECK([COB_PROF_ENABLE=0 COB_PROF_FILE='prof-$b.csv' $COBCRUN_DIRECT ./prog], [0], [], [])
 
-AT_CHECK([COB_PROF_ENABLE=1 COB_PROF_FILE='prof-$b.csv' COB_PROF_FORMAT=%i,%m,%s,%p,%e,%f,%l,%w,%k,%t,%h,%n,%x $COBCRUN_DIRECT ./prog], [0], [],
-[File prof-prog.csv generated
+# Specific test for $f, which is an absolute file name
+AT_CHECK([COB_PROF_ENABLE=1 COB_PROF_FILE='$f-prof.csv' $COBCRUN_DIRECT ./prog], [0], [], [ignore])
+AT_CHECK([ls prog-prof.csv], [0], [ignore], [])
+
+AT_CHECK([COB_PROF_ENABLE=1 COB_PROF_FILE='prof-$$-$b.csv' COB_PROF_FORMAT=%i,%m,%s,%p,%e,%f,%l,%w,%k,%t,%h,%n,%x $COBCRUN_DIRECT ./prog], [0], [],
+[File prof-123456-prog.csv generated
 ])
 
 # note: The time here is actually the number of times the procedure has
 # been run, to avoid any indeterminism in the running time of the
 # procedure.
 
-AT_CHECK([cat prof-prog.csv], [0],
+AT_CHECK([cat prof-123456-prog.csv], [0],
 [pid,program-id,section,paragraph,entry,file,line,location,kind,time-ns,time,ncalls,%x
-42,prog,,,,prog.cob,4,prog.cob:4,PROGRAM,13000000,0.013 s,1,%x
-42,prog,1ST,,,prog.cob,5,prog.cob:5,SECTION,12000000,0.012 s,1,%x
-42,prog,1ST,PARA-0001,,prog.cob,6,prog.cob:6,PARAGRAPH,11000000,0.011 s,1,%x
-42,prog,1ST,PARA-0002,,prog.cob,8,prog.cob:8,PARAGRAPH,0,0.000 s,0,%x
-42,prog,1ST,PARA-0003,,prog.cob,10,prog.cob:10,PARAGRAPH,1000000,0.001 s,1,%x
-42,prog,1ST,PARA-0004,,prog.cob,12,prog.cob:12,PARAGRAPH,0,0.000 s,0,%x
-42,prog,2ND,,,prog.cob,14,prog.cob:14,SECTION,6000000,0.006 s,1,%x
-42,prog,2ND,PARA-0005,,prog.cob,15,prog.cob:15,PARAGRAPH,3000000,0.003 s,1,%x
-42,prog,2ND,PARA-0006,,prog.cob,17,prog.cob:17,PARAGRAPH,2000000,0.002 s,2,%x
-42,prog,2ND,PARA-0007,,prog.cob,19,prog.cob:19,PARAGRAPH,1000000,0.001 s,1,%x
+123456,prog,,,,prog.cob,4,prog.cob:4,PROGRAM,13000000,0.013 s,1,%x
+123456,prog,1ST,,,prog.cob,5,prog.cob:5,SECTION,12000000,0.012 s,1,%x
+123456,prog,1ST,PARA-0001,,prog.cob,6,prog.cob:6,PARAGRAPH,11000000,0.011 s,1,%x
+123456,prog,1ST,PARA-0002,,prog.cob,8,prog.cob:8,PARAGRAPH,0,0.000 s,0,%x
+123456,prog,1ST,PARA-0003,,prog.cob,10,prog.cob:10,PARAGRAPH,1000000,0.001 s,1,%x
+123456,prog,1ST,PARA-0004,,prog.cob,12,prog.cob:12,PARAGRAPH,0,0.000 s,0,%x
+123456,prog,2ND,,,prog.cob,14,prog.cob:14,SECTION,6000000,0.006 s,1,%x
+123456,prog,2ND,PARA-0005,,prog.cob,15,prog.cob:15,PARAGRAPH,3000000,0.003 s,1,%x
+123456,prog,2ND,PARA-0006,,prog.cob,17,prog.cob:17,PARAGRAPH,2000000,0.002 s,2,%x
+123456,prog,2ND,PARA-0007,,prog.cob,19,prog.cob:19,PARAGRAPH,1000000,0.001 s,1,%x
 ])
 
 AT_CLEANUP


### PR DESCRIPTION
This PR would add a simple profiling tool in GnuCOBOL which computes the time spent in each section and each paragraph of the COBOL program.