### PR TITLE
attempt at optimizing allocs in replace.c

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -57,10 +57,13 @@ NEWS - user visible changes				-*- outline -*-
 * More notable changes
 
 ** execution times were significantly reduced for the following:
-	comparison between a numeric DISPLAY variable to another or to a literal
-	comparison between numeric DISPLAY or BCD variable to zero
-	INSPECT CONVERTING (and "simple" INSPECT REPLACING), in general
-	   and especially if both from and to are constants
+   comparison between a numeric DISPLAY variable to another or to a
+   literal comparison between numeric DISPLAY or BCD variable to zero
+   INSPECT CONVERTING (and "simple" INSPECT REPLACING), in general and
+   especially if both from and to are constants
+
+** optimization of the two-pass preprocessing step of cobc: memory usage
+   and performance should be back close to the ones of 3.1.
 
 * Changes in the COBOL runtime
 

--- a/cobc/ChangeLog
+++ b/cobc/ChangeLog
@@ -1,4 +1,14 @@
 
+2024-04-24  Fabrice Le Fessant <fabrice.le_fessant@ocamlpro.com>
+
+	* replace.c: optimize speed and memory usage. For speed, we add two
+	  fast paths in cb_ppecho_copy_replace() to completely skip the
+	  replacement machinery if there is no need for it. For allocations,
+	  we only allocate tokens that are coming from the lexer (not the
+	  ones passed internally from the copy-replacing stream to the
+	  replace stream) and we use a circular buffer for the temporary
+	  queue of tokens instead of a list.
+
 2024-03-17  Fabrice Le Fessant <fabrice.le_fessant@ocamlpro.com>
 	    Emilien Lemaire <emilien.lemaire@ocamlpro.com>
 

--- a/tests/testsuite.src/syn_copy.at
+++ b/tests/testsuite.src/syn_copy.at
@@ -1119,3 +1119,41 @@ AT_CHECK([$COMPILE_ONLY --copy copybook1 --copy copybook4 prog.cob], [1], [],
 ])
 
 AT_CLEANUP
+
+
+AT_SETUP([COPY LONG REPLACE])
+AT_KEYWORDS([copy replace])
+
+AT_DATA([copy.inc], [
+       01  TEST-FIRST  PIC X(2) VALUE "OK".
+       01  TEST-SECOND PIC X(2) VALUE "OK".
+])
+AT_DATA([prog.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      prog.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       COPY "copy.inc"
+            REPLACING TRAILING ==FIRST== BY ==VAR1==
+                      TRAILING ==SECOND== BY ==VAR2==.
+       REPLACE ==
+              01  TEST-VAR1  PIC X(2) VALUE "OK".
+              01  TEST-VAR2 PIC X(2) VALUE "OK".
+	      == BY ==
+	             PROCEDURE        DIVISION.
+           DISPLAY TEST-VAR1 NO ADVANCING
+           END-DISPLAY.
+           DISPLAY TEST-VAR2 NO ADVANCING
+           END-DISPLAY.
+           STOP RUN.
+	   ==.
+       COPY "copy.inc"
+            REPLACING TRAILING ==FIRST== BY ==VAR1==
+                      TRAILING ==SECOND== BY ==VAR2==.
+])
+
+AT_CHECK([$COMPILE prog.cob])
+
+AT_CHECK([$COBCRUN_DIRECT ./prog], [0], [OKOK])
+
+AT_CLEANUP


### PR DESCRIPTION
There are two steps to remove allocations:
* use a circular buffer for the list of tokens
* remove re-allocation of tokens passing from one stream to another