### PR TITLE
[CANCELLED] Add a settings file to configure cobc at runtime

### DIFF
--- a/cobc/Makefile.am
+++ b/cobc/Makefile.am
@@ -23,7 +23,7 @@ bin_PROGRAMS = cobc
 cobc_SOURCES = cobc.c cobc.h ppparse.y pplex.c parser.y scanner.c config.c \
 	reserved.c error.c tree.c tree.h field.c typeck.c codegen.c help.c \
 	config.def flag.def warning.def codeoptim.def ppparse.def \
-	codeoptim.c replace.c 
+	codeoptim.c replace.c settings.c settings.def
 
 #cobc_SOURCES = cobc.c cobc.h ppparse.y pplex.l parser.y scanner.l config.c
 

--- a/cobc/cobc.h
+++ b/cobc/cobc.h
@@ -684,4 +684,18 @@ extern int		cb_strcasecmp (const void *, const void *);
 extern unsigned char	cb_toupper (const unsigned char);
 extern unsigned char	cb_tolower (const unsigned char);
 
+/* settings.c */
+
+#define STRING_SETTING(help,name) \
+	extern const char* cb_setting_##name;
+
+#define BOOL_SETTING(help,name) \
+	extern int cb_setting_##name;
+
+#include "settings.def"
+#undef STRING_SETTING
+#undef BOOL_SETTING
+extern void             cb_settings_print (void);
+extern void             cb_settings_load (const char* filename);
+
 #endif /* CB_COBC_H */

--- a/cobc/codegen.c
+++ b/cobc/codegen.c
@@ -1754,22 +1754,22 @@ output_standard_includes (struct cb_program *prog)
 {
 	struct cb_program *p;
 
-#if !defined (_GNU_SOURCE) && defined (_XOPEN_SOURCE_EXTENDED)
-	output_line ("#ifndef\t_XOPEN_SOURCE_EXTENDED");
-	output_line ("#define\t_XOPEN_SOURCE_EXTENDED 1");
-	output_line ("#endif");
-#endif
+	if (cb_setting_XOPEN_SOURCE_EXTENDED){
+		output_line ("#ifndef\t_XOPEN_SOURCE_EXTENDED");
+		output_line ("#define\t_XOPEN_SOURCE_EXTENDED 1");
+		output_line ("#endif");
+	}
 #if 0	/* Simon: why should we include that? */
 	output_line ("#include <stdio.h>");
 #endif
 	output_line ("#include <string.h> /* for memcpy, memcmp and friends */");
-#ifdef	WORDS_BIGENDIAN
-	output_line ("#define  WORDS_BIGENDIAN 1");
-#endif
-#ifdef	COB_KEYWORD_INLINE
-	output_line ("#define  COB_KEYWORD_INLINE %s",
-		CB_XSTRINGIFY(COB_KEYWORD_INLINE));
-#endif
+	if (cb_setting_WORDS_BIGENDIAN){
+		output_line ("#define  WORDS_BIGENDIAN 1");
+	}
+	if (cb_setting_COB_INLINE_KEYWORD){
+		output_line ("#define  COB_KEYWORD_INLINE %s",
+			     cb_setting_COB_INLINE_KEYWORD);
+	}
 	if (cb_flag_winmain) {
 		output_line ("#include <windows.h>");
 	}
@@ -6523,15 +6523,12 @@ output_call (struct cb_call *p)
 		ret_ptr = 1;
 	}
 
-#ifdef	_WIN32
-	if (p->convention & CB_CONV_STDCALL) {
+	if (cb_setting_WIN32 &&
+	    (p->convention & CB_CONV_STDCALL) ) {
 		convention = "_std";
 	} else {
 		convention = "";
 	}
-#else
-	convention = "";
-#endif
 
 	/* System routine entry points */
 	if (p->is_system) {

--- a/cobc/ppparse.y
+++ b/cobc/ppparse.y
@@ -582,15 +582,10 @@ ppparse_clear_vars (const struct cb_define_struct *p)
 						  "SIGN",
 						  "'ASCII'", 0);
 	}
-#ifdef	WORDS_BIGENDIAN
 	ppp_setvar_list = ppp_define_add (ppp_setvar_list,
 					  "ENDIAN",
-					  "'BIG'", 0);
-#else
-	ppp_setvar_list = ppp_define_add (ppp_setvar_list,
-					  "ENDIAN",
-					  "'LITTLE'", 0);
-#endif
+					  cb_setting_WORDS_BIGENDIAN ? "'BIG'" : "'LITTLE'",
+					  0);
 #if	' ' == 0x20
 	ppp_setvar_list = ppp_define_add (ppp_setvar_list,
 					  "CHARSET",

--- a/cobc/settings.c
+++ b/cobc/settings.c
@@ -1,0 +1,446 @@
+/*
+   Copyright (C) 2001-2023 Free Software Foundation, Inc.
+
+   Authors:
+   Keisuke Nishida, Roger While, Ron Norman, Simon Sobisch, Brian Tiffin,
+   Edward Hart, Dave Pitts, Fabrice Le Fessant
+
+   This file is part of GnuCOBOL.
+
+   The GnuCOBOL compiler is free software: you can redistribute it
+   and/or modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation, either version 3 of the
+   License, or (at your option) any later version.
+
+   GnuCOBOL is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with GnuCOBOL.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "tarstamp.h"
+#include "config.h"
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#ifdef	HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <stdarg.h>
+#include <string.h>
+#ifdef	HAVE_STRINGS_H
+#include <strings.h>
+#endif
+#include <ctype.h>
+#include <time.h>
+#include <limits.h>
+
+#include "cobc.h"
+#include "tree.h"
+
+/*
+Settings are used to override GnuCOBOL host config, i.e. parameters
+that are used to adapt GnuCOBOL to the system running it. By default,
+these parameters are guessed at compilation time. However, it happens
+that we want to change them at runtime:
+
+- For relocation, i.e. to install GnuCOBOL in a different directory
+  from the one in which it was supposed to be.
+
+- For retargetting, i.e. to target a different C compiler or linker
+  that the one that was detected at compile time.
+
+Use `gnucobol --settings` to output the current settings. The output
+can be copied into a file, that will later be read by GnuCOBOL:
+
+```
+$ gnucobol --settings > gnucobol.settings
+$ gnucobol --settings=gnucobol.settings
+```
+
+You can then modify any option within the file.
+
+A file containing these settings can be specified in 3 different ways,
+the first working way in this order will be used:
+
+* Use of the argument `--settings=FILE`
+* Use of the environment variable `COBC_SETTINGS`
+* Use of `../etc/gnucobol/gnucobol.settings` from the directory
+  containing the `cobc` executable
+
+If a file is specified, an error while loading the file is fatal.
+
+Once the settings have been loaded, a few variables can be modified if
+the `COBC_IS_RELOCATABLE` setting is set to 1. This setting can also
+be overwritten by setting the `COBC_IS_RELOCATABLE` environment
+variable. In this case, the following variables are modified
+relatively to the directory containing `cobc` (`$bindir`):
+
+* `COB_CFLAGS`: `-I $bindir/../include` is added in front
+* `COB_CONFIG_DIR`: set to `$bindir/../share/gnucobol/config`
+* `COB_COPY_DIR`: set to `$bindir/../share/gnucobol/copy`
+* `COB_LIBRARY_PATH`: set to `$bindir/../lib/gnucobol`
+* `COB_LIBS`: `-L$bindir/../lib` is added in front
+
+ */
+
+#ifndef COB_DEBUG_FLAGS
+#ifdef	_MSC_VER
+#define COB_DEBUG_FLAGS ""
+#else
+#error		missing definition of COB_DEBUG_FLAGS
+#endif
+#endif
+
+/* For all boolean options, we must force their existence */
+#ifdef _MSC_VER
+#define MSC_VER 1
+#else
+#define MSC_VER 0
+#endif
+
+#ifdef __CYGWIN__
+#define CYGWIN 1
+#else
+#define CYGWIN 0
+#endif
+
+#ifdef __clang__
+#define CLANG 1
+#else
+#define CLANG 0
+#endif
+
+#ifdef _WIN32
+#define WIN32 1
+#else
+#define WIN32 0
+#endif
+
+#ifdef __WATCOMC__
+#define WATCOMC 1
+#else
+#define WATCOMC 0
+#endif
+
+#ifdef __BORLANDC__
+#define BORLANDC 1
+#else
+#define BORLANDC 0
+#endif
+
+#ifdef __arm__
+#define ARM 1
+#else
+#define ARM 0
+#endif
+
+#ifdef COB_NON_ALIGNED
+#define COB_NON_ALIGNED 1
+#else
+#define COB_NON_ALIGNED 0
+#endif
+
+
+
+#ifndef COBC_IS_RELOCATABLE
+#define COBC_IS_RELOCATABLE 0
+#endif
+
+#ifndef HAVE_ATTRIBUTE_ALIGNED
+#define HAVE_ATTRIBUTE_ALIGNED 0
+#endif
+
+#ifndef HAVE_GMP_H
+#define HAVE_GMP_H 0
+#endif
+
+#ifndef HAVE_MPIR_H
+#define HAVE_MPIR_H 0
+#endif
+
+#ifndef HAVE_ATTRIBUTE_CONSTRUCTOR
+#define HAVE_ATTRIBUTE_CONSTRUCTOR 0
+#endif
+
+#define STRING_SETTING(help,name) \
+	const char* cb_setting_##name = name;
+#define BOOL_SETTING(help,name) \
+	int cb_setting_##name = name;
+#include "settings.def"
+#undef STRING_SETTING
+#undef BOOL_SETTING
+
+/* string settings */
+
+struct cb_string_setting {
+	const char* name ;
+	const char* help ;
+	const char** value ;
+};
+
+static struct cb_string_setting string_settings[] = {
+#define STRING_SETTING(help,name) \
+	{ #name, help, &cb_setting_##name },
+#define BOOL_SETTING(help,name)
+#include "settings.def"
+#undef STRING_SETTING
+#undef BOOL_SETTING
+	{ NULL, NULL, NULL }
+};
+
+/* boolean settings */
+
+struct cb_bool_setting {
+	const char* name ;
+	const char* help ;
+	int* value ;
+};
+
+static struct cb_bool_setting bool_settings[] = {
+#define STRING_SETTING(help,name)
+#define BOOL_SETTING(help,name) \
+	{ #name, help, &cb_setting_##name },
+#include "settings.def"
+#undef STRING_SETTING
+#undef BOOL_SETTING
+	{ NULL, NULL, NULL }
+};
+
+
+/* Could be put in a generic library, with cobc_strdup, etc. */
+static char*
+cobc_concat (const char *s1, const char *s2, const char *s3, const char *s4)
+{
+	size_t	calcsize = 1;
+	char* s;
+
+	if (!s1) {
+		return NULL;
+	}
+
+	calcsize += strlen (s1) +
+		( s2 ? strlen (s2) : 0 ) +
+		( s3 ? strlen (s3) : 0 ) +
+		( s4 ? strlen (s4) : 0 ) + 1;
+
+	/* LCOV_EXCL_START */
+	if (calcsize >= 131072) {
+		/* Arbitrary limit */
+		cobc_err_exit (_("parameter buffer size exceeded"));
+	}
+	/* LCOV_EXCL_STOP */
+	s = cobc_malloc (calcsize);
+	strcat (s, s1);
+	if (s2) {
+		strcat (s, s2);
+	}
+	if (s3) {
+		strcat (s, s3);
+	}
+	if (s4) {
+		strcat (s, s4);
+	}
+	return s;
+}
+
+
+static char * cobc_executable_name(void)
+{
+  char name[COB_NORMAL_BUFF];
+#if defined(__linux__)
+  struct stat st;
+  int retcode;
+
+  retcode = readlink("/proc/self/exe", name, COB_NORMAL_MAX);
+  if (retcode == -1 || retcode == COB_NORMAL_MAX) {
+	  return NULL;
+  }
+  name[retcode] = 0;
+  /* Make sure that the contents of /proc/self/exe is a regular file.
+     (Old Linux kernels return an inode number instead.) */
+  if (stat(name, &st) == -1 || ! S_ISREG(st.st_mode)) {
+	  return NULL;
+  }
+  return cobc_strdup (name);
+
+#elif defined(__APPLE__)
+  unsigned int namelen;
+
+  namelen = COB_NORMAL_MAX;
+  if (_NSGetExecutablePath(name, &namelen) == 0) {
+	  return name;
+  }
+  return NULL;
+
+#else
+  return NULL;
+
+#endif
+}
+
+
+
+void cb_settings_print (void)
+{
+	printf ("# Current settings:\n");
+
+#define STRING_SETTING(help,name) \
+	printf ( "\n# %s\n", help); \
+	printf ( #name": %s\n", cb_setting_##name);
+#define BOOL_SETTING(help,name) \
+	printf ( "\n# %s\n", help); \
+	printf ( #name": %s\n", cb_setting_##name ? "1" : "0");
+#include "settings.def"
+#undef STRING_SETTING
+#undef BOOL_SETTING
+
+	printf ("\n");
+}
+
+static void really_load_settings (const char *filename){
+	char buff[COB_SMALL_BUFF];
+	int  line ;
+	char *value;
+	char *cp;
+	FILE *fp;
+	struct cb_string_setting *ss = string_settings;
+	struct cb_bool_setting *bs = bool_settings;
+
+	fp = fopen (filename, "r");
+	if (fp == NULL) {
+		cobc_err_exit ("%s: %s", filename, cb_get_strerror ());
+	}
+
+	line = 0;
+	while (fgets (buff, COB_SMALL_MAX, fp)) {
+		line++;
+		value = NULL;
+		cp = buff;
+		if (*cp == '#') continue;
+		while (*cp != 0 && *cp != '\r' && *cp != '\n')
+		{
+			if (!value && *cp == ':' && cp[1] == ' '){
+				*cp = 0;
+				cp += 2;
+				value = cp;
+			} else {
+				cp++;
+			}
+		}
+		*cp = 0;
+		if (*buff == 0 && (!value || *value == 0)) continue;
+		if (!value){
+			cobc_err_exit ("%s:%d: invalid setting format",
+				       filename, line);
+		}
+
+		/* For now, we start with a linear search. In the future,
+		   we could require the options to be sorted at their
+		   definition and use a dichotomy for faster lookup. */
+
+		while (ss->name){
+			if (!strcmp(ss->name, buff)){
+				*(ss->value) = cobc_strdup (value);
+				break;
+			}
+			ss++;
+		}
+		if (ss->name) continue;
+
+
+		while (bs->name){
+			if (!strcmp(bs->name, buff)){
+				if ( value[0] == '0' && value[1] == 0 ){
+					*(bs->value) = 0;
+					break;
+				} 
+				if ( value[0] == '1' && value[1] == 0 ){
+					*(bs->value) = 1;
+					break;
+				}
+				cobc_err_exit ("%s:%d: wrong value '%s' for '%s', must be '0' or '1'",
+					       filename, line, value, buff);
+			}
+			bs++;
+		}
+		if (bs->name) continue;
+
+		cobc_err_exit ("%s:%d: setting '%s' does not exist",
+			       filename, line, buff);
+	}
+	fclose (fp);
+}
+
+
+void cb_settings_load (const char* filename)
+{
+	char *cobc_dirname = cobc_executable_name ();
+
+	if (cobc_dirname){
+		int len = strlen(cobc_dirname);
+		while (len>0){
+			if (cobc_dirname[len-1] == '/' || cobc_dirname[len-1] == '\\') break;
+			len--;
+		}
+		cobc_dirname[len] = 0;
+	}
+
+	if (!filename){
+		/* If no settings filename is provided by argument or
+		   by env variable, let's check if there is a file
+		   relative to the binary position. */
+		struct stat st;
+		filename = cobc_concat (cobc_dirname,
+					"../etc/gnucobol/gnucobol.settings",
+					NULL, NULL);
+		if (!filename || stat(filename, &st) == -1 || ! S_ISREG(st.st_mode)) {
+			filename = NULL;
+		}
+	}
+
+	if (filename){
+		really_load_settings (filename);
+	}
+
+	if (cob_getenv_direct ("COBC_IS_RELOCATABLE"))
+		cb_setting_COBC_IS_RELOCATABLE = 1;
+	if (cb_setting_COBC_IS_RELOCATABLE){
+		const char* prefix =
+			cobc_concat (cobc_dirname, "..", NULL, NULL);
+		const char* prefix_include =
+			cb_setting_MSC_VER ?
+			"/I \"" :
+			cb_setting_WATCOMC ?
+			"-i\"" :
+			"-I\"";
+		const char* prefix_lib =
+			cb_setting_MSC_VER ?
+			"/LIBPATH:\"" :
+			"-L\"";
+
+		cb_setting_COB_CFLAGS =
+			cobc_concat (prefix_include,
+				     prefix,
+				     "/include\" ",
+				     cb_setting_COB_CFLAGS);
+		cb_setting_COB_CONFIG_DIR =
+			cobc_concat (prefix, "/share/gnucobol/config", NULL, NULL);
+		cb_setting_COB_COPY_DIR =
+			cobc_concat (prefix, "/share/gnucobol/copy", NULL, NULL);
+		cb_setting_COB_LIBRARY_PATH =
+			cobc_concat (prefix, "/lib/gnucobol", NULL, NULL);
+		cb_setting_COB_LIBS =
+			cobc_concat (prefix_lib,
+				     prefix,
+				     "/lib\" ",
+				     cb_setting_COB_LIBS);
+	}
+}

--- a/cobc/settings.c
+++ b/cobc/settings.c
@@ -89,6 +89,38 @@ relatively to the directory containing `cobc` (`$bindir`):
 * `COB_LIBRARY_PATH`: set to `$bindir/../lib/gnucobol`
 * `COB_LIBS`: `-L$bindir/../lib` is added in front
 
+TODO in codegen.c:
+* COB_ALIGN_PRAGMA_8
+* USE_INT_HEX
+* COB_NON_ALIGNED
+* COB_SHORT_BORK
+* COB_EBCDIC_MACHINE
+* GEN_CHAR_AS_UINT
+* GEN_SINGLE_MEMCPY
+* NO_INIT_SOURCE_LOC
+* COB_64_BIT_POINTER
+* COB_TREE_DEBUG
+* COBC_HAS_CUTOFF_FLAG
+
+TODO in typeck.c:
+* COB_EBCDIC_MACHINE
+* COB_NON_ALIGNED
+* COB_SHORT_BORK
+* COB_ALLOW_UNALIGNED
+* COB_64_BIT_POINTER
+* WITH_EXTENDED_SCREENIO
+* WIN32
+* WITH_XML2
+
+TODO in parser.y:
+* COB_EBCDIC_MACHINE
+* COB_32_BIT_LONG
+
+TODO in ppparse.y:
+* #if	' ' == 0x20
+* #elif	' ' == 0x40
+
+
  */
 
 #ifndef COB_DEBUG_FLAGS
@@ -148,6 +180,17 @@ relatively to the directory containing `cobc` (`$bindir`):
 #define COB_NON_ALIGNED 0
 #endif
 
+#if !defined (_GNU_SOURCE) && defined (_XOPEN_SOURCE_EXTENDED)
+#define XOPEN_SOURCE_EXTENDED 1
+#else
+#define XOPEN_SOURCE_EXTENDED 0
+#endif
+
+#ifdef COB_KEYWORD_INLINE
+#define COB_INLINE_KEYWORD CB_XSTRINGIFY(COB_KEYWORD_INLINE)
+#else
+#define COB_INLINE_KEYWORD NULL
+#endif
 
 
 #ifndef COBC_IS_RELOCATABLE
@@ -164,6 +207,10 @@ relatively to the directory containing `cobc` (`$bindir`):
 
 #ifndef HAVE_MPIR_H
 #define HAVE_MPIR_H 0
+#endif
+
+#ifndef WORDS_BIGENDIAN
+#define WORDS_BIGENDIAN 0
 #endif
 
 #ifndef HAVE_ATTRIBUTE_CONSTRUCTOR

--- a/cobc/settings.def
+++ b/cobc/settings.def
@@ -1,4 +1,12 @@
 
+/* All these settings must belong to these two categories:
+   - Settings that modify the way other commands are called (paths, options, etc.)
+   - Settings that modify the way the C code is generated
+
+   We are not interested by compile time defines from config.h that only
+   modify the code of cobc, but have no impact on its runtime behavior.
+   */
+
 STRING_SETTING (
 "executable name for module runner",
  COBCRUN_NAME )
@@ -65,7 +73,12 @@ STRING_SETTING (
 "strip command",
  COB_STRIP_CMD )
 
-/* just to test BOOL_SETTING */
+STRING_SETTING (
+"need keyword for inline",
+ COB_INLINE_KEYWORD )
+
+
+
 
 BOOL_SETTING (
 "has __attribute__((aligned))",
@@ -118,6 +131,14 @@ BOOL_SETTING (
 BOOL_SETTING (
 "Support for non aligned structures",
  COB_NON_ALIGNED )
+
+BOOL_SETTING (
+"XOPEN_SOURCE_EXTENDED is needed",
+ XOPEN_SOURCE_EXTENDED )
+
+BOOL_SETTING (
+"set to 1 if your processor stores words with the most significant byte first (like Motorola and SPARC, unlike Intel).",
+ WORDS_BIGENDIAN )
 
 
 

--- a/cobc/settings.def
+++ b/cobc/settings.def
@@ -1,0 +1,621 @@
+
+STRING_SETTING (
+"executable name for module runner",
+ COBCRUN_NAME )
+
+STRING_SETTING (
+"compiler used by cobc",
+ COB_CC )
+
+STRING_SETTING (
+"compiler flags passed to compiler by cobc",
+ COB_CFLAGS )
+
+STRING_SETTING (
+"default search path for copybooks",
+ COB_CONFIG_DIR )
+
+STRING_SETTING (
+"default search path for configuration files",
+ COB_COPY_DIR )
+
+STRING_SETTING (
+"Compile/link option for debugging",
+ COB_DEBUG_FLAGS )
+
+STRING_SETTING (
+"executable extension",
+COB_EXE_EXT )
+
+STRING_SETTING (
+"compile/link option for exporting symbols",
+ COB_EXPORT_DYN )
+
+/* check done until here */
+
+STRING_SETTING (
+"linker flags passed to linker by cobc",
+ COB_LDFLAGS )
+
+STRING_SETTING (
+"default search path for extra modules",
+ COB_LIBRARY_PATH )
+
+STRING_SETTING (
+"libraries passed to linker by cobc",
+ COB_LIBS )
+
+STRING_SETTING (
+"module extension",
+ COB_MODULE_EXT )
+
+STRING_SETTING (
+"object extension",
+ COB_OBJECT_EXT )
+
+STRING_SETTING (
+"compile/link option for PIC code",
+ COB_PIC_FLAGS )
+
+STRING_SETTING (
+"compile/link option for shared code",
+ COB_SHARED_OPT )
+
+STRING_SETTING (
+"strip command",
+ COB_STRIP_CMD )
+
+/* just to test BOOL_SETTING */
+
+BOOL_SETTING (
+"has __attribute__((aligned))",
+HAVE_ATTRIBUTE_ALIGNED )
+
+BOOL_SETTING (
+"has __attribute__((constructor))",
+ HAVE_ATTRIBUTE_CONSTRUCTOR )
+
+BOOL_SETTING (
+"compute paths relative to compiler binary path",
+COBC_IS_RELOCATABLE )
+
+BOOL_SETTING (
+"define to 1 if you have the <gmp.h> header file.",
+ HAVE_GMP_H )
+
+BOOL_SETTING (
+"define to 1 if you have the <mpir.h> header file.",
+ HAVE_MPIR_H )
+
+BOOL_SETTING (
+"code is expected to run on Windows platforms",
+ WIN32 )
+
+BOOL_SETTING (
+"code is expected to run on Cygwin",
+ CYGWIN )
+
+BOOL_SETTING (
+"use Microsoft C Compiler",
+MSC_VER )
+
+BOOL_SETTING (
+"use Borland C Compiler",
+BORLANDC )
+
+BOOL_SETTING (
+"use Watcom C Compiler",
+WATCOMC )
+
+BOOL_SETTING (
+"compiler is Clang based",
+ CLANG )
+
+BOOL_SETTING (
+"arch is arm",
+ ARM )
+
+BOOL_SETTING (
+"Support for non aligned structures",
+ COB_NON_ALIGNED )
+
+
+
+#if 0
+
+/* long int is 32 bits */
+/* #undef COB_32_BIT_LONG */
+
+/* Pointers are longer than 32 bits */
+#define COB_64_BIT_POINTER 1
+
+/* Compilation of computed gotos works */
+#define COB_COMPUTED_GOTO 1
+
+/* Enable internal logging (Developers only!) */
+/* #undef COB_DEBUG_LOG */
+
+/* Enable experimental code (Developers only!) */
+/* #undef COB_EXPERIMENTAL */
+
+/* Keyword for inline */
+#define COB_KEYWORD_INLINE __inline
+
+/* long int is long long */
+#define COB_LI_IS_LL 1
+
+/* Can not dlopen self */
+/* #undef COB_NO_SELFOPEN */
+
+/* Enable minimum parameter check for system libraries */
+/* #undef COB_PARAM_CHECK */
+
+/* Enable extra checks within the compiler (Developers only!) */
+#define COB_TREE_DEBUG 1
+
+/* Define to 1 if translation of program messages to the user's native
+   language is requested. */
+#define ENABLE_NLS 1
+
+/* Has __attribute__((aligned)) */
+#define HAVE_ATTRIBUTE_ALIGNED 1
+
+/* Has __attribute__((pure)) */
+#define HAVE_ATTRIBUTE_PURE 1
+
+/* Define to 1 if you have the `canonicalize_file_name' function. */
+#define HAVE_CANONICALIZE_FILE_NAME 1
+
+/* Define to 1 if you have the Mac OS X function
+   CFLocaleCopyPreferredLanguages in the CoreFoundation framework. */
+/* #undef HAVE_CFLOCALECOPYPREFERREDLANGUAGES */
+
+/* Define to 1 if you have the Mac OS X function CFPreferencesCopyAppValue in
+   the CoreFoundation framework. */
+/* #undef HAVE_CFPREFERENCESCOPYAPPVALUE */
+
+/* Define to 1 if you have the <cjson/cJSON.h> header file. */
+/* #undef HAVE_CJSON_CJSON_H */
+
+/* Define to 1 if you have the <cJSON.h> header file. */
+#define HAVE_CJSON_H 1
+
+/* Has clock_gettime function and CLOCK_REALTIME */
+#define HAVE_CLOCK_GETTIME 1
+
+/* curses has color_set function */
+#define HAVE_COLOR_SET 1
+
+/* curses provides function to free all memory */
+#define HAVE_CURSES_FREEALL 1
+
+/* Define to 1 if you have the <curses.h> header file. */
+/* #undef HAVE_CURSES_H */
+
+/* Define to 1 if you have the <db.h> header file. */
+#define HAVE_DB_H 1
+
+/* Define if the GNU dcgettext() function is already present or preinstalled.
+   */
+#define HAVE_DCGETTEXT 1
+
+/* Define to 1 if you have the declaration of `fdatasync', and to 0 if you
+   don't. */
+#define HAVE_DECL_FDATASYNC 1
+
+/* Define to 1 if you have the declaration of `fmemopen', and to 0 if you
+   don't. */
+#define HAVE_DECL_FMEMOPEN 1
+
+/* curses has define_key function */
+#define HAVE_DEFINE_KEY 1
+
+/* Has designated initializers */
+#define HAVE_DESIGNATED_INITS 1
+
+/* Define to 1 if you have the <disam.h> header file. */
+/* #undef HAVE_DISAM_H */
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+#define HAVE_DLFCN_H 1
+
+/* Define to 1 if you don't have `vprintf' but do have `_doprnt.' */
+/* #undef HAVE_DOPRNT */
+
+/* Define to 1 if you have the `fcntl' function. */
+#define HAVE_FCNTL 1
+
+/* Define to 1 if you have the <fcntl.h> header file. */
+#define HAVE_FCNTL_H 1
+
+/* Define to 1 if you have the `fdatasync' function. */
+#define HAVE_FDATASYNC 1
+
+/* Declaration of finite function in ieeefp.h instead of math.h */
+/* #undef HAVE_FINITE_IEEEFP_H */
+
+/* Define to 1 if you have the `flockfile' function. */
+#define HAVE_FLOCKFILE 1
+
+/* Define to 1 if you have the `fmemopen' function. */
+#define HAVE_FMEMOPEN 1
+
+/* Define to 1 if you have the `getexecname' function. */
+/* #undef HAVE_GETEXECNAME */
+
+/* Define if the GNU gettext() function is already present or preinstalled. */
+#define HAVE_GETTEXT 1
+
+/* Define to 1 if you have the `gettimeofday' function. */
+#define HAVE_GETTIMEOFDAY 1
+
+/* curses has has_mouse function */
+#define HAVE_HAS_MOUSE 1
+
+/* Define if you have the iconv() function and it works. */
+/* #undef HAVE_ICONV */
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#define HAVE_INTTYPES_H 1
+
+/* Define to 1 if you have the <isam.h> header file. */
+/* #undef HAVE_ISAM_H */
+
+/* Has isfinite function */
+#define HAVE_ISFINITE 1
+
+/* Define to 1 if you have the <json-c/json.h> header file. */
+/* #undef HAVE_JSON_C_JSON_H */
+
+/* Define to 1 if you have the <json.h> header file. */
+/* #undef HAVE_JSON_H */
+
+/* Define if you have <langinfo.h> and nl_langinfo(CODESET). */
+#define HAVE_LANGINFO_CODESET 1
+
+/* Define to 1 if you have the `posix4' library (-lposix4). */
+/* #undef HAVE_LIBPOSIX4 */
+
+/* Define to 1 if you have the `rt' library (-lrt). */
+/* #undef HAVE_LIBRT */
+
+/* Define to 1 if you have the `localeconv' function. */
+#define HAVE_LOCALECONV 1
+
+/* Define to 1 if you have the <locale.h> header file. */
+#define HAVE_LOCALE_H 1
+
+/* Define to 1 if you have the <ltdl.h> header file. */
+/* #undef HAVE_LTDL_H */
+
+/* Define to 1 if you have the `memmove' function. */
+#define HAVE_MEMMOVE 1
+
+/* Define to 1 if you have the `memset' function. */
+#define HAVE_MEMSET 1
+
+/* Define to 1 if you have the <minix/config.h> header file. */
+/* #undef HAVE_MINIX_CONFIG_H */
+
+/* curses has mouseinterval function */
+#define HAVE_MOUSEINTERVAL 1
+
+/* curses has mousemask function and mmask_t definition */
+#define HAVE_MOUSEMASK 1
+
+/* Do we have mp_get_memory_functions in GMP/MPIR */
+#define HAVE_MP_GET_MEMORY_FUNCTIONS 1
+
+/* Has nanosleep function */
+#define HAVE_NANO_SLEEP 1
+
+/* Define to 1 if you have the <ncursesw/curses.h> header file. */
+/* #undef HAVE_NCURSESW_CURSES_H */
+
+/* Define to 1 if you have the <ncursesw/ncurses.h> header file. */
+#define HAVE_NCURSESW_NCURSES_H 1
+
+/* Define to 1 if you have the <ncurses/curses.h> header file. */
+/* #undef HAVE_NCURSES_CURSES_H */
+
+/* Define to 1 if you have the <ncurses.h> header file. */
+/* #undef HAVE_NCURSES_H */
+
+/* Define to 1 if you have the <ncurses/ncurses.h> header file. */
+/* #undef HAVE_NCURSES_NCURSES_H */
+
+/* Define to 1 if you have the <pdcurses.h> header file. */
+/* #undef HAVE_PDCURSES_H */
+
+/* Define to 1 if you have the `popen' function. */
+#define HAVE_POPEN 1
+
+/* Define to 1 if you have the `raise' function. */
+#define HAVE_RAISE 1
+
+/* Define to 1 if you have the `readlink' function. */
+#define HAVE_READLINK 1
+
+/* Define to 1 if you have the `realpath' function. */
+#define HAVE_REALPATH 1
+
+/* curses has resize_term function */
+#define HAVE_RESIZE_TERM 1
+
+/* Define to 1 if you have the `setenv' function. */
+#define HAVE_SETENV 1
+
+/* Define to 1 if you have the `setlocale' function. */
+#define HAVE_SETLOCALE 1
+
+/* Define to 1 if you have the `sigaction' function. */
+#define HAVE_SIGACTION 1
+
+/* Define to 1 if you have the <signal.h> header file. */
+#define HAVE_SIGNAL_H 1
+
+/* Define to 1 if the system has the type `sig_atomic_t'. */
+#define HAVE_SIG_ATOMIC_T 1
+
+/* Define to 1 if you have the <stddef.h> header file. */
+#define HAVE_STDDEF_H 1
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#define HAVE_STDINT_H 1
+
+/* Define to 1 if you have the <stdio.h> header file. */
+#define HAVE_STDIO_H 1
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#define HAVE_STDLIB_H 1
+
+/* Define to 1 if you have the `strcasecmp' function. */
+#define HAVE_STRCASECMP 1
+
+/* Define to 1 if you have the `strchr' function. */
+#define HAVE_STRCHR 1
+
+/* Define to 1 if you have the `strcoll' function. */
+#define HAVE_STRCOLL 1
+
+/* Define to 1 if you have the `strdup' function. */
+#define HAVE_STRDUP 1
+
+/* Define to 1 if you have the `strerror' function. */
+#define HAVE_STRERROR 1
+
+/* Define to 1 if you have the <strings.h> header file. */
+#define HAVE_STRINGS_H 1
+
+/* Define to 1 if you have the <string.h> header file. */
+#define HAVE_STRING_H 1
+
+/* Define to 1 if you have the `strrchr' function. */
+#define HAVE_STRRCHR 1
+
+/* Define to 1 if you have the `strstr' function. */
+#define HAVE_STRSTR 1
+
+/* Define to 1 if you have the `strtol' function. */
+#define HAVE_STRTOL 1
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#define HAVE_SYS_STAT_H 1
+
+/* Define to 1 if you have the <sys/time.h> header file. */
+#define HAVE_SYS_TIME_H 1
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#define HAVE_SYS_TYPES_H 1
+
+/* Has timezone variable */
+#define HAVE_TIMEZONE 1
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#define HAVE_UNISTD_H 1
+
+/* ncurses has use_legacy_coding function */
+#define HAVE_USE_LEGACY_CODING 1
+
+/* Define to 1 if you have the <vbisam.h> header file. */
+/* #undef HAVE_VBISAM_H */
+
+/* Define to 1 if you have the `vprintf' function. */
+#define HAVE_VPRINTF 1
+
+/* Define to 1 if you have the <wchar.h> header file. */
+#define HAVE_WCHAR_H 1
+
+/* Define to 1 if you have the <xcurses/curses.h> header file. */
+/* #undef HAVE_XCURSES_CURSES_H */
+
+/* Define to 1 if you have the <xcurses.h> header file. */
+/* #undef HAVE_XCURSES_H */
+
+/* Define to the sub-directory where libtool stores uninstalled libraries. */
+#define LT_OBJDIR ".libs/"
+
+/* Define maximum parameters for CALL */
+#define MAX_CALL_FIELD_PARAMS 192
+
+/* Define a patch level (numeric, max. 8 digits) */
+#define PATCH_LEVEL 0
+
+/* The size of `long', as computed by sizeof. */
+#define SIZEOF_LONG 8
+
+/* The size of `long int', as computed by sizeof. */
+#define SIZEOF_LONG_INT 8
+
+/* The size of `long long', as computed by sizeof. */
+#define SIZEOF_LONG_LONG 8
+
+/* The size of `void *', as computed by sizeof. */
+#define SIZEOF_VOID_P 8
+
+/* Define to 1 if all of the C90 standard headers exist (not just the ones
+   required in a freestanding environment). This macro is provided for
+   backward compatibility; new code need not use it. */
+#define STDC_HEADERS 1
+
+/* Define to 1 if your <sys/time.h> declares `struct tm'. */
+/* #undef TM_IN_SYS_TIME */
+
+/* Use system dynamic loader */
+#define USE_LIBDL 1
+
+/* Enable extensions on AIX 3, Interix.  */
+#ifndef _ALL_SOURCE
+# define _ALL_SOURCE 1
+#endif
+/* Enable general extensions on macOS.  */
+#ifndef _DARWIN_C_SOURCE
+# define _DARWIN_C_SOURCE 1
+#endif
+/* Enable general extensions on Solaris.  */
+#ifndef __EXTENSIONS__
+# define __EXTENSIONS__ 1
+#endif
+/* Enable GNU extensions on systems that have them.  */
+#ifndef _GNU_SOURCE
+# define _GNU_SOURCE 1
+#endif
+/* Enable X/Open compliant socket functions that do not require linking
+   with -lxnet on HP-UX 11.11.  */
+#ifndef _HPUX_ALT_XOPEN_SOCKET_API
+# define _HPUX_ALT_XOPEN_SOCKET_API 1
+#endif
+/* Identify the host operating system as Minix.
+   This macro does not affect the system headers' behavior.
+   A future release of Autoconf may stop defining this macro.  */
+#ifndef _MINIX
+/* # undef _MINIX */
+#endif
+/* Enable general extensions on NetBSD.
+   Enable NetBSD compatibility extensions on Minix.  */
+#ifndef _NETBSD_SOURCE
+# define _NETBSD_SOURCE 1
+#endif
+/* Enable OpenBSD compatibility extensions on NetBSD.
+   Oddly enough, this does nothing on OpenBSD.  */
+#ifndef _OPENBSD_SOURCE
+# define _OPENBSD_SOURCE 1
+#endif
+/* Define to 1 if needed for POSIX-compatible behavior.  */
+#ifndef _POSIX_SOURCE
+/* # undef _POSIX_SOURCE */
+#endif
+/* Define to 2 if needed for POSIX-compatible behavior.  */
+#ifndef _POSIX_1_SOURCE
+/* # undef _POSIX_1_SOURCE */
+#endif
+/* Enable POSIX-compatible threading on Solaris.  */
+#ifndef _POSIX_PTHREAD_SEMANTICS
+# define _POSIX_PTHREAD_SEMANTICS 1
+#endif
+/* Enable extensions specified by ISO/IEC TS 18661-5:2014.  */
+#ifndef __STDC_WANT_IEC_60559_ATTRIBS_EXT__
+# define __STDC_WANT_IEC_60559_ATTRIBS_EXT__ 1
+#endif
+/* Enable extensions specified by ISO/IEC TS 18661-1:2014.  */
+#ifndef __STDC_WANT_IEC_60559_BFP_EXT__
+# define __STDC_WANT_IEC_60559_BFP_EXT__ 1
+#endif
+/* Enable extensions specified by ISO/IEC TS 18661-2:2015.  */
+#ifndef __STDC_WANT_IEC_60559_DFP_EXT__
+# define __STDC_WANT_IEC_60559_DFP_EXT__ 1
+#endif
+/* Enable extensions specified by ISO/IEC TS 18661-4:2015.  */
+#ifndef __STDC_WANT_IEC_60559_FUNCS_EXT__
+# define __STDC_WANT_IEC_60559_FUNCS_EXT__ 1
+#endif
+/* Enable extensions specified by ISO/IEC TS 18661-3:2015.  */
+#ifndef __STDC_WANT_IEC_60559_TYPES_EXT__
+# define __STDC_WANT_IEC_60559_TYPES_EXT__ 1
+#endif
+/* Enable extensions specified by ISO/IEC TR 24731-2:2010.  */
+#ifndef __STDC_WANT_LIB_EXT2__
+# define __STDC_WANT_LIB_EXT2__ 1
+#endif
+/* Enable extensions specified by ISO/IEC 24747:2009.  */
+#ifndef __STDC_WANT_MATH_SPEC_FUNCS__
+# define __STDC_WANT_MATH_SPEC_FUNCS__ 1
+#endif
+/* Enable extensions on HP NonStop.  */
+#ifndef _TANDEM_SOURCE
+# define _TANDEM_SOURCE 1
+#endif
+/* Enable X/Open extensions.  Define to 500 only if necessary
+   to make mbstate_t available.  */
+#ifndef _XOPEN_SOURCE
+/* # undef _XOPEN_SOURCE */
+#endif
+
+
+/* Use CISAM as INDEXED handler */
+/* #undef WITH_CISAM */
+
+/* Use cJSON library/source as JSON handler */
+#define WITH_CJSON 1
+
+/* curses library for extended SCREEN I/O */
+#define WITH_CURSES "ncursesw"
+
+/* Use Berkeley DB library as INDEXED handler */
+#define WITH_DB 1
+
+/* Use DISAM as INDEXED handler */
+/* #undef WITH_DISAM */
+
+/* Compile with obsolete external INDEXED handler */
+/* #undef WITH_INDEX_EXTFH */
+
+/* JSON handler */
+#define WITH_JSON "cjson"
+
+/* Use JSON-C library as JSON handler */
+/* #undef WITH_JSON_C */
+
+/* Math multiple precision library */
+/* #undef WITH_MATH */
+
+/* Compile with obsolete external SEQ/RAN handler */
+/* #undef WITH_SEQRA_EXTFH */
+
+/* Define variable sequential file format */
+#define WITH_VARSEQ 0
+
+/* Use VBISAM as INDEXED handler */
+/* #undef WITH_VBISAM */
+
+/* Use libxml2 as XML handler */
+#define WITH_XML2 1
+
+/* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
+   significant byte first (like Motorola and SPARC, unlike Intel). */
+#if defined AC_APPLE_UNIVERSAL_BUILD
+# if defined __BIG_ENDIAN__
+#  define WORDS_BIGENDIAN 1
+# endif
+#else
+# ifndef WORDS_BIGENDIAN
+/* #  undef WORDS_BIGENDIAN */
+# endif
+#endif
+
+/* Define to 1 if `lex' declares `yytext' as a `char *' by default, not a
+   `char[]'. */
+#define YYTEXT_POINTER 1
+
+/* Define to 1 if on HPUX.  */
+#ifndef _XOPEN_SOURCE_EXTENDED
+/* # undef _XOPEN_SOURCE_EXTENDED */
+#endif
+
+/* Define to empty if `const' does not conform to ANSI C. */
+/* #undef const */
+
+/* Define to `unsigned int' if <sys/types.h> does not define. */
+/* #undef size_t */
+
+#endif

--- a/cobc/typeck.c
+++ b/cobc/typeck.c
@@ -551,18 +551,18 @@ cb_is_integer_field (struct cb_field *f)
 	if (f->usage == CB_USAGE_BINARY
 	 && cb_binary_truncate)
 		return 0;
-#ifdef WORDS_BIGENDIAN
-	if (f->usage != CB_USAGE_COMP_5
-	 && f->usage != CB_USAGE_DISPLAY
-	 && f->usage != CB_USAGE_BINARY
-	 && f->usage != CB_USAGE_COMP_X)
-		return 0;
-#else
-	if (f->usage != CB_USAGE_COMP_5
-	 && f->usage != CB_USAGE_BINARY
-	 && f->usage != CB_USAGE_DISPLAY)
-		return 0;
-#endif
+	if (cb_setting_WORDS_BIGENDIAN){
+		if (f->usage != CB_USAGE_COMP_5
+		    && f->usage != CB_USAGE_DISPLAY
+		    && f->usage != CB_USAGE_BINARY
+		    && f->usage != CB_USAGE_COMP_X)
+			return 0;
+	} else {
+		if (f->usage != CB_USAGE_COMP_5
+		    && f->usage != CB_USAGE_BINARY
+		    && f->usage != CB_USAGE_DISPLAY)
+			return 0;
+	}
 	if (f->storage == CB_STORAGE_WORKING
 #ifdef	COB_SHORT_BORK
 	 && (f->size == 4 || f->size == 8 || f->size == 1)

--- a/configure.ac
+++ b/configure.ac
@@ -134,6 +134,7 @@ AC_DEFINE_UNQUOTED([PACKAGE], ["$PACKAGE"], [Name of package])  # used for bindt
 dnl Autoheader templates
 AH_TEMPLATE([COB_DEBUG_LOG], [Enable internal logging (Developers only!)])
 AH_TEMPLATE([COB_EXPERIMENTAL], [Enable experimental code (Developers only!)])
+AH_TEMPLATE([COBC_IS_RELOCATABLE], [Enable path relocation from binary path])
 AH_TEMPLATE([COB_TREE_DEBUG], [Enable extra checks within the compiler (Developers only!)])
 AH_TEMPLATE([COB_PARAM_CHECK], [Enable minimum parameter check for system libraries])
 AH_TEMPLATE([PATCH_LEVEL], [Define a patch level (numeric, max. 8 digits)])
@@ -216,6 +217,14 @@ AC_ARG_ENABLE([experimental],
     [(GnuCOBOL) Enable experimental code (Developers only!)])],
   [if test "$enable_experimental" = yes; then
 	AC_DEFINE([COB_EXPERIMENTAL], [1])
+   fi],
+  [])
+
+AC_ARG_ENABLE([relocatable],
+  [AS_HELP_STRING([--enable-relocatable],
+    [(GnuCOBOL) Enable relocation of paths from binary location])],
+  [if test "$enable_relocatable" = yes; then
+	AC_DEFINE([COBC_IS_RELOCATABLE], [1])
    fi],
   [])
 


### PR DESCRIPTION
New --settings=FILE can be used to configure flags that are normally set at compile time. These settings can be used typically to create cross-compilers by retargetting an existing compiler.

Also add a setting to make the compiler relocatable, i.e. compute paths of include, share, etc. relative to cobc's location.