### PR TITLE
New flag -fdiagnostics-absolute-path to display full paths within err…

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,25 @@
 NEWS - user visible changes				-*- outline -*-
 
+
+ GnuCOBOL 3.3     ASAP
+
+* New GnuCOBOL features:
+
+* Changes that potentially effect existing programs:
+
+* Changes that potentially effect recompilation of existing programs:
+
+* Changes to the COBOL compiler (cobc) options:
+
+** New option -fdiagnostics-absolute-paths to print the full path of
+   a file for diagnostics; this flag can be activated if your editor and
+   build system do not correctly work together to locate files from
+   diagnostic output
+
+* Important Bugfixes:
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
  GnuCOBOL 3.2     (20230728)
  GnuCOBOL 3.2rc1  (20230118)
  GnuCOBOL 3.2rc2  (20230210)

--- a/cobc/ChangeLog
+++ b/cobc/ChangeLog
@@ -1,11 +1,11 @@
 
 2023-10-02  Fabrice Le Fessant <fabrice.le_fessant@ocamlpro.com>
 
-	* error.c (print_error_prefix), flag.def: add new flag
+	* error.c (print_error_prefix), flag.def: new flag
 	  -fdiagnostics-absolute-paths to print the full path of
-	  a file in case of error. This flag can be activated if
+	  a file for diagnostics; this flag can be activated if
 	  your editor and build system do not correctly work
-	  together to locate files after errors within your project.
+	  together to locate files from diagnostic output
 
 2023-07-26  Simon Sobisch <simonsobisch@gnu.org>
 

--- a/cobc/ChangeLog
+++ b/cobc/ChangeLog
@@ -1,4 +1,12 @@
 
+2023-10-02  Fabrice Le Fessant <fabrice.le_fessant@ocamlpro.com>
+
+	* error.c (print_error_prefix), flag.def: add new flag
+	  -fdiagnostics-absolute-paths to print the full path of
+	  a file in case of error. This flag can be activated if
+	  your editor and build system do not correctly work
+	  together to locate files after errors within your project.
+
 2023-07-26  Simon Sobisch <simonsobisch@gnu.org>
 
 	* typeck.c (search_set_keys): improving SEARCH ALL syntax checks

--- a/cobc/cobc.c
+++ b/cobc/cobc.c
@@ -3565,6 +3565,8 @@ process_command_line (const int argc, char **argv)
 			/* -fdiagnostics-plain-output */
 			cb_diagnostics_show_caret = 0 ;
 			cb_diagnostics_show_line_numbers = 0;
+			/* in the future, may also disable urls,
+			   colors, text art, flow paths */
 			break;
 
 		case 'P':

--- a/cobc/error.c
+++ b/cobc/error.c
@@ -28,10 +28,19 @@
 #include <ctype.h>
 #include <errno.h>
 #include <stdarg.h>
+#ifdef HAVE_SYS_STAT_H
 #include <sys/stat.h>
+#endif
 
 #include "cobc.h"
 #include "tree.h"
+
+#ifdef	_WIN32
+#if !defined(__BORLANDC__) && !defined(__WATCOMC__) && !defined(__ORANGEC__)
+#include <direct.h> // _getcwd
+#define	getcwd		_getcwd
+#endif
+#endif
 
 enum cb_error_kind {
 	CB_KIND_ERROR,
@@ -70,11 +79,16 @@ print_error_prefix (const char *file, int line, const char *prefix)
 			absfile = cobc_malloc( dirlen + 1 + filelen + 1 );
 			cwd = getcwd (absfile, dirlen);
 			if (cwd != NULL ){
+#ifdef HAVE_SYS_STAT_H
 				struct stat st;
+#endif
 				dirlen = strlen (cwd);
 				absfile[dirlen] = '/';
 				memcpy (absfile+dirlen+1, file, filelen+1);
-				if (!stat(absfile,&st)){
+#ifdef HAVE_SYS_STAT_H
+				if (!stat (absfile,&st))
+#endif
+				{
 					file = absfile;
 				}
 			}

--- a/cobc/error.c
+++ b/cobc/error.c
@@ -60,11 +60,10 @@ print_error_prefix (const char *file, int line, const char *prefix)
 	if (file) {
 		char *absfile = NULL ;
 		if (cb_diagnostics_absolute_paths
-		    && strcmp (file, COB_DASH) != 0
-		    && file[0] != '/'
-		    && file[0] != '\\'
-		    && ( file[0] != 0 && file[1] != ':' )
-			){
+		 && strcmp (file, COB_DASH) != 0
+		 && file[0] != '/'
+		 && file[0] != '\\'
+		 && file[1] != ':'){
 			int filelen = strlen (file);
 			int dirlen = 256;
 			char *cwd ;

--- a/cobc/flag.def
+++ b/cobc/flag.def
@@ -254,3 +254,6 @@ CB_FLAG_ON (cb_diagnostics_show_caret, 1, "diagnostics-show-caret",
 
 CB_FLAG_ON (cb_diagnostics_show_line_numbers, 1, "diagnostics-show-line-numbers",
 	_("  -fno-diagnostics-show-line-numbers\tsuppress display of line numbers in diagnostics"))
+
+CB_FLAG (cb_diagnostics_absolute_paths, 1, "diagnostics-absolute-paths",
+	_("  -fdiagnostics-absolute-paths\tprint absolute paths in diagnostics"))

--- a/doc/gnucobol.texi
+++ b/doc/gnucobol.texi
@@ -281,6 +281,7 @@ A complete list of options can be displayed by using the option @option{--help}.
 * Build target::                Build target
 * Source format::               Source format
 * Warning options::             Warning options
+* Diagnostics options::         Diagnostics options
 * Configuration options::       Configuration options
 * Listing options::             Listing options
 * Debug switches::              Debug switches
@@ -649,6 +650,34 @@ Warn if statements are likely unreachable. This is @emph{not} set with @option{-
 
 @item -Wadditional
 Enable warnings that don't have an own warning flag.
+@end table
+
+@node Diagnostics options
+@subsection Diagnostics options
+
+The compiler provides some options to tune the way errors and warnings
+(diagnostics) are displayed to the user.
+
+@table @code
+
+@item -fdiagnostics-absolute-paths
+Print absolute paths in diagnostics. This option can be useful if your editor is not able
+to correctly locate relative paths in your project.
+
+@item -fdiagnostics-plain-output
+Make diagnostic output as plain as possible.
+
+@item -fno-diagnostics-show-option
+Suppress output of option that directly controls the diagnostic, on which
+warnings should be displayed.
+
+@item -fno-diagnostics-show-caret
+Do not display source context on warning/error diagnostic. By default, diagnostics
+contain an excerpt with two lines before and after the location.
+
+@item -fno-diagnostics-show-line-numbers
+Suppress display of line numbers in the source context in diagnostics
+
 @end table
 
 @node Configuration options

--- a/tests/testsuite.src/used_binaries.at
+++ b/tests/testsuite.src/used_binaries.at
@@ -922,9 +922,9 @@ AT_CLEANUP
 
 
 AT_SETUP([cobc diagnostics show caret])
-#AT_KEYWORDS([cobc diagnostics])
 
-AT_DATA([progprep.cob],[
+#AT_KEYWORDS([cobc diagnostics])
+AT_DATA([progprep.cob], [
        IDENTIFICATION   DIVISION.
        PROGRAM-ID.      prog.
        DATA             DIVISION.
@@ -941,6 +941,7 @@ AT_DATA([progprep.cob],[
 ])
 
 # Testcase includes trailing whitespace, setup by dropping '#'
+
 AT_CHECK([cat progprep.cob | tr -d '#' > prog.cob])
 
 AT_CHECK([$COBC -fdiagnostics-plain-output -Wall prog.cob], [1], [],
@@ -948,6 +949,7 @@ AT_CHECK([$COBC -fdiagnostics-plain-output -Wall prog.cob], [1], [],
 prog.cob:6: warning: numeric value is expected [-Wothers]
 prog.cob:14: warning: ignoring redundant . [-Wothers]
 ]])
+
 AT_CHECK([$COBC -fdiagnostics-show-caret -fdiagnostics-show-line-numbers prog.cob], [1], [],
 [[prog.cob:7: error: CRUD.CPY: No such file or directory
     5 |        WORKING-STORAGE  SECTION.
@@ -989,24 +991,24 @@ prog.cob:14: warning: ignoring redundant . [-Wothers]
 ]])
 
 # Testcase for line too long and printing only one line
-AT_DATA([longgy.cob],[ddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd
+AT_DATA([longgy.cob], [ddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd
 ])
 
 # note: this is actually an error in the parser line number,
 #       but until that is solved, it is a nice edge case of "line not available"
+
 AT_CHECK([$COBC -fdiagnostics-plain-output -fdiagnostics-show-caret -Wno-others longgy.cob], [1], [],
-[[longgy.cob:2: error: PROGRAM-ID header missing
+[longgy.cob:2: error: PROGRAM-ID header missing
    dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd..
  > <EOF>
-]])
+])
 
+AT_CHECK([$COMPILE -fdiagnostics-absolute-paths -Wall prog.cob 2> compiler.output], [1])
 
-AT_CHECK([$COBC -fdiagnostics-plain-output -fdiagnostics-absolute-paths -Wall prog.cob 2> compiler.output], [1])
-
-AT_CHECK([sed -e "s|$PWD|HOME|" compiler.output], [0],
+AT_CHECK([$SED -e "s|$PWD|HOME|" compiler.output], [0],
 [HOME/prog.cob:7: error: CRUD.CPY: No such file or directory
-HOME/prog.cob:6: warning: numeric value is expected @<:@-Wothers@:>@
-HOME/prog.cob:14: warning: ignoring redundant . @<:@-Wothers@:>@
+HOME/prog.cob:6: warning: numeric value is expected
+HOME/prog.cob:14: warning: ignoring redundant .
 ])
 
 AT_CLEANUP

--- a/tests/testsuite.src/used_binaries.at
+++ b/tests/testsuite.src/used_binaries.at
@@ -1000,5 +1000,14 @@ AT_CHECK([$COBC -fdiagnostics-plain-output -fdiagnostics-show-caret -Wno-others 
  > <EOF>
 ]])
 
+
+AT_CHECK([$COBC -fdiagnostics-plain-output -fdiagnostics-absolute-paths -Wall prog.cob 2> compiler.output], [1])
+
+AT_CHECK([sed -e "s|$PWD|HOME|" compiler.output], [0],
+[HOME/prog.cob:7: error: CRUD.CPY: No such file or directory
+HOME/prog.cob:6: warning: numeric value is expected @<:@-Wothers@:>@
+HOME/prog.cob:14: warning: ignoring redundant . @<:@-Wothers@:>@
+])
+
 AT_CLEANUP
 


### PR DESCRIPTION
…or locations

This flag is useful for editors that cannot correctly locate files with recursive build systems (typically, vscode running `make` to compile a gnucobol project)