### PR TITLE
Add support for collating sequences on indexed files

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -10,6 +10,9 @@ NEWS - user visible changes				-*- outline -*-
    the error output for format errors (for example invalid indicator column)
    is now limitted to 5 per source file
 
+** support the COLLATING SEQUENCE clause on indexed files
+   (currently only with the BDB backend)
+
   more work in progress
 
 * Important Bugfixes
@@ -40,6 +43,9 @@ NEWS - user visible changes				-*- outline -*-
    a file for diagnostics; this flag can be activated if your editor and
    build system do not correctly work together to locate files from
    diagnostic output
+
+** New option -fdefault-file-colseq to specify the default
+   file collating sequence
 
 * More notable changes
 

--- a/cobc/ChangeLog
+++ b/cobc/ChangeLog
@@ -1,4 +1,17 @@
 
+2024-01-25  David Declerck <david.declerck@ocamlpro.com>
+
+	FR #459: support COLLATING SEQUENCE clause on SELECT / INDEXED files
+	* codegen.c (output_file_initialization): output the indexed
+	  file/keys collating sequence (were already present in the AST)
+	* tree.c (validate_indexed_key_field): process postponed
+	  key collating sequences
+	* parser.y (collating_sequence_clause, collating_sequence_clause_key):
+	  replace CB_PENDING by CB_UNFINISHED on file and key collating sequence
+	* flag.def, tree.c, tree.h, cobc.c, parser.y: add and handle a new
+	  -fdefault-file-colseq flag to specify the default collating
+	  sequence to use for files without a collating sequence clause
+
 2023-10-12  Fabrice Le Fessant <fabrice.le_fessant@ocamlpro.com>
 
 	* cobc.c, codegen.c: new option --include FILE, to #include

--- a/cobc/cobc.c
+++ b/cobc/cobc.c
@@ -90,24 +90,25 @@ enum compile_level {
 	CB_LEVEL_EXECUTABLE	= 7
 };
 
-#define	CB_FLAG_GETOPT_STACK_SIZE       1
-#define	CB_FLAG_GETOPT_IF_CUTOFF        2
-#define	CB_FLAG_GETOPT_SIGN             3
-#define	CB_FLAG_GETOPT_FOLD_COPY        4
-#define	CB_FLAG_GETOPT_FOLD_CALL        5
-#define	CB_FLAG_GETOPT_TTITLE           6
-#define	CB_FLAG_GETOPT_MAX_ERRORS       7
-#define	CB_FLAG_GETOPT_DUMP             8
-#define	CB_FLAG_GETOPT_CALLFH           9
-#define	CB_FLAG_GETOPT_INTRINSICS      10
-#define	CB_FLAG_GETOPT_EC              11
-#define	CB_FLAG_GETOPT_NO_EC           12
-#define	CB_FLAG_GETOPT_NO_DUMP         13
-#define	CB_FLAG_GETOPT_EBCDIC_TABLE    14
-#define	CB_FLAG_GETOPT_DEFAULT_COLSEQ  15
-#define	CB_FLAG_GETOPT_MEMORY_CHECK    16
-#define	CB_FLAG_GETOPT_COPY_FILE       17
-#define	CB_FLAG_GETOPT_INCLUDE_FILE    18
+#define	CB_FLAG_GETOPT_STACK_SIZE            1
+#define	CB_FLAG_GETOPT_IF_CUTOFF             2
+#define	CB_FLAG_GETOPT_SIGN                  3
+#define	CB_FLAG_GETOPT_FOLD_COPY             4
+#define	CB_FLAG_GETOPT_FOLD_CALL             5
+#define	CB_FLAG_GETOPT_TTITLE                6
+#define	CB_FLAG_GETOPT_MAX_ERRORS            7
+#define	CB_FLAG_GETOPT_DUMP                  8
+#define	CB_FLAG_GETOPT_CALLFH                9
+#define	CB_FLAG_GETOPT_INTRINSICS           10
+#define	CB_FLAG_GETOPT_EC                   11
+#define	CB_FLAG_GETOPT_NO_EC                12
+#define	CB_FLAG_GETOPT_NO_DUMP              13
+#define	CB_FLAG_GETOPT_EBCDIC_TABLE         14
+#define	CB_FLAG_GETOPT_DEFAULT_COLSEQ       15
+#define	CB_FLAG_GETOPT_DEFAULT_FILE_COLSEQ  16
+#define	CB_FLAG_GETOPT_MEMORY_CHECK         17
+#define	CB_FLAG_GETOPT_COPY_FILE            18
+#define	CB_FLAG_GETOPT_INCLUDE_FILE         19
 
 
 /* Info display limits */
@@ -3819,6 +3820,13 @@ process_command_line (const int argc, char **argv)
 			}
 			break;
 
+		case CB_FLAG_GETOPT_DEFAULT_FILE_COLSEQ: /* 16 */
+			/* -fdefault-file-colseq=<ASCII/EBCDIC/NATIVE> */
+			if (cb_deciph_default_file_colseq_name (cob_optarg)) {
+				cobc_err_exit (COBC_INV_PAR, "-fdefault-file-colseq");
+			}
+			break;
+
 		case CB_FLAG_GETOPT_FOLD_COPY: /* 4 */
 			/* -ffold-copy=<UPPER/LOWER> : COPY fold case */
 			if (!cb_strcasecmp (cob_optarg, "UPPER")) {
@@ -3898,7 +3906,7 @@ process_command_line (const int argc, char **argv)
 			}
 			break;
 
-		case CB_FLAG_GETOPT_MEMORY_CHECK: /* 16 */
+		case CB_FLAG_GETOPT_MEMORY_CHECK: /* 17 */
 			/* -fmemory-check=<scope> :  */
 			if (!cob_optarg) {
 				cb_flag_memory_check = CB_MEMCHK_ALL;
@@ -3907,7 +3915,7 @@ process_command_line (const int argc, char **argv)
 			}
 			break;
 
-		case CB_FLAG_GETOPT_COPY_FILE: /* 17 */
+		case CB_FLAG_GETOPT_COPY_FILE: /* 18 */
 			/* --copy=<file> : COPY file at beginning */
 			if (strlen (cob_optarg) > (COB_MINI_MAX)) {
 				cobc_err_exit (COBC_INV_PAR, "--copy");
@@ -3916,7 +3924,7 @@ process_command_line (const int argc, char **argv)
 					  cobc_strdup (cob_optarg));
 			break;
 
-		case CB_FLAG_GETOPT_INCLUDE_FILE: /* 18 */
+		case CB_FLAG_GETOPT_INCLUDE_FILE: /* 19 */
 			/* -include=<file.h> : add #include "file.h" to 
 			   generated C file */
 			if (strlen (cob_optarg) > (COB_MINI_MAX)) {

--- a/cobc/flag.def
+++ b/cobc/flag.def
@@ -103,6 +103,10 @@ CB_FLAG_NQ (1, "default-colseq", CB_FLAG_GETOPT_DEFAULT_COLSEQ,
 	_("  -fdefault-colseq=[ASCII|EBCDIC|NATIVE]\tdefine default collating sequence\n"
 	  "                        * default: NATIVE"))
 
+CB_FLAG_NQ (1, "default-file-colseq", CB_FLAG_GETOPT_DEFAULT_FILE_COLSEQ,
+	_("  -fdefault-file-colseq=[ASCII|EBCDIC|NATIVE]\tdefine default file collating sequence\n"
+	  "                        * default: NATIVE"))
+
 /* Binary flags */
 
 /* Flags with suppressed help */

--- a/cobc/tree.c
+++ b/cobc/tree.c
@@ -4661,9 +4661,12 @@ validate_file (struct cb_file *f, cb_tree name)
 
 static void
 validate_indexed_key_field (struct cb_file *f, struct cb_field *records,
-					cb_tree key, struct cb_key_component *component_list)
+					cb_tree key, struct cb_key_component *component_list,
+					struct cb_alt_key *cbak)
 {
 	cb_tree			key_ref;
+	cb_tree			l;
+
 	struct cb_field		*k;
 	struct cb_field		*p;
 	struct cb_field		*v;
@@ -4730,6 +4733,18 @@ validate_indexed_key_field (struct cb_file *f, struct cb_field *records,
 						  " needs to be at least %d"), f->record_min, k->name, field_end);
 		}
 	}
+
+	/* get key collating sequence, if any */
+	for (l = f->collating_sequence_keys; l; l = CB_CHAIN (l)) {
+		cb_tree alpha_key = CB_VALUE (l);
+		if (key_ref == cb_ref (CB_PAIR_Y (alpha_key))) {
+			if (cbak == NULL) {
+				f->collating_sequence_key = CB_PAIR_X (alpha_key);
+			} else {
+				cbak->collating_sequence_key = CB_PAIR_X (alpha_key);
+			}
+		}
+	}
 }
 
 void
@@ -4771,7 +4786,7 @@ finalize_file (struct cb_file *f, struct cb_field *records)
 		struct cb_alt_key	*cbak;
 		if (f->key) {
 			validate_indexed_key_field (f, records,
-				f->key, f->component_list);
+				f->key, f->component_list, NULL);
 		}
 		for (cbak = f->alt_key_list; cbak; cbak = cbak->next) {
 			if (f->flag_global) {
@@ -4781,7 +4796,7 @@ finalize_file (struct cb_file *f, struct cb_field *records)
 				}
 			}
 			validate_indexed_key_field (f, records,
-				cbak->key, cbak->component_list);
+				cbak->key, cbak->component_list, cbak);
 		}
 	}
 
@@ -7411,6 +7426,38 @@ cb_build_ml_suppress_checks (struct cb_ml_generate_tree *tree)
 			     sizeof (struct cb_ml_suppress_checks));
 	check->tree = tree;
 	return CB_TREE (check);
+}
+
+
+enum cb_colseq cb_default_colseq = CB_COLSEQ_NATIVE;
+enum cb_colseq cb_default_file_colseq = CB_COLSEQ_NATIVE;
+
+/* Decipher character conversion table names */
+static int
+cb_deciph_colseq_name (const char * const name, enum cb_colseq *colseq)
+{
+	if (!cb_strcasecmp (name, "ASCII")) {
+		*colseq = CB_COLSEQ_ASCII;
+	} else if (!cb_strcasecmp (name, "EBCDIC")) {
+		*colseq = CB_COLSEQ_EBCDIC;
+	} else if (!cb_strcasecmp (name, "NATIVE")) {
+		*colseq = CB_COLSEQ_NATIVE;
+	} else {
+		return 1;
+	}
+	return 0;
+}
+
+int
+cb_deciph_default_colseq_name (const char * const name)
+{
+	return cb_deciph_colseq_name (name, &cb_default_colseq);
+}
+
+int
+cb_deciph_default_file_colseq_name (const char * const name)
+{
+	return cb_deciph_colseq_name (name, &cb_default_file_colseq);
 }
 
 

--- a/cobc/tree.h
+++ b/cobc/tree.h
@@ -2343,6 +2343,7 @@ extern cb_tree		cb_debug_sub_3;
 extern cb_tree		cb_debug_contents;
 
 extern int		cb_deciph_default_colseq_name (const char *const);
+extern int		cb_deciph_default_file_colseq_name (const char *const);
 
 extern struct cb_program	*cb_build_program (struct cb_program *,
 						   const int);
@@ -2739,6 +2740,18 @@ extern int		cobc_has_areacheck_directive (const char *directive);
 #define CB_ADD_TO_CHAIN(x,y)		y = CB_BUILD_CHAIN (x, y)
 #define CB_CHAIN_PAIR(x,y,z)		x = cb_pair_add (x, y, z)
 #define CB_FIELD_ADD(x,y)		x = cb_field_add (x, y)
+
+enum cb_colseq {
+	CB_COLSEQ_NATIVE,
+	CB_COLSEQ_ASCII,
+	CB_COLSEQ_EBCDIC,
+};
+
+extern enum cb_colseq cb_default_colseq;
+extern enum cb_colseq cb_default_file_colseq;
+
+extern int	cb_deciph_default_colseq_name (const char * const name);
+extern int	cb_deciph_default_file_colseq_name (const char * const name);
 
 
 #endif /* CB_TREE_H */

--- a/libcob/ChangeLog
+++ b/libcob/ChangeLog
@@ -1,4 +1,12 @@
 
+2024-01-25  David Declerck <david.declerck@ocamlpro.com>
+
+	FR #459: support COLLATING SEQUENCE clause on SELECT / INDEXED files
+	* fileio.c (bdb_setkeycol, bdb_bt_compare, indexed_open, ...):
+	  take the file collating sequence into account when comparing keys
+	* common.c, coblocal.h: rename common_cmps to cob_cmps
+	  and make it available locally
+
 2024-01-19  Simon Sobisch <simonsobisch@gnu.org>
 
 	* fileio.c (indexed_keylen): signature change to directly take the keydesc

--- a/libcob/coblocal.h
+++ b/libcob/coblocal.h
@@ -570,6 +570,9 @@ cob_max_int (const int x, const int y)
 	return y;
 }
 
+COB_HIDDEN int		cob_cmps	(const unsigned char *, const unsigned char *,
+					 const size_t, const unsigned char *);
+
 #undef	COB_HIDDEN
 
 #endif	/* COB_LOCAL_H */

--- a/libcob/common.c
+++ b/libcob/common.c
@@ -1822,8 +1822,8 @@ common_cmpc (const unsigned char *p, const unsigned int c,
 
 /* compare up to 'size' characters in 's1' to 's2'
    using collation 'col' */
-static int
-common_cmps (const unsigned char *s1, const unsigned char *s2,
+int
+cob_cmps (const unsigned char *s1, const unsigned char *s2,
 	     const size_t size, const unsigned char *col)
 {
 	register const unsigned char *end = s1 + size;
@@ -1943,7 +1943,7 @@ cob_cmp_all (cob_field *f1, cob_field *f2)
 		const size_t	chunk_size = size2;
 		size_t		size_loop = size1;
 		while (size_loop >= chunk_size) {
-			if ((ret = common_cmps (data1, data2, chunk_size, col)) != 0) {
+			if ((ret = cob_cmps (data1, data2, chunk_size, col)) != 0) {
 				break;
 			}
 			size_loop -= chunk_size;
@@ -1951,7 +1951,7 @@ cob_cmp_all (cob_field *f1, cob_field *f2)
 		}
 		if (!ret
 		 && size1 > 0) {
-			ret = common_cmps (data1, data2, size_loop, col);
+			ret = cob_cmps (data1, data2, size_loop, col);
 		}
 	}
 
@@ -1991,7 +1991,7 @@ cob_cmp_alnum (cob_field *f1, cob_field *f2)
 	} else {		/* check with collation */
 
 		/* Compare common substring */
-		if ((ret = common_cmps (data1, data2, min, col)) != 0) {
+		if ((ret = cob_cmps (data1, data2, min, col)) != 0) {
 			return ret;
 		}
 
@@ -2052,7 +2052,7 @@ sort_compare_collate (const void *data1, const void *data2)
 		if (COB_FIELD_IS_NUMERIC (&f1)) {
 			res = cob_numeric_cmp (&f1, &f2);
 		} else {
-			res = common_cmps (f1.data, f2.data, f1.size, sort_collate);
+			res = cob_cmps (f1.data, f2.data, f1.size, sort_collate);
 		}
 		if (res != 0) {
 			return (sort_keys[i].flag == COB_ASCENDING) ? res : -res;

--- a/libcob/common.h
+++ b/libcob/common.h
@@ -1370,9 +1370,7 @@ typedef struct __cob_file_key {
 	unsigned int	offset;			/* Offset of field */
 	int		count_components;		/* 0..1::simple-key  2..n::split-key   */
 	cob_field	*component[COB_MAX_KEYCOMP];	/* key-components iff split-key   */
-#if 0	/* TODO (for file keys, not for SORT/MERGE) */
-	const unsigned char *collating_sequence;	/* COLLATING */
-#endif
+	const unsigned char *collating_sequence;	/* COLLATING (for file keys, not for SORT/MERGE) */
 } cob_file_key;
 
 

--- a/libcob/fileio.c
+++ b/libcob/fileio.c
@@ -689,6 +689,16 @@ static unsigned int	bdb_lock_id = 0;
 	key.data = fld->data;			\
 	key.size = (cob_dbtsize_t) fld->size
 
+#if (DB_VERSION_MAJOR > 4) || ((DB_VERSION_MAJOR == 4) && (DB_VERSION_MINOR > 0))
+#define DBT_SET_APP_DATA(key,data)	((key)->app_data = (data))
+#define DBT_GET_APP_DATA(key)		((key)->app_data)
+#else
+/* Workaround for older BDB versions that do not have app_data in DBT */
+static void		*bdb_app_data = NULL;
+#define DBT_SET_APP_DATA(key,data)	((void)(key), bdb_app_data = (data))
+#define DBT_GET_APP_DATA(key)		((void)(key), bdb_app_data)
+#endif
+
 struct indexed_file {
 	DB		**db;		/* Database handlers */
 	DBC		**cursor;
@@ -755,6 +765,13 @@ bdb_savekey (cob_file *f, unsigned char *keyarea, unsigned char *record, int idx
 	return (int)f->keys[idx].field->size;
 }
 
+static COB_INLINE void
+bdb_setkeycol (cob_file *f, int idx)
+{
+	struct indexed_file	*p = f->file;
+	DBT_SET_APP_DATA(&p->key, (void *)f->keys[idx].collating_sequence);
+}
+
 static void
 bdb_setkey (cob_file *f, int idx)
 {
@@ -765,6 +782,7 @@ bdb_setkey (cob_file *f, int idx)
 	len = bdb_savekey (f, p->savekey, f->record->data, idx);
 	p->key.data = p->savekey;
 	p->key.size = (cob_dbtsize_t) len;
+	bdb_setkeycol (f, idx);
 }
 
 /* Compare key for given index 'keyarea' to 'record'.
@@ -3901,6 +3919,7 @@ indexed_start_internal (cob_file *f, const int cond, cob_field *key,
 		}
 		p->key.data = p->data.data;
 		p->key.size = p->primekeylen;
+		bdb_setkeycol (f, 0);
 		ret = DB_GET (p->db[0], &p->key, &p->data, 0);
 	}
 
@@ -4003,6 +4022,7 @@ indexed_delete_internal (cob_file *f, const int rewrite)
 		len = bdb_savekey(f, p->savekey, p->saverec, i);
 		p->key.data = p->savekey;
 		p->key.size = (cob_dbtsize_t) len;
+		bdb_setkeycol (f, i);
 		/* rewrite: no delete if secondary key is unchanged */
 		if (rewrite) {
 			bdb_savekey (f, p->suppkey, p->saverec, i);
@@ -4140,6 +4160,32 @@ indexed_file_delete (cob_file *f, const char *filename)
 	COB_UNUSED (f);
 	COB_UNUSED (filename);
 #endif
+}
+
+static int
+indexed_key_compare (const unsigned char *k1, const unsigned char *k2,
+		     size_t sz, const unsigned char *col)
+{
+	if (col == NULL) {
+		return memcmp (k1, k2, sz);
+	} else {
+		return cob_cmps (k1, k2, sz, col);
+	}
+}
+
+static int
+bdb_bt_compare(DB *db, const DBT *k1, const DBT *k2)
+{
+	const unsigned char *col = (unsigned char *)DBT_GET_APP_DATA(k1);
+	/* LCOV_EXCL_START */
+	if (col == NULL) {
+		cob_runtime_error ("bdb_bt_compare was set but no collating sequence was stored in DBT");
+	}
+	if (k1->size != k2->size) {
+		cob_runtime_error ("bdb_bt_compare was given keys of different length");
+	}
+	/* LCOV_EXCL_STOP */
+	return indexed_key_compare(k1->data, k2->data, k2->size, col);
 }
 
 /* OPEN INDEXED file */
@@ -4611,6 +4657,9 @@ dobuild:
 			if (!ret) {
 				if (f->keys[i].tf_duplicates) {
 					p->db[i]->set_flags (p->db[i], DB_DUP);
+				}
+				if (f->keys[i].collating_sequence) {
+					p->db[i]->set_bt_compare(p->db[i], bdb_bt_compare);
 				}
 			}
 		} else {
@@ -5378,6 +5427,7 @@ indexed_read_next (cob_file *f, const int read_opts)
 		/* Check if previously read data still exists */
 		p->key.size = (cob_dbtsize_t) bdb_keylen(f,p->key_index);
 		p->key.data = p->last_readkey[p->key_index];
+		bdb_setkeycol (f, p->key_index);
 		ret = DB_SEQ (p->cursor[p->key_index], &p->key, &p->data, DB_SET);
 		if (!ret && p->key_index > 0) {
 			if (f->keys[p->key_index].tf_duplicates) {
@@ -5403,6 +5453,7 @@ indexed_read_next (cob_file *f, const int read_opts)
 			if (!ret) {
 				p->key.size = (cob_dbtsize_t) p->primekeylen;
 				p->key.data = p->last_readkey[p->key_index + f->nkeys];
+				bdb_setkeycol (f, 0);
 				ret = DB_GET (p->db[0], &p->key, &p->data, 0);
 			}
 		}
@@ -5428,6 +5479,7 @@ indexed_read_next (cob_file *f, const int read_opts)
 		} else {
 			p->key.size = (cob_dbtsize_t) bdb_keylen (f, p->key_index);
 			p->key.data = p->last_readkey[p->key_index];
+			bdb_setkeycol (f, p->key_index);
 			ret = DB_SEQ (p->cursor[p->key_index], &p->key, &p->data, DB_SET_RANGE);
 			/* ret != 0 possible, records may be deleted since last read */
 			if (ret != 0) {
@@ -5509,6 +5561,7 @@ indexed_read_next (cob_file *f, const int read_opts)
 			}
 			p->key.data = p->data.data;
 			p->key.size = p->primekeylen;
+			bdb_setkeycol (f, 0);
 			ret = DB_GET (p->db[0], &p->key, &p->data, 0);
 			if (ret != 0) {
 				bdb_close_index (f, p->key_index);
@@ -5635,7 +5688,8 @@ indexed_write (cob_file *f, const int opt)
 		p->last_key = cob_malloc ((size_t)p->maxkeylen);
 	} else
 	if (f->access_mode == COB_ACCESS_SEQUENTIAL
-	 && memcmp (p->last_key, p->key.data, (size_t)p->key.size) > 0) {
+	 && indexed_key_compare (p->last_key,  (unsigned char *)p->key.data, (size_t)p->key.size,
+				 (unsigned char *)DBT_GET_APP_DATA(&p->key)) > 0) {
 		return COB_STATUS_21_KEY_INVALID;
 	}
 	memcpy (p->last_key, p->key.data, (size_t)p->key.size);

--- a/tests/testsuite.src/run_file.at
+++ b/tests/testsuite.src/run_file.at
@@ -12430,6 +12430,425 @@ AT_CHECK([diff reference prog.out], [0], [], [])
 AT_CLEANUP
 
 
+# This is only supported by the BDB backend
+AT_SETUP([INDEXED file manipulation under ASCII/EBCDIC collation])
+AT_KEYWORDS([runfile WRITE DELETE READ EBCDIC])
+
+AT_SKIP_IF([test "$COB_HAS_ISAM" != "db"])
+
+AT_DATA([prog.cpy], [
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. prog.
+
+       ENVIRONMENT DIVISION.
+
+       CONFIGURATION SECTION.
+       OBJECT-COMPUTER.
+           PROGRAM COLLATING SEQUENCE IS DISORDERED.
+       SPECIAL-NAMES.
+           ALPHABET DISORDERED IS "WVUTSRJIHGFEDCB".
+
+       INPUT-OUTPUT SECTION.
+       FILE-CONTROL.
+           SELECT MY-FILE ASSIGN TO "testfile"
+               ORGANIZATION IS INDEXED
+               ACCESS IS DYNAMIC
+               FILE-COLSEQ
+               KEY-COLSEQ
+               RECORD KEY IS MY-PKEY
+               ALTERNATE RECORD KEY IS MY-AKEY1 WITH DUPLICATES
+               ALTERNATE RECORD KEY IS MY-AKEY2 WITH DUPLICATES.
+
+       DATA DIVISION.
+
+       FILE SECTION.
+       FD  MY-FILE.
+       01  MY-REC.
+           05  MY-PKEY   PIC X(3).
+           05  MY-AKEY1  PIC X(3).
+           05  MY-AKEY2  BINARY-LONG.
+           05  MY-DATA   PIC 9.
+
+       WORKING-STORAGE SECTION.
+       01  DONE-READING  PIC 9.
+
+       PROCEDURE DIVISION.
+
+           OPEN OUTPUT MY-FILE
+
+           DISPLAY "WRITING DATA"
+
+           MOVE "CCC" TO MY-PKEY
+           MOVE "888" TO MY-AKEY1
+           MOVE 43 TO MY-AKEY2
+           MOVE 1 TO MY-DATA
+           WRITE MY-REC
+
+           MOVE "ZZZ" TO MY-PKEY
+           MOVE "AAA" TO MY-AKEY1
+           MOVE 40 TO MY-AKEY2
+           MOVE 2 TO MY-DATA
+           WRITE MY-REC
+
+           MOVE "DDD" TO MY-PKEY
+           MOVE "777" TO MY-AKEY1
+           MOVE 42 TO MY-AKEY2
+           MOVE 3 TO MY-DATA
+           WRITE MY-REC
+
+           MOVE "XXX" TO MY-PKEY
+           MOVE "VVV" TO MY-AKEY1
+           MOVE 42 TO MY-AKEY2
+           MOVE 4 TO MY-DATA
+           WRITE MY-REC
+
+           MOVE "666" TO MY-PKEY
+           MOVE "AAA" TO MY-AKEY1
+           MOVE 41 TO MY-AKEY2
+           MOVE 5 TO MY-DATA
+           WRITE MY-REC
+
+           MOVE "222" TO MY-PKEY
+           MOVE "555" TO MY-AKEY1
+           MOVE 44 TO MY-AKEY2
+           MOVE 6 TO MY-DATA
+           WRITE MY-REC
+
+           CLOSE MY-FILE
+
+
+           OPEN I-O MY-FILE
+
+           DISPLAY "DELETING DATA"
+
+           MOVE "ZZZ" TO MY-PKEY
+           DELETE MY-FILE
+
+           MOVE "XXX" TO MY-PKEY
+           DELETE MY-FILE
+
+           CLOSE MY-FILE
+
+
+           OPEN INPUT MY-FILE
+
+           DISPLAY "READING BY PKEY"
+
+           MOVE 0 TO DONE-READING
+           MOVE SPACES TO MY-PKEY
+           START MY-FILE KEY >= MY-PKEY
+
+           PERFORM UNTIL NOT DONE-READING = 0
+               READ MY-FILE NEXT
+                   AT END MOVE 1 TO DONE-READING
+               END-READ
+               IF DONE-READING = 0
+                   DISPLAY MY-PKEY " " MY-AKEY1
+                       " " MY-AKEY2 " " MY-DATA
+               END-IF
+           END-PERFORM
+
+           DISPLAY "READING BY AKEY1"
+
+           MOVE 0 TO DONE-READING
+           MOVE SPACES TO MY-AKEY1
+           START MY-FILE KEY >= MY-AKEY1
+
+           PERFORM UNTIL NOT DONE-READING = 0
+               READ MY-FILE NEXT
+                   AT END MOVE 1 TO DONE-READING
+               END-READ
+               IF DONE-READING = 0
+                   DISPLAY MY-PKEY " " MY-AKEY1
+                       " " MY-AKEY2 " " MY-DATA
+               END-IF
+           END-PERFORM
+
+           DISPLAY "READING BY AKEY2"
+
+           MOVE 0 TO DONE-READING
+           MOVE ZERO TO MY-AKEY2
+           START MY-FILE KEY >= MY-AKEY2
+
+           PERFORM UNTIL NOT DONE-READING = 0
+               READ MY-FILE NEXT
+                   AT END MOVE 1 TO DONE-READING
+               END-READ
+               IF DONE-READING = 0
+                   DISPLAY MY-PKEY " " MY-AKEY1
+                       " " MY-AKEY2 " " MY-DATA
+               END-IF
+           END-PERFORM
+
+           CLOSE MY-FILE
+
+
+           DISPLAY "DONE"
+
+           STOP RUN.
+])
+
+AT_DATA([reference_ascii],
+[WRITING DATA
+DELETING DATA
+READING BY PKEY
+222 555 +0000000044 6
+666 AAA +0000000041 5
+CCC 888 +0000000043 1
+DDD 777 +0000000042 3
+READING BY AKEY1
+222 555 +0000000044 6
+DDD 777 +0000000042 3
+CCC 888 +0000000043 1
+666 AAA +0000000041 5
+READING BY AKEY2
+666 AAA +0000000041 5
+DDD 777 +0000000042 3
+CCC 888 +0000000043 1
+222 555 +0000000044 6
+DONE
+])
+
+AT_DATA([reference_ascii_ebcdic],
+[WRITING DATA
+DELETING DATA
+READING BY PKEY
+222 555 +0000000044 6
+666 AAA +0000000041 5
+CCC 888 +0000000043 1
+DDD 777 +0000000042 3
+READING BY AKEY1
+666 AAA +0000000041 5
+222 555 +0000000044 6
+DDD 777 +0000000042 3
+CCC 888 +0000000043 1
+READING BY AKEY2
+666 AAA +0000000041 5
+DDD 777 +0000000042 3
+CCC 888 +0000000043 1
+222 555 +0000000044 6
+DONE
+])
+
+AT_DATA([reference_ebcdic],
+[WRITING DATA
+DELETING DATA
+READING BY PKEY
+CCC 888 +0000000043 1
+DDD 777 +0000000042 3
+222 555 +0000000044 6
+666 AAA +0000000041 5
+READING BY AKEY1
+666 AAA +0000000041 5
+222 555 +0000000044 6
+DDD 777 +0000000042 3
+CCC 888 +0000000043 1
+READING BY AKEY2
+666 AAA +0000000041 5
+DDD 777 +0000000042 3
+CCC 888 +0000000043 1
+222 555 +0000000044 6
+DONE
+])
+
+AT_DATA([reference_ebcdic_ascii],
+[WRITING DATA
+DELETING DATA
+READING BY PKEY
+CCC 888 +0000000043 1
+DDD 777 +0000000042 3
+222 555 +0000000044 6
+666 AAA +0000000041 5
+READING BY AKEY1
+222 555 +0000000044 6
+DDD 777 +0000000042 3
+CCC 888 +0000000043 1
+666 AAA +0000000041 5
+READING BY AKEY2
+666 AAA +0000000041 5
+DDD 777 +0000000042 3
+CCC 888 +0000000043 1
+222 555 +0000000044 6
+DONE
+])
+
+# Testing ASCII file collating sequence using clause
+AT_DATA([prog1.cob], [
+       COPY "prog.cpy" REPLACING
+         ==FILE-COLSEQ== BY ==COLLATING SEQUENCE IS ASCII==
+         ==KEY-COLSEQ== BY ====.
+])
+AT_CHECK([$COMPILE -Wno-unfinished prog1.cob], [0], [], [])
+AT_CHECK([$COBCRUN_DIRECT ./prog1 1>prog1.out], [0], [], [])
+AT_CHECK([diff reference_ascii prog1.out], [0], [], [])
+
+# Testing ASCII file collating sequence using flag
+AT_DATA([prog2.cob], [
+       COPY "prog.cpy" REPLACING
+         ==FILE-COLSEQ== BY ====
+         ==KEY-COLSEQ== BY ====.
+])
+AT_CHECK([$COMPILE -Wno-unfinished -fdefault-file-colseq=ASCII prog2.cob], [0], [], [])
+AT_CHECK([$COBCRUN_DIRECT ./prog2 1>prog2.out], [0], [], [])
+AT_CHECK([diff reference_ascii prog2.out], [0], [], [])
+
+
+# Testing ASCII file collating sequence + EBCDIC key collating sequence using clauses
+AT_DATA([prog3.cob], [
+       COPY "prog.cpy" REPLACING
+         ==FILE-COLSEQ== BY ==COLLATING SEQUENCE IS ASCII==
+         ==KEY-COLSEQ== BY ==COLLATING SEQUENCE OF MY-AKEY1 IS EBCDIC==.
+])
+AT_CHECK([$COMPILE -Wno-unfinished prog3.cob], [0], [], [])
+AT_CHECK([$COBCRUN_DIRECT ./prog3 1>prog3.out], [0], [], [])
+AT_CHECK([diff reference_ascii_ebcdic prog3.out], [0], [], [])
+
+# Testing ASCII file collating sequence using flag + EBCDIC key collating sequence using clause
+AT_DATA([prog4.cob], [
+       COPY "prog.cpy" REPLACING
+         ==FILE-COLSEQ== BY ====
+         ==KEY-COLSEQ== BY ==COLLATING SEQUENCE OF MY-AKEY1 IS EBCDIC==.
+])
+AT_CHECK([$COMPILE -Wno-unfinished -fdefault-file-colseq=ASCII prog4.cob], [0], [], [])
+AT_CHECK([$COBCRUN_DIRECT ./prog4 1>prog4.out], [0], [], [])
+AT_CHECK([diff reference_ascii_ebcdic prog4.out], [0], [], [])
+
+# Testing EBCDIC file collating sequence using clause
+AT_DATA([prog5.cob], [
+       COPY "prog.cpy" REPLACING
+         ==FILE-COLSEQ== BY ==COLLATING SEQUENCE IS EBCDIC==
+         ==KEY-COLSEQ== BY ==COLLATING SEQUENCE OF MY-AKEY1 IS EBCDIC==.
+])
+AT_CHECK([$COMPILE -Wno-unfinished prog5.cob], [0], [], [])
+AT_CHECK([$COBCRUN_DIRECT ./prog5 1>prog5.out], [0], [], [])
+AT_CHECK([diff reference_ebcdic prog5.out], [0], [], [])
+
+# Testing EBCDIC file collating sequence using flag
+AT_DATA([prog6.cob], [
+       COPY "prog.cpy" REPLACING
+         ==FILE-COLSEQ== BY ====
+         ==KEY-COLSEQ== BY ====.
+])
+AT_CHECK([$COMPILE -Wno-unfinished -fdefault-file-colseq=EBCDIC prog6.cob], [0], [], [])
+AT_CHECK([$COBCRUN_DIRECT ./prog6 1>prog6.out], [0], [], [])
+AT_CHECK([diff reference_ebcdic prog6.out], [0], [], [])
+
+# Testing EBCDIC file collating sequence + ASCII key collating sequence using clauses
+AT_DATA([prog7.cob], [
+       COPY "prog.cpy" REPLACING
+         ==FILE-COLSEQ== BY ==COLLATING SEQUENCE IS EBCDIC==
+         ==KEY-COLSEQ== BY ==COLLATING SEQUENCE OF MY-AKEY1 IS ASCII==.
+])
+AT_CHECK([$COMPILE -Wno-unfinished prog7.cob], [0], [], [])
+AT_CHECK([$COBCRUN_DIRECT ./prog7 1>prog7.out], [0], [], [])
+AT_CHECK([diff reference_ebcdic_ascii prog7.out], [0], [], [])
+
+# Testing EBCDIC file collating sequence using flag + ASCII key collating sequence using clause
+AT_DATA([prog8.cob], [
+       COPY "prog.cpy" REPLACING
+         ==FILE-COLSEQ== BY ====
+         ==KEY-COLSEQ== BY ==COLLATING SEQUENCE OF MY-AKEY1 IS ASCII==.
+])
+AT_CHECK([$COMPILE -Wno-unfinished -fdefault-file-colseq=EBCDIC prog8.cob], [0], [], [])
+AT_CHECK([$COBCRUN_DIRECT ./prog8 1>prog8.out], [0], [], [])
+AT_CHECK([diff reference_ebcdic_ascii prog8.out], [0], [], [])
+
+AT_CLEANUP
+
+
+AT_SETUP([INDEXED file numeric keys ordering])
+AT_KEYWORDS([runfile])
+
+# BUG: non-display numeric keys are currently ordered lexicographically
+# with respect to their binary representation, which is incorrect.
+# Could be fixed with a custom comparison function (BDB)
+# or using key types other than CHARTYPE (ISAM).
+AT_XFAIL_IF([true])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. prog.
+
+       ENVIRONMENT DIVISION.
+       INPUT-OUTPUT SECTION.
+       FILE-CONTROL.
+           SELECT MY-FILE ASSIGN TO "testfile"
+               ORGANIZATION IS INDEXED
+               ACCESS IS DYNAMIC
+               RECORD KEY IS MY-PKEY.
+
+       DATA DIVISION.
+       FILE SECTION.
+       FD  MY-FILE.
+       01  MY-REC.
+           05  MY-PKEY   BINARY-LONG.
+           05  MY-DATA   PIC 9.
+
+       WORKING-STORAGE SECTION.
+       01  DONE-READING  PIC 9.
+
+       PROCEDURE DIVISION.
+
+           OPEN OUTPUT MY-FILE
+
+           DISPLAY "WRITING DATA"
+
+           MOVE 255 TO MY-PKEY
+           MOVE 1 TO MY-DATA
+           WRITE MY-REC
+
+           MOVE 256 TO MY-PKEY
+           MOVE 2 TO MY-DATA
+           WRITE MY-REC
+
+           MOVE 65535 TO MY-PKEY
+           MOVE 3 TO MY-DATA
+           WRITE MY-REC
+
+           MOVE 65536 TO MY-PKEY
+           MOVE 4 TO MY-DATA
+           WRITE MY-REC
+
+           CLOSE MY-FILE
+
+
+           OPEN INPUT MY-FILE
+
+           DISPLAY "READING BY PKEY"
+
+           MOVE 0 TO DONE-READING
+           MOVE 0 TO MY-PKEY
+           START MY-FILE KEY >= MY-PKEY
+
+           PERFORM UNTIL NOT DONE-READING = 0
+               READ MY-FILE NEXT
+                   AT END MOVE 1 TO DONE-READING
+               END-READ
+               IF DONE-READING = 0
+                   DISPLAY MY-PKEY " " MY-DATA
+               END-IF
+           END-PERFORM
+
+           CLOSE MY-FILE
+
+           DISPLAY "DONE" WITH NO ADVANCING
+
+           STOP RUN.
+])
+
+AT_CHECK([$COMPILE prog.cob], [0], [], [])
+AT_CHECK([$COBCRUN_DIRECT ./prog], [0],
+[WRITING DATA
+READING BY PKEY
++0000000255 1
++0000000256 2
++0000065535 3
++0000065536 4
+DONE], [])
+
+AT_CLEANUP
+
+
 AT_SETUP([TURN EC-I-O])
 AT_KEYWORDS([runfile directive])
 


### PR DESCRIPTION
This PR adds support for COLLATING SEQUENCE on indexed files, as mentionned in [https://sourceforge.net/p/gnucobol/feature-requests/459/](https://sourceforge.net/p/gnucobol/feature-requests/459/).

Note this has. only been done for the BDB backend - that's what our client needs.