### PR TITLE
Fixes to have texi macros on a single line

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,4 +1,10 @@
 
+2023-10-02  Fabrice Le Fessant <fabrice.le_fessant@ocamlpro.com>
+
+	* gnucobol.texi: fix some macro applications to be on a single
+	  line, because the converter to rst for Sphinx format expects
+	  them like that
+
 2023-07-10  Simon Sobisch <simonsobisch@gnu.org>
 
 	* gnucobol.texi: updated "Build target" (change of -P / -E),

--- a/doc/fdl.texi
+++ b/doc/fdl.texi
@@ -475,8 +475,8 @@ license notices just after the title page:
   under the terms of the GNU Free Documentation License, Version 1.3
   or any later version published by the Free Software Foundation;
   with no Invariant Sections, no Front-Cover Texts, and no Back-Cover
-  Texts.  A copy of the license is included in the section entitled ``GNU
-  Free Documentation License''.
+  Texts.  A copy of the license is included in the section entitled
+  ``GNU Free Documentation License''.
 @end group
 @end smallexample
 

--- a/doc/gnucobol.texi
+++ b/doc/gnucobol.texi
@@ -272,8 +272,7 @@ This chapter describes how to compile COBOL programs using GnuCOBOL.
 @section Compiler options
 
 The compiler @code{cobc} accepts the options described in this section.
-The compiler arguments follow the general syntax @code{cobc @var{options}
-@var{file} [@var{file} @dots{}]}.
+The compiler arguments follow the general syntax @code{cobc @var{options} @var{file} [@var{file} @dots{}]}.
 A complete list of options can be displayed by using the option @option{--help}.
 
 @menu
@@ -432,8 +431,7 @@ ICOBOL xCard and Free-form, ACUCOBOL-GT Terminal, and COBOLX source
 formats.  By default, the compiler tries to autodetect the format using
 the indicator on the first line, using the fixed format for correct
 indicators and the free format for incorrect ones.  This can be
-overridden either by the @code{>>SOURCE [FORMAT] [IS]
-@{FIXED|FREE|COBOL85|VARIABLE|XOPEN|XCARD|CRT|TERMINAL|COBOLX|AUTO@}}
+overridden either by the @code{>>SOURCE [FORMAT] [IS] @{FIXED|FREE|COBOL85|VARIABLE|XOPEN|XCARD|CRT|TERMINAL|COBOLX|AUTO@}}
 directive, or by one of the following options:
 
 @table @code
@@ -445,8 +443,7 @@ in GnuCOBOL).
 @item -fixed, -fformat=fixed
 Fixed format.  Source code is divided into: columns 1-6, the sequence
 number area; column 7, the indicator area; columns 8-72, the program-text
-area; and columns 72-80 as the reference area.@footnote{Historically, fixed
-format was based on 80-character punch cards.}
+area; and columns 72-80 as the reference area.@footnote{Historically, fixed format was based on 80-character punch cards.}
 
 @item -fformat=cobol85
 Fixed format with enforcements on the use of Area A.
@@ -1082,8 +1079,7 @@ Subprograms are compiled with the option @option{-m}:
 @example
 $ cobc -m subr.cob
 @end example
-This creates a module file @file{subr.so}@footnote{The extension
-used depends on your operating system.}.
+This creates a module file @file{subr.so}@footnote{The extension used depends on your operating system.}.
 
 Before running the main program, install the module files in your
 library directory:


### PR DESCRIPTION
The converter to rst syntax for Sphinx expects macros to be on a single line.