### PR TITLE
Fix Bug 923: generated modules init/clear unused decimal constants

### DIFF
--- a/cobc/ChangeLog
+++ b/cobc/ChangeLog
@@ -2,21 +2,21 @@
 2023-10-17  David Declerck <david.declerck@ocamlpro.com>
 
 	BUG #923: generated modules init/clear unused decimal constants
-	* tree.h (struct cb_program): new `decimal_constant` field to store
-	  decimal constants used by the current program
-	* codegen.c (literal_list): removal of the unused `c` field
+	* codegen.c (literal_list): removal of the unused x field,
+	  and type moved to tree.h
+	* tree.h (struct cb_program): new decimal_constant field
+	  to store decimal constants used by the current program,
 	* codegen.c (cb_cache_program_decimal_constant): new function
 	  that adds constants used by the current program to the new
-	  `decimal_constant` field in `struct cb_prog`
+	  decimal_constant field in struct cb_prog
 	* codegen.c (cb_lookup_literal): added the current program as
-	  argument to `cb_lookup_literal` to account for different
+	  argument to cb_lookup_literal to account for different
 	  usage contexts (parse/typecheck vs codegen)
 	* codegen.c (output_internal_function): iterate over
-	  `prog->decimal_constants` instead of `literal_cache` so as to only
+	  prog->decimal_constants instead of literal_cache so as to only
 	  output decimal constants actually used by the current program
-	* codegen.c (output_param): pass `current_prog` to `cb_lookup_literal`
-	* typeck.c (decimal_expand, cb_build_cond_fields): pass `current_program`
-	  to `cb_lookup_literal`
+	* typeck.c (decimal_expand, cb_build_cond_fields),
+	  codegen.c (output_param) : pass current_program to cb_lookup_literal
 
 2023-07-26  Simon Sobisch <simonsobisch@gnu.org>
 

--- a/cobc/ChangeLog
+++ b/cobc/ChangeLog
@@ -1,4 +1,23 @@
 
+2023-10-17  David Declerck <david.declerck@ocamlpro.com>
+
+	BUG #923: generated modules init/clear unused decimal constants
+	* tree.h (struct cb_program): new `decimal_constant` field to store
+	  decimal constants used by the current program
+	* codegen.c (literal_list): removal of the unused `c` field
+	* codegen.c (cb_cache_program_decimal_constant): new function
+	  that adds constants used by the current program to the new
+	  `decimal_constant` field in `struct cb_prog`
+	* codegen.c (cb_lookup_literal): added the current program as
+	  argument to `cb_lookup_literal` to account for different
+	  usage contexts (parse/typecheck vs codegen)
+	* codegen.c (output_internal_function): iterate over
+	  `prog->decimal_constants` instead of `literal_cache` so as to only
+	  output decimal constants actually used by the current program
+	* codegen.c (output_param): pass `current_prog` to `cb_lookup_literal`
+	* typeck.c (decimal_expand, cb_build_cond_fields): pass `current_program`
+	  to `cb_lookup_literal`
+
 2023-07-26  Simon Sobisch <simonsobisch@gnu.org>
 
 	* typeck.c (search_set_keys): improving SEARCH ALL syntax checks

--- a/cobc/tree.h
+++ b/cobc/tree.h
@@ -1794,6 +1794,8 @@ struct cb_ml_generate_tree {
 
 /* Program */
 
+struct literal_list;
+
 struct nested_list {
 	struct nested_list	*next;
 	struct cb_program	*nested_prog;
@@ -1890,6 +1892,7 @@ struct cb_program {
 	unsigned char	numeric_separator;		/* ',' or '.' */
 	enum cob_module_type	prog_type;			/* Program type (program = 0, function = 1) */
 	cb_tree			entry_convention;	/* ENTRY convention / PROCEDURE convention */
+	struct literal_list	*decimal_constants;
 
 	unsigned int	flag_main		: 1;	/* Gen main function */
 	unsigned int	flag_common		: 1;	/* COMMON PROGRAM */
@@ -2076,7 +2079,7 @@ extern cb_tree			cb_concat_literals (const cb_tree,
 
 extern cb_tree			cb_build_decimal (const unsigned int);
 extern cb_tree			cb_build_decimal_literal (const int);
-extern int			cb_lookup_literal (cb_tree x, int make_decimal);
+extern int			cb_lookup_literal (struct cb_program *prog, cb_tree x, int make_decimal);
 
 extern cb_tree			cb_build_comment (const char *);
 extern cb_tree			cb_build_direct (const char *,

--- a/cobc/tree.h
+++ b/cobc/tree.h
@@ -1794,7 +1794,12 @@ struct cb_ml_generate_tree {
 
 /* Program */
 
-struct literal_list;
+struct literal_list {
+	struct literal_list	*next;
+	struct cb_literal	*literal;
+	int			id;
+	int			make_decimal;
+};
 
 struct nested_list {
 	struct nested_list	*next;

--- a/cobc/typeck.c
+++ b/cobc/typeck.c
@@ -6433,7 +6433,7 @@ decimal_expand (cb_tree d, cb_tree x)
 
 		if (CB_TREE_TAG (p->y) == CB_TAG_LITERAL
 		 && CB_TREE_CATEGORY (p->y) == CB_CATEGORY_NUMERIC) {
-			t = cb_build_decimal_literal (cb_lookup_literal(p->y,1));
+			t = cb_build_decimal_literal (cb_lookup_literal(current_program, p->y,1));
 			decimal_compute (p->op, d, t);
 		} else {
 			t = decimal_alloc ();
@@ -7062,7 +7062,7 @@ cb_build_cond_fields (struct cb_binary_op *p,
 			memset (data, ' ', size1 - size2);
 		}
 		new_lit = cb_build_alphanumeric_literal (data, size1);
-		lit = cb_lookup_literal (new_lit, 0);
+		lit = cb_lookup_literal (current_progr, new_lit, 0);
 		return CB_BUILD_FUNCALL_3 ("memcmp",
 			CB_BUILD_CAST_ADDRESS (left),
 			CB_BUILD_CAST_ADDRESS (lit),


### PR DESCRIPTION
That should address [https://sourceforge.net/p/gnucobol/bugs/923/](https://sourceforge.net/p/gnucobol/bugs/923/).

Passes all of the testsuite.