### PR TITLE
Small fixes from profiling PR

### DIFF
--- a/cobc/ChangeLog
+++ b/cobc/ChangeLog
@@ -1,4 +1,10 @@
 
+2023-11-29  Fabrice Le Fessant <fabrice.le_fessant@ocamlpro.com>
+
+	* cobc.c (cobc_clean_up): when save-temps specifies a directory,
+	  do not move object files and preprocess files when they were
+	  specified as an explicit target on the command line (-E, -c)
+
 2023-07-26  Simon Sobisch <simonsobisch@gnu.org>
 
 	* typeck.c (search_set_keys): improving SEARCH ALL syntax checks

--- a/cobc/cobc.c
+++ b/cobc/cobc.c
@@ -2180,7 +2180,8 @@ clean_up_intermediates (struct filename *fn, const int status)
 	if (fn->need_preprocess
 	 && (status
 		||  cb_compile_level > CB_LEVEL_PREPROCESS
-		|| (cb_compile_level == CB_LEVEL_PREPROCESS && save_temps))) {
+		|| (cb_compile_level == CB_LEVEL_PREPROCESS
+		    && save_temps && !save_temps_dir))) {
 		cobc_check_action (fn->preprocess);
 	}
 	/* CHECKME: we had reports of unexpected intermediate
@@ -2287,7 +2288,8 @@ cobc_clean_up (const int status)
 		if (fn->need_assemble
 		 && (status
 			||  cb_compile_level > CB_LEVEL_ASSEMBLE
-			|| (cb_compile_level == CB_LEVEL_ASSEMBLE && save_temps))) {
+			|| (cb_compile_level == CB_LEVEL_ASSEMBLE
+			    && save_temps && !save_temps_dir))) {
 			cobc_check_action (fn->object);
 		}
 		clean_up_intermediates (fn, status);

--- a/libcob/ChangeLog
+++ b/libcob/ChangeLog
@@ -2,6 +2,7 @@
 2023-11-29  Fabrice Le Fessant <fabrice.le_fessant@ocamlpro.com>
 
 	* common.c (cob_get_strerror), coblocal.h: export as utility function
+	* common.c (cob_expand_env_string): fix potention buffer overflow
 
 2023-07-28  Simon Sobisch <simonsobisch@gnu.org>
 

--- a/libcob/ChangeLog
+++ b/libcob/ChangeLog
@@ -1,8 +1,7 @@
 
 2023-11-29  Fabrice Le Fessant <fabrice.le_fessant@ocamlpro.com>
 
-	* common.h/common.c: export "cob_get_strerror" as a public function
-	* coblocal.h: include "config.h"
+	* coblocal.h, common.c: export "cob_get_strerror" as a public function
 
 2023-07-28  Simon Sobisch <simonsobisch@gnu.org>
 

--- a/libcob/ChangeLog
+++ b/libcob/ChangeLog
@@ -1,4 +1,9 @@
 
+2023-11-29  Fabrice Le Fessant <fabrice.le_fessant@ocamlpro.com>
+
+	* common.h/common.c: export "cob_get_strerror" as a public function
+	* coblocal.h: include "config.h"
+
 2023-07-28  Simon Sobisch <simonsobisch@gnu.org>
 
 	* screenio.c, common.c: replace use of NCURSES_MOUSE_VERSION by

--- a/libcob/ChangeLog
+++ b/libcob/ChangeLog
@@ -1,7 +1,7 @@
 
 2023-11-29  Fabrice Le Fessant <fabrice.le_fessant@ocamlpro.com>
 
-	* coblocal.h, common.c: export "cob_get_strerror" as a public function
+	* common.c (cob_get_strerror), coblocal.h: export as utility function
 
 2023-07-28  Simon Sobisch <simonsobisch@gnu.org>
 

--- a/libcob/coblocal.h
+++ b/libcob/coblocal.h
@@ -487,6 +487,7 @@ COB_HIDDEN int		cob_check_env_true	(char*);
 COB_HIDDEN int		cob_check_env_false	(char*);
 COB_HIDDEN const char	*cob_get_last_exception_name	(void);
 COB_HIDDEN void		cob_parameter_check	(const char *, const int);
+COB_HIDDEN char*        cob_get_strerror (void);
 
 enum cob_case_modifier {
 	CCM_NONE,

--- a/libcob/common.c
+++ b/libcob/common.c
@@ -907,7 +907,7 @@ cob_get_source_line ()
 }
 
 /* reentrant version of strerror */
-static char *
+char *
 cob_get_strerror (void)
 {
 	size_t size;

--- a/libcob/common.c
+++ b/libcob/common.c
@@ -7785,9 +7785,10 @@ cob_expand_env_string (char *strval)
 				}
 			}
 			if (penv != NULL) {
-				if ((strlen (penv) + j) > (envlen - 128)) {
-					env = cob_realloc (env, envlen, strlen (penv) + 256);
-					envlen = strlen (penv) + 256;
+				size_t copy_len = strlen (penv);
+				if (copy_len + j + 128 > envlen) {
+					env = cob_realloc (env, envlen, j + copy_len + 256);
+					envlen = j + copy_len + 256;
 				}
 				j += sprintf (&env[j], "%s", penv);
 				penv = NULL;

--- a/tests/testsuite.src/used_binaries.at
+++ b/tests/testsuite.src/used_binaries.at
@@ -424,6 +424,68 @@ AT_CHECK([$COBCRUN_DIRECT ./prog], [0], [OK], [])
 AT_CLEANUP
 
 
+AT_SETUP([save-temps in sub-directory])
+AT_KEYWORDS([runmisc])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      prog.
+       PROCEDURE        DIVISION.
+           DISPLAY "OK" NO ADVANCING
+           END-DISPLAY.
+           EXIT PROGRAM.
+])
+
+AT_CHECK([mkdir debug])
+
+AT_CHECK([$COMPILE -save-temps=debug -o prog.exe prog.cob])
+AT_CHECK([$COBCRUN_DIRECT ./prog.exe], [0], [OK])
+AT_CHECK([test -f debug/prog.$COB_OBJECT_EXT])
+AT_CHECK([test -f debug/prog.c])
+AT_CHECK([test -f debug/prog.s], [1])
+AT_CHECK([test -f debug/prog.i])
+AT_CHECK([test -f debug/prog.c.h])
+AT_CHECK([test -f debug/prog.c.l.h])
+
+# Check with -c
+
+AT_CHECK([test -f prog.$COB_OBJECT_EXT], [1])
+AT_CHECK([$COMPILE -save-temps=debug -c prog.cob])
+AT_CHECK([test -f prog.$COB_OBJECT_EXT])
+AT_CHECK([$COMPILE -save-temps=debug -c -o program.$COB_OBJECT_EXT prog.cob])
+AT_CHECK([test -f program.$COB_OBJECT_EXT])
+
+# Check with -S
+
+AT_CHECK([test -f prog.s], [1])
+AT_CHECK([$COMPILE -save-temps=debug -S prog.cob])
+AT_CHECK([test -f prog.s])
+AT_CHECK([$COMPILE -save-temps=debug -S -o program.s prog.cob])
+AT_CHECK([test -f program.s])
+
+# Check with -C
+
+AT_CHECK([test -f prog.c], [1])
+AT_CHECK([$COMPILE -save-temps=debug -C prog.cob])
+AT_CHECK([test -f prog.c])
+AT_CHECK([test -f prog.c.h])
+AT_CHECK([test -f prog.c.l.h])
+AT_CHECK([$COMPILE -save-temps=debug -C -o program.c prog.cob])
+AT_CHECK([test -f program.c])
+AT_CHECK([test -f program.c.h])
+AT_CHECK([test -f program.c.l.h])
+
+# Check with -E
+
+AT_CHECK([test -f prog.i], [1])
+AT_CHECK([$COMPILE -save-temps=debug -E -o prog.i prog.cob])
+AT_CHECK([test -f prog.i])
+AT_CHECK([$COMPILE -save-temps=debug -E -o program.i prog.cob])
+AT_CHECK([test -f program.i])
+
+AT_CLEANUP
+
+
 AT_SETUP([C Compiler optimizations])
 AT_KEYWORDS([runmisc cobc optimization])
 


### PR DESCRIPTION
Do not move object files if they were specified as an explicit target on the command line (typically `cobc -c --save-temps=DIR -o foo.o foo.cob` should keep `foo.o` in the current directory)