### PR TITLE
New option --copy COPYBOOK, to include a COPYBOOK

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -22,6 +22,16 @@ NEWS - user visible changes				-*- outline -*-
 
 * Changes to the COBOL compiler (cobc) options:
 
+** New option --copy COPYBOOK to load copybooks before parsing files. This
+   option can typically be used to perform replacements without modifying
+   the source code, or to add prototypes for external calls.
+
+** New option --include FILE.h to add a #include in the generated C file.
+   This option can typically be used to force the C compiler to check static
+   calls to externals. The files are put into quotes, unless they start by
+   '<'. Quoted files are expected to have absolute paths, as the C compiler
+   is called in a temp directory instead of the project directory.
+
 ** output of unlimited errors may be requested by -fmax-errors=0,
    to stop compiliation at first error use -Wfatal-errors
 ** default value for -fmax-errors was changed from 128 to 20

--- a/cobc/ChangeLog
+++ b/cobc/ChangeLog
@@ -1,4 +1,9 @@
 
+2023-10-11  Fabrice Le Fessant <fabrice.le_fessant@ocamlpro.com>
+
+	* cobc.c, pplex.l: new option --copy COPYBOOK, to include a COPYBOOK
+	  before reading the source file
+
 2023-11-29  Fabrice Le Fessant <fabrice.le_fessant@ocamlpro.com>
 
 	* cobc.c (cobc_clean_up): when save-temps specifies a directory,

--- a/cobc/ChangeLog
+++ b/cobc/ChangeLog
@@ -1,4 +1,13 @@
 
+2023-10-12  Fabrice Le Fessant <fabrice.le_fessant@ocamlpro.com>
+
+	* cobc.c, codegen.c: new option --include FILE, to #include
+	  additional files in the C generated code. Such files can be
+	  used to statically check the number of arguments in static
+	  calls, for example. The files are put into quotes, unless
+	  they start by '<'. Since C files are compiled in a temp dir,
+	  quoted files should be absolute paths. Implementing FR #176
+
 2023-10-11  Fabrice Le Fessant <fabrice.le_fessant@ocamlpro.com>
 
 	* cobc.c, pplex.l: new option --copy COPYBOOK, to include a COPYBOOK

--- a/cobc/cobc.c
+++ b/cobc/cobc.c
@@ -107,6 +107,7 @@ enum compile_level {
 #define	CB_FLAG_GETOPT_DEFAULT_COLSEQ  15
 #define	CB_FLAG_GETOPT_MEMORY_CHECK    16
 #define	CB_FLAG_GETOPT_COPY_FILE       17
+#define	CB_FLAG_GETOPT_INCLUDE_FILE    18
 
 
 /* Info display limits */
@@ -234,6 +235,7 @@ const char		*demangle_name = NULL;
 const char		*cb_storage_file_name = NULL;
 const char		*cb_call_extfh = NULL;
 struct cb_text_list	*cb_copy_list = NULL;
+struct cb_text_list	*cb_include_file_list = NULL;
 struct cb_text_list	*cb_include_list = NULL;
 struct cb_text_list	*cb_depend_list = NULL;
 struct cb_text_list	*cb_intrinsic_list = NULL;
@@ -598,6 +600,7 @@ static const struct option long_options[] = {
 	{"std",			CB_RQ_ARG, NULL, '$'},
 	{"conf",		CB_RQ_ARG, NULL, '&'},
 	{"copy",                CB_RQ_ARG, NULL, CB_FLAG_GETOPT_COPY_FILE},
+	{"include",             CB_RQ_ARG, NULL, CB_FLAG_GETOPT_INCLUDE_FILE},
 	{"debug",		CB_NO_ARG, NULL, 'd'},
 	{"ext",			CB_RQ_ARG, NULL, 'e'},	/* note: kept *undocumented* until GC4, will be changed to '.' */
 	{"free",		CB_NO_ARG, NULL, 'F'},	/* note: not assigned directly as this is only valid for */
@@ -3911,6 +3914,17 @@ process_command_line (const int argc, char **argv)
 			}
 			CB_TEXT_LIST_ADD (cb_copy_list,
 					  cobc_strdup (cob_optarg));
+			break;
+
+		case CB_FLAG_GETOPT_INCLUDE_FILE: /* 18 */
+			/* -include=<file.h> : add #include "file.h" to 
+			   generated C file */
+			if (strlen (cob_optarg) > (COB_MINI_MAX)) {
+				cobc_err_exit (COBC_INV_PAR, "--include");
+			}
+			CB_TEXT_LIST_ADD (cb_include_file_list,
+					  cobc_strdup (cob_optarg));
+			cb_flag_c_decl_for_static_call = 0;
 			break;
 
 		case 'A':

--- a/cobc/cobc.h
+++ b/cobc/cobc.h
@@ -474,6 +474,7 @@ extern FILE			*cb_src_list_file;
 extern FILE			*cb_depend_file;
 extern struct cb_text_list	*cb_depend_list;
 extern struct cb_text_list	*cb_copy_list;
+extern struct cb_text_list	*cb_include_file_list;
 extern struct cb_text_list	*cb_include_list;
 extern struct cb_text_list	*cb_intrinsic_list;
 extern struct cb_text_list	*cb_extension_list;

--- a/cobc/cobc.h
+++ b/cobc/cobc.h
@@ -473,6 +473,7 @@ extern FILE			*cb_listing_file;
 extern FILE			*cb_src_list_file;
 extern FILE			*cb_depend_file;
 extern struct cb_text_list	*cb_depend_list;
+extern struct cb_text_list	*cb_copy_list;
 extern struct cb_text_list	*cb_include_list;
 extern struct cb_text_list	*cb_intrinsic_list;
 extern struct cb_text_list	*cb_extension_list;
@@ -652,6 +653,7 @@ extern void		cb_plex_error (const size_t,
 					 const char *, ...) COB_A_FORMAT23;
 extern unsigned int	cb_plex_verify (const size_t, const enum cb_support,
 					const char *);
+extern const char *cb_copy_find_file (char *name, int has_ext);
 extern void		configuration_warning (const char *, const int,
 					 const char *, ...) COB_A_FORMAT34;
 extern void		configuration_error (const char *, const int,

--- a/cobc/codegen.c
+++ b/cobc/codegen.c
@@ -1829,6 +1829,17 @@ output_gnucobol_defines (const char *formatted_date)
 		current_compile_tm.tm_sec;
 	output_line ("#define  COB_MODULE_TIME\t\t%d", i);
 
+	{
+		struct cb_text_list *l = cb_include_file_list ;
+		for (;l;l=l->next){
+			if (l->text[0] == '<'){
+				output_line ("#include %s", l->text);
+			} else {
+				output_line ("#include \"%s\"", l->text);
+			}
+		}
+	}
+
 }
 
 /* CALL cache */

--- a/cobc/flag.def
+++ b/cobc/flag.def
@@ -166,7 +166,7 @@ CB_FLAG (cb_flag_stack_check, 1, "stack-check",
 	_("  -fstack-check         PERFORM stack checking\n"
 	  "                        * turned on by --debug/-g"))
 
-CB_FLAG_OP (1, "memory-check", CB_FLAG_MEMORY_CHECK,
+CB_FLAG_OP (1, "memory-check", CB_FLAG_GETOPT_MEMORY_CHECK,
 	_("  -fmemory-check=<scope>     checks for invalid writes to internal storage,\n"
 	  "                        <scope> may be one of: all, pointer, using, none\n"
 	  "                        * default: none, set to all by --debug"))

--- a/cobc/help.c
+++ b/cobc/help.c
@@ -116,8 +116,11 @@ cobc_print_usage_common_options (void)
 	puts (_("  -X, --Xref            specify cross reference in listing"));
 #endif
 	puts (_("  -I <directory>        add <directory> to copy/include search path"));
-	puts (_("  --copy <copybook>     include <copybook> at beginning of file, as would COPY copybook."));
+	puts (_("  --copy <copybook>     include <copybook> at beginning of file,\n"
+                "                        as would COPY copybook."));
 	puts (_("  -L <directory>        add <directory> to library search path"));
+	puts (_("  --include <file.h>    add a #include \"file.h\" at the beginning of the C\n"
+		"                        generated file (implies -fno-gen-c-decl-static-call)"));
 	puts (_("  -l <lib>              link the library <lib>"));
 	puts (_("  -K <entry>            generate CALL to <entry> as static"));
 	puts (_("  -D <define>           define <define> for COBOL compilation"));

--- a/cobc/help.c
+++ b/cobc/help.c
@@ -116,6 +116,7 @@ cobc_print_usage_common_options (void)
 	puts (_("  -X, --Xref            specify cross reference in listing"));
 #endif
 	puts (_("  -I <directory>        add <directory> to copy/include search path"));
+	puts (_("  --copy <copybook>     include <copybook> at beginning of file, as would COPY copybook."));
 	puts (_("  -L <directory>        add <directory> to library search path"));
 	puts (_("  -l <lib>              link the library <lib>"));
 	puts (_("  -K <entry>            generate CALL to <entry> as static"));

--- a/cobc/pplex.l
+++ b/cobc/pplex.l
@@ -59,19 +59,21 @@ static int ppwrap (void) {
 	return 1;
 }
 
+static void insert_copy_arg (void);
+
 #define	PPLEX_BUFF_LEN		512
 #define YY_INPUT(buf,result,max_size)	result = ppinput (buf, max_size);
 #define	ECHO				fputs (yytext, yyout)
 
+/* The first --copy COPYBOOK is inserted using this macro. The next
+   ones will be inserted in <<EOF>>, when we come back to the toplevel
+   source file. */
 #define	YY_USER_INIT							\
-	if (!plexbuff1) {						\
-		plexbuff1 = cobc_malloc ((size_t)COB_SMALL_BUFF);	\
-	}								\
-	if (!plexbuff2) {						\
-		plexbuff2 = cobc_malloc ((size_t)COB_SMALL_BUFF);	\
-	}								\
 	requires_listing_line = 1;					\
-	comment_allowed = 1;
+	comment_allowed = 1;						\
+	copy_list_pointer = cb_copy_list;				\
+	insert_copy_arg ();
+
 
 #include "config.h"
 
@@ -178,6 +180,20 @@ static void	output_pending_newlines	(FILE *);
 
 static struct cb_text_list	*pp_text_list_add (struct cb_text_list *,
 					 const char *, const size_t);
+
+static struct cb_text_list *copy_list_pointer = NULL;
+
+static void insert_copy_arg (void)
+{
+	if (copy_list_pointer != NULL){
+		int ret = ppcopy (copy_list_pointer->text, NULL, NULL);
+		if ( ret < 0 ){ /* This should never happen, as we already test it before */
+			cobc_err_msg (_("fatal error: %s"), "could not find --copy argument");
+			cobc_abort_terminate (0);
+		}
+		copy_list_pointer = copy_list_pointer->next;
+	}
+}
 
 %}
 
@@ -1205,6 +1221,13 @@ ENDIF_DIRECTIVE_STATE>{
 	copy_stack = current_copy_info->next;
 	cobc_free (current_copy_info->dname);
 	cobc_free (current_copy_info);
+
+	/* Check whether we are back at the toplevel source file. In this case,
+	   check if there is a pending copy argument (--copy COPYBOOK) waiting
+	   to be inserted. */
+	if (copy_stack->next == NULL){
+		insert_copy_arg();
+	}
 }
 
 %%
@@ -1480,6 +1503,10 @@ ppcopy_try_open (const char *dir, const char *name, int has_ext)
 	const char		*extension = "";
 	struct stat st;
 
+	if (!plexbuff2) {
+		plexbuff2 = cobc_malloc ((size_t)COB_SMALL_BUFF);
+	}
+
 	for (;;) {
 		if (dir) {
 			snprintf (plexbuff2, (size_t)COB_SMALL_MAX, "%s%c%s%s",
@@ -1520,8 +1547,8 @@ ppcopy_try_open (const char *dir, const char *name, int has_ext)
    each with all known copybook extensions:
    1 - as is
    2 - all known copybook directories */
-static const char *
-ppcopy_find_file (char *name, int has_ext)
+const char *
+cb_copy_find_file (char *name, int has_ext)
 {
 	const char *filename;
 	{
@@ -1597,6 +1624,10 @@ ppcopy (const char *name, const char *lib, struct cb_replace_list *replace_list)
 		cb_current_file->copy_line = cb_source_line;
 	}
 
+	if (!plexbuff1) {
+		plexbuff1 = cobc_malloc ((size_t)COB_SMALL_BUFF);
+	}
+
 	/* TODO: open with path relative to the current file's path,
 	         if any (applies both to with and without "lib") */
 
@@ -1620,10 +1651,10 @@ ppcopy (const char *name, const char *lib, struct cb_replace_list *replace_list)
 					snprintf (plexbuff1, (size_t)COB_SMALL_MAX, "%s%c%s",
 						lib_env, SLASH_CHAR, name);
 					plexbuff1[COB_SMALL_MAX] = 0;
-					filename = ppcopy_find_file (plexbuff1, has_ext);
+					filename = cb_copy_find_file (plexbuff1, has_ext);
 				} else {
 					strcpy (plexbuff1, name);
-					filename = ppcopy_find_file (plexbuff1, has_ext);
+					filename = cb_copy_find_file (plexbuff1, has_ext);
 				}
 			}
 		}
@@ -1634,13 +1665,13 @@ ppcopy (const char *name, const char *lib, struct cb_replace_list *replace_list)
 			snprintf (plexbuff1, (size_t)COB_SMALL_MAX, "%s%c%s",
 				lib, SLASH_CHAR, name);
 			plexbuff1[COB_SMALL_MAX] = 0;
-			filename = ppcopy_find_file (plexbuff1, has_ext);
+			filename = cb_copy_find_file (plexbuff1, has_ext);
 		}
 
 		/* try without library name, if not resolved by env */
 		if (!filename && !lib_env) {
 			strcpy (plexbuff1, name);
-			filename = ppcopy_find_file (plexbuff1, has_ext);
+			filename = cb_copy_find_file (plexbuff1, has_ext);
 			if (filename) {
 				cb_plex_warning (COBC_WARN_FILLER, 0,
 					_("copybook not found in library '%s', library-name ignored"),
@@ -1656,7 +1687,7 @@ ppcopy (const char *name, const char *lib, struct cb_replace_list *replace_list)
 		}
 	} else {
 		strcpy (plexbuff1, name);
-		filename = ppcopy_find_file (plexbuff1, has_ext);
+		filename = cb_copy_find_file (plexbuff1, has_ext);
 	}
 
 	/* expected case: filename found */

--- a/cobc/replace.c
+++ b/cobc/replace.c
@@ -193,6 +193,17 @@ STRING_OF_LIST(token)
 /* string_of_text_list (...) */
 STRING_OF_LIST(text)
 
+static void dump_replacement(struct cb_replacement_state* repls)
+{
+	fprintf(stderr, "dump_replacement('%s'):\n", repls->name);
+	struct cb_replace_list  *list = repls->replace_list ;
+	for (;list;list = list->next){
+		fprintf(stderr, "   replace: %s\n", string_of_text_list (list->src->text_list));
+		fprintf(stderr, "        by: %s\n", string_of_text_list (list->new_text));
+	}
+	fprintf(stderr, "=================================================================\n");
+}
+
 #endif /* DEBUG_REPLACE */
 
 /* global state */
@@ -759,7 +770,6 @@ cb_free_replace (void)
 	reset_replacements (copy_repls);
 	reset_replacements (replace_repls);
 #endif
-
 	cobc_free (copy_repls);
 	copy_repls = NULL;
 
@@ -772,6 +782,10 @@ cb_free_replace (void)
 struct cb_replace_list *
 cb_get_copy_replacing_list (void)
 {
+#ifdef DEBUG_REPLACE_TRACE
+	fprintf (stderr, "cb_get_copy_replacing_list()\n");
+#endif
+
 	if (copy_repls == NULL) {
 #ifdef DEBUG_REPLACE_TRACE
 		int i;
@@ -845,4 +859,7 @@ cb_set_replace_list (struct cb_replace_list *list, const int is_pushpop)
 	if (cb_src_list_file) {
 		cb_set_print_replace_list (list);
 	}
+#ifdef DEBUG_REPLACE_TRACE
+	dump_replacement(replace_repls);
+#endif
 }

--- a/doc/gnucobol.texi
+++ b/doc/gnucobol.texi
@@ -365,9 +365,13 @@ The following options specify the target type produced by the compiler:
 @table @code
 @item -E
 Preprocess only: compiler directives are executed, comment lines are
-removed and @code{COPY} statements are expanded.
+removed, and @code{COPY} and @code{REPLACE} statements are performed.
 The output is sent to stdout, allowing you to directly use it as input for
 another process. You can manually set an output file using @option{-o}.
+
+@item --copy @var{copybook}
+Include @file{copybook} at the beginning of the source code, as if
+@code{COPY copybook} had been parsed.
 
 @item -C
 Translation only.  COBOL source files are translated into C files.

--- a/doc/gnucobol.texi
+++ b/doc/gnucobol.texi
@@ -373,6 +373,18 @@ another process. You can manually set an output file using @option{-o}.
 Include @file{copybook} at the beginning of the source code, as if
 @code{COPY copybook} had been parsed.
 
+@item --include @var{file.h}
+Add a @code{#include} @file{file.h} at the beginning of the generated
+C source file. The file name is put into quotes, unless it starts by
+@code{<}. Quoted files should be absolute paths, since C files are compiled
+in temporary directories.
+The option also implies @option{-fno-gen-c-decl-static-call}.
+This option can be used to check function prototypes when
+static calls are used. When this option is used, the source file is
+compiled in the project directory (instead of the temp directory), and
+no prototypes are generated, so ALL static call functions must appear
+in the header file, with GnuCOBOL compatible types.
+
 @item -C
 Translation only.  COBOL source files are translated into C files.
 The output is saved in file @file{*.c}.

--- a/tests/testsuite.src/syn_copy.at
+++ b/tests/testsuite.src/syn_copy.at
@@ -1072,3 +1072,50 @@ AT_DATA([prog.cob], [
 AT_CHECK([$COMPILE_ONLY prog.cob], [0], [], [])
 
 AT_CLEANUP
+
+
+AT_SETUP([Option --copy COPYBOOK])
+AT_KEYWORDS([argument])
+
+AT_DATA([copybook1.CPY], [
+       REPLACE ==BEGIN PROGRAM== BY ==IDENTIFICATION DIVISION.
+       PROGRAM-ID.==.
+])
+AT_DATA([copybook2.CPY], [
+       REPLACE ALSO ==output== BY =="Hello world"==.
+])
+AT_DATA([copybook3.CPY], [
+       REPLACE ALSOO ==output== BY =="Hello world"==.
+])
+AT_DATA([prog.cob], [
+       BEGIN PROGRAM    prog.
+       PROCEDURE        DIVISION.
+           DISPLAY output
+           STOP RUN.
+])
+
+AT_CHECK([$COMPILE_ONLY prog.cob], [1], [],
+[prog.cob:2: error: PROGRAM-ID header missing
+prog.cob:2: error: ENVIRONMENT DIVISION header missing
+prog.cob:2: error: CONFIGURATION SECTION header missing
+prog.cob:2: error: SPECIAL-NAMES header missing
+prog.cob:2: error: invalid system-name 'BEGIN'
+prog.cob:2: error: syntax error, unexpected PROGRAM, expecting CRT or Identifier
+prog.cob:2: error: invalid system-name 'prog'
+prog.cob:2: error: syntax error, unexpected ., expecting CRT or Identifier
+prog.cob:3: error: syntax error, unexpected PROCEDURE
+prog.cob:4: error: PROCEDURE DIVISION header missing
+])
+
+AT_CHECK([$COMPILE_ONLY --copy copybook1 --copy copybook2 prog.cob], [0], [], [])
+
+AT_CHECK([$COMPILE_ONLY --copy copybook1 --copy copybook3 prog.cob], [1], [],
+[copybook3.CPY:2: error: syntax error, unexpected ==, expecting BY
+copybook3.CPY:2: error: PROGRAM-ID header missing
+])
+
+AT_CHECK([$COMPILE_ONLY --copy copybook1 --copy copybook4 prog.cob], [1], [],
+[cobc: error: fatal error: could not find --copy argument copybook4
+])
+
+AT_CLEANUP

--- a/tests/testsuite.src/used_binaries.at
+++ b/tests/testsuite.src/used_binaries.at
@@ -1081,3 +1081,61 @@ HOME/prog.cob:14: warning: ignoring redundant .
 
 AT_CLEANUP
 
+
+AT_SETUP([check include header file])
+AT_KEYWORDS([-include])
+
+AT_DATA([file.h], [
+extern void f(char *, long );
+])
+AT_DATA([prog.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      prog.
+       PROCEDURE        DIVISION.
+           CALL "f" USING "Hello".
+])
+
+# No check, program seems correct
+
+AT_CHECK([$COBC -m -fstatic-call prog.cob], [0], [], [])
+
+# We ignore the error output, as it depends on the C compiler in use
+
+AT_CHECK([$COBC -m --include "$PWD/file.h" -fstatic-call prog.cob], [1], [], [ignore])
+AT_DATA([prog2.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      prog.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01 long USAGE BINARY-C-LONG.
+       PROCEDURE        DIVISION.
+           CALL "f" USING "Hello" BY VALUE long RETURNING NOTHING.
+])
+
+AT_CHECK([$COBC -m --include "$PWD/file.h" -fstatic-call prog2.cob], [0], [], [])
+
+AT_CHECK([$COBC -I . -m --include "file.h" -fstatic-call prog2.cob], [0], [], [])
+
+# We can use --copy to check a CALL against a prototype. However, this
+# feature is not fully supported by GnuCOBOL yet, so we get some
+# warnings. For exemple:
+# * not putting RETURNING triggers an error
+# * putting RETURNING NOTHING is not supported
+# * putting RETURNING OMITTED is ok, but triggers a warning (see stderr)
+
+AT_DATA([f.copy], [
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. f PROTOTYPE.
+       DATA DIVISION.
+       LINKAGE SECTION.
+       01  a PIC X(20).
+       01  b BINARY-C-LONG.
+       PROCEDURE DIVISION USING a BY VALUE b RETURNING OMITTED.
+       END PROGRAM f.
+])
+
+AT_CHECK([$COMPILE_MODULE -Wno-unfinished --copy "f.copy" -fstatic-call prog2.cob], [0], [],
+[prog2.cob:8: warning: unexpected RETURNING item
+])
+
+AT_CLEANUP


### PR DESCRIPTION
This option provides the same behavior as `--include FILE` for `gcc` and `clang`, i.e. including a file (or a group of files) before parsing the source. 
It can be used typically to include `REPLACE` statements.
