### PR TITLE
Fix testsuite 8 on Windows/MSYS2

### DIFF
--- a/tests/testsuite.src/used_binaries.at
+++ b/tests/testsuite.src/used_binaries.at
@@ -396,11 +396,16 @@ AT_DATA([prog.cob], [
            EXIT PROGRAM.
 ])
 
-AT_CHECK([TMPDIR="" TMP="notthere" TEMP="" $COMPILE prog.cob], [0], [],
+# Note: on Windows, GCC/MinGW randomly fails when it can't access the temporary directory,
+# so we only perform the COBOL-to-C translation. This is sufficient since the error we want
+# to check is a compile-time error. Note that we nevertheless perform a full compilation
+# afterwards, without tweaking the temporary, so that we can test the actual execution.
+AT_CHECK([TMPDIR="" TMP="notthere" TEMP="" $COMPILE_ONLY prog.cob], [0], [],
 [libcob: warning: Temporary directory TMP is invalid, adjust TMPDIR!
 ])
+AT_CHECK([$COMPILE prog.cob], [0], [], [])
 AT_CHECK([$COBCRUN_DIRECT ./prog], [0], [OK], [])
-AT_CHECK([TMPDIR="" TMP="" TEMP="./prog.cob" $COMPILE prog.cob], [0], [],
+AT_CHECK([TMPDIR="" TMP="" TEMP="./prog.cob" $COMPILE_ONLY prog.cob], [0], [],
 [libcob: warning: Temporary directory TEMP is invalid, adjust TMPDIR!
 ])
 # TMPDIR is only checked when actually needed which is currently only the case


### PR DESCRIPTION
EDIT: fixes for 808 and 809 already merged

This fixes tests number 8, 808 and 809 on Windows with MSYS2.

Test 8 fails randomly during the call to gcc, as it tries to access the temporary directory.
Since the objective of this test is to check the compilation behavior when tweaking TMP/TEMP/TMPDIR, I resorted to a workaround: I simply replaced $COMPILE by $COMPILE_ONLY.

As for tests 808 and 809, they fail because of differences in the way paths are shown on Windows VS Unix. Since the expected output uses relative Unix-style paths, I used sed to pre-process the output to remove any absolue Windows-style prefix and replace them with ./.

The only remaining failing test, 771, is a bit more tricky ; it will be handled separately.