### PR TITLE
[WIP] Backport GC4 new dump feature tu GC3

### DIFF
--- a/cobc/cobc.c
+++ b/cobc/cobc.c
@@ -2788,6 +2788,8 @@ cobc_def_dump_opts (const char *opt, const int on)
 		} else {
 			cb_flag_dump = COB_DUMP_NONE;
 		}
+		if (cb_flag_dump)
+			cb_flag_symbols = 1;
 		return;
 	}
 
@@ -2823,6 +2825,8 @@ cobc_def_dump_opts (const char *opt, const int on)
 	} else {
 		cb_flag_dump ^= dump_to_set;
 	}
+	if (cb_flag_dump)
+		cb_flag_symbols = 1;
 	cobc_free (p);
 }
 
@@ -3256,6 +3260,7 @@ process_command_line (const int argc, char **argv)
 			cb_flag_c_line_directives = 1;
 			cb_flag_c_labels = 1;
 #endif
+			cb_flag_symbols = 1;
 #ifdef COB_DEBUG_FLAGS
 			COBC_ADD_STR (cobc_cflags, " ", cobc_debug_flags, NULL);
 #endif
@@ -3267,6 +3272,7 @@ process_command_line (const int argc, char **argv)
 			cb_flag_stack_extended = 1;
 			cb_flag_stack_check = 1;
 			cb_flag_memory_check = CB_MEMCHK_ALL;
+			cb_flag_symbols = 1;
 			cobc_wants_debug = 1;
 			break;
 
@@ -4197,6 +4203,9 @@ process_command_line (const int argc, char **argv)
 	if (cb_flag_traceall) {
 		cb_flag_trace = 1;
 		cb_flag_source_location = 1;
+	}
+	if (cb_flag_trace) {
+		cb_flag_symbols = 1;
 	}
 
 	/* If C debug, never strip output */
@@ -8937,6 +8946,8 @@ finish_setup_compiler_env (void)
 
 	if (getenv ("COBC_GEN_DUMP_COMMENTS")) {
 		cb_wants_dump_comments = 1;
+		/* Disable "new" symbol table if requesting dump comments */
+		cb_flag_symbols = 0;
 	}
 }
 

--- a/cobc/cobc.h
+++ b/cobc/cobc.h
@@ -426,16 +426,6 @@ extern int			cb_ml_tree_id;
 extern int			cb_flag_functions_all;
 
 extern int			cb_flag_dump;
-#define COB_DUMP_NONE	0x0000	/* No dump */
-#define COB_DUMP_FD	0x0001	/* FILE SECTION -> FILE DESCRIPTION */
-#define COB_DUMP_WS	0x0002  /* WORKING-STORAGE SECTION */
-#define COB_DUMP_RD	0x0004	/* REPORT SECTION */
-#define COB_DUMP_SD	0x0008	/* FILE SECTION -> SORT DESCRIPTION */
-#define COB_DUMP_SC	0x0010	/* SCREEN SECTION */
-#define COB_DUMP_LS	0x0020  /* LINKAGE SECTION */
-#define COB_DUMP_LO	0x0040  /* LOCAL-STORAGE SECTION */
-#define COB_DUMP_ALL	(COB_DUMP_FD|COB_DUMP_WS|COB_DUMP_RD|COB_DUMP_SD|COB_DUMP_SC|COB_DUMP_LS|COB_DUMP_LO)
-
 
 extern int			cb_unix_lf;
 

--- a/cobc/flag.def
+++ b/cobc/flag.def
@@ -143,6 +143,9 @@ CB_FLAG (cb_flag_traceall, 1, "traceall",
 	_("  -ftraceall            generate trace code\n"
 	  "                        * scope: executed SECTION/PARAGRAPH/STATEMENTS"))
 
+CB_FLAG (cb_flag_symbols, 1, "symtab",
+	_("  -fsymtab              build symbol table for dump/trace/debug"))
+
 CB_FLAG (cb_flag_syntax_only, 1, "syntax-only",
 	_("  -fsyntax-only         syntax error checking only; don't emit any output"))
 

--- a/cobc/tree.h
+++ b/cobc/tree.h
@@ -933,6 +933,8 @@ struct cb_field {
 	enum cb_storage		storage;	/* Storage section */
 	enum cb_usage		usage;		/* USAGE */
 
+	unsigned int  symtab;			/* Position in cob_symbol table */
+
 	/* Flags */
 	unsigned char flag_base;		/* Has memory allocation */
 	unsigned char flag_external;		/* EXTERNAL */
@@ -991,6 +993,8 @@ struct cb_field {
 	unsigned int flag_sync_left : 1;	/* SYNCHRONIZED LEFT */
 	unsigned int flag_sync_right : 1;	/* SYNCHRONIZED RIGHT */
 	unsigned int flag_internal_register	: 1;	/* Is an internally generated register */
+	unsigned int flag_sym_emitted: 1;	/* cob_symbol was emitted */
+	unsigned int flag_cob_field	: 1;	/* Had cob_field emitted */
 	unsigned int flag_is_typedef : 1;	/* TYPEDEF  */
 	unsigned int flag_picture_l : 1;	/* Is USAGE PICTURE L */
 	unsigned int flag_comp_1	: 1;	/* Is USAGE COMP-1 */


### PR DESCRIPTION
Following #130 , attempt to backport the dump / symtab feature from GC4 to GC3.

"Mostly" works, but breaks 25 tests, mainly due to subtle divergences betwen the GC3 and GC4 branches.
I could fix some. For others, I'm not sure about the right way to fix them.
Here are a few of the problematic ones and my observations.

```
990: FUNCTION BYTE-LENGTH
1030: FUNCTION LENGTH
```
Generates invalid C: missing field variable. This is due to the fact that GC3 inlines calls to LENGTH on fields with a NATIONAL category while GC4 does not inline them, preventing the generation of the field in the C code. Note that LENGTH of fields with an ALPHANUMERIC category are also inlined but do not suffer for this problem, possibly because of the field initialization code (I suppose because `initialize_uniform_char` is defined for ALPHANUMERIC but not NATIONAL).

```
679: LOCAL-STORAGE (3)
```
Generates invalid C: storing the address of a non-static index variable into a static variable. This is due to a fix (bug 794) in GC3, which allowed the index type to be either `CB_INT_INDEX` or `CB_STATIC_INT_INDEX` (see `parser.y:occurs_index`). In GC4, it is always `CB_STATIC_INT_INDEX` thus we never run into problems.

```
1163: System routine C$NARG
```
Generates invalid C : storing the address of a non-static variable into a static variable. This is due to a different handling of procedure parameters (USING...) between GC3 and GC4. In GC3, the C function generated for a procedure with parameters has the field passed as arguments, while in GC4 these parameters are stored in (static) field in the local storage.

```
808: stack and dump feature
809: dump feature with NULL address
```
Divergence in the ouput, probably because the old and new dumps don't do *exactly* the same thing. I yet have to investigate more into this.

