### PR TITLE
Add >>IMP INCLUDE directive

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,13 +6,9 @@ NEWS - user visible changes				-*- outline -*-
 
 * New GnuCOBOL features
 
-** the leading space for all internal directives is removed in the lexer.
-   Source previously processed may need to be ajusted to be processed by
-   GnuCOBOL 3.3.
-
-** cobc now checks for binary files and early exit parsing those;
-   the error output for format errors (for example invalid indicator column)
-   is now limitted to 5 per source file
+** cobc now checks for binary and multi-byte encoded files and early exit
+   parsing those; the error output for format errors (for example invalid
+   indicator column) is now limitted to 5 per source file
 
 ** support the COLLATING SEQUENCE clause on indexed files
    (currently only with the BDB backend)

--- a/NEWS
+++ b/NEWS
@@ -6,9 +6,13 @@ NEWS - user visible changes				-*- outline -*-
 
 * New GnuCOBOL features
 
-** cobc now checks for binary and multi-byte encoded files and early exit
-   parsing those; the error output for format errors (for example invalid
-   indicator column) is now limitted to 5 per source file
+** the leading space for all internal directives is removed in the lexer.
+   Source previously processed may need to be ajusted to be processed by
+   GnuCOBOL 3.3.
+
+** cobc now checks for binary files and early exit parsing those;
+   the error output for format errors (for example invalid indicator column)
+   is now limitted to 5 per source file
 
 ** support the COLLATING SEQUENCE clause on indexed files
    (currently only with the BDB backend)

--- a/NEWS
+++ b/NEWS
@@ -54,6 +54,9 @@ NEWS - user visible changes				-*- outline -*-
    calls to externals. The files are put into quotes, unless they start by
    '<'. Quoted files are expected to have absolute paths, as the C compiler
    is called in a temp directory instead of the project directory.
+   The directive >>IMP INCLUDE "file.h", >>IMP INCLUDE "<file.h>",
+   >>IMP INCLUDE <file.h> or >>IMP INCLUDE file.h can be used as an alternative
+   to this compiler option.
 
 ** output of unlimited errors may be requested by -fmax-errors=0,
    to stop compiliation at first error use -Wfatal-errors

--- a/cobc/ChangeLog
+++ b/cobc/ChangeLog
@@ -149,9 +149,12 @@
 
 2024-04-25  Boris Eng <boris.eng@ocamlpro.com>
 
-	* pplex.l, ppparse.y, scanner.l, cobc.h, codegen.c:
-	  new >>IMP INCLUDE directive to include one or multiple header files in
-	  the generated C code (same behavior as the --include compiler option)
+	FR #176: "Implementation of GC directive to include .h (c/c++) files"
+	* pplex.l, ppparse.y, cobc.h, codegen.c: new >>IMP INCLUDE directive to
+	  include one or multiple header files in the generated C code (same behavior
+	  as the --include but with one directive per file)
+	* scanner.l: the leading space for all internal directives is removed in the
+	  lexer. Source previously preprocessed may need to be adjusted
 
 2024-04-24  Fabrice Le Fessant <fabrice.le_fessant@ocamlpro.com>
 

--- a/cobc/ChangeLog
+++ b/cobc/ChangeLog
@@ -163,6 +163,12 @@
 	  replace stream) and we use a circular buffer for the temporary
 	  queue of tokens instead of a list.
 
+2024-04-25  Boris Eng <boris.eng@ocamlpro.com>
+
+	* pplex.l, ppparse.y, scanner.l, cobc.h, codegen.c:
+	  new >>IMP INCLUDE directive to include one or multiple header files in
+	  the generated C code (same behavior as the --include compiler option)
+
 2024-03-17  Fabrice Le Fessant <fabrice.le_fessant@ocamlpro.com>
             Emilien Lemaire <emilien.lemaire@ocamlpro.com>
 

--- a/cobc/ChangeLog
+++ b/cobc/ChangeLog
@@ -150,9 +150,10 @@
 2024-04-25  Boris Eng <boris.eng@ocamlpro.com>
 
 	FR #176: "Implementation of GC directive to include .h (c/c++) files"
-	* pplex.l, ppparse.y, cobc.h, codegen.c: new >>IMP INCLUDE directive to
-	  include one or multiple header files in the generated C code (same behavior
-	  as the --include but with one directive per file)
+	* pplex.l, ppparse.y, cobc.h, codegen.c (output_gnucobol_defines):
+	  new >>IMP INCLUDE directive to include one or multiple header files in the
+	  generated C code (same behavior as the --include but with one directive per
+	  file)
 	* scanner.l: the leading space for all internal directives is removed in the
 	  lexer. Source previously preprocessed may need to be adjusted
 
@@ -165,12 +166,6 @@
 	  ones passed internally from the copy-replacing stream to the
 	  replace stream) and we use a circular buffer for the temporary
 	  queue of tokens instead of a list.
-
-2024-04-25  Boris Eng <boris.eng@ocamlpro.com>
-
-	* pplex.l, ppparse.y, scanner.l, cobc.h, codegen.c:
-	  new >>IMP INCLUDE directive to include one or multiple header files in
-	  the generated C code (same behavior as the --include compiler option)
 
 2024-03-17  Fabrice Le Fessant <fabrice.le_fessant@ocamlpro.com>
             Emilien Lemaire <emilien.lemaire@ocamlpro.com>

--- a/cobc/ChangeLog
+++ b/cobc/ChangeLog
@@ -149,9 +149,9 @@
 
 2024-04-25  Boris Eng <boris.eng@ocamlpro.com>
 
-	* cobc.h, pplex.l, ppparse.y: new >>IMP INCLUDE directive to include
-	  multiple header files in the C generated code. Has the same behavior as the
-	  --include compiler option.
+	* pplex.l, ppparse.y, scanner.l, cobc.h, codegen.c:
+	  new >>IMP INCLUDE directive to include one or multiple header files in
+	  the generated C code (same behavior as the --include compiler option)
 
 2024-04-24  Fabrice Le Fessant <fabrice.le_fessant@ocamlpro.com>
 
@@ -162,12 +162,6 @@
 	  ones passed internally from the copy-replacing stream to the
 	  replace stream) and we use a circular buffer for the temporary
 	  queue of tokens instead of a list.
-
-2024-04-25  Boris Eng <boris.eng@ocamlpro.com>
-
-	* pplex.l, ppparse.y, scanner.l, cobc.h, codegen.c:
-	  new >>IMP INCLUDE directive to include one or multiple header files in
-	  the generated C code (same behavior as the --include compiler option)
 
 2024-03-17  Fabrice Le Fessant <fabrice.le_fessant@ocamlpro.com>
             Emilien Lemaire <emilien.lemaire@ocamlpro.com>

--- a/cobc/ChangeLog
+++ b/cobc/ChangeLog
@@ -147,6 +147,12 @@
 	  compiler aborts on broken expressions, bugs #933, #938 and #966
 	* typeck.c: minor refactoring within functions
 
+2024-04-25  Boris Eng <boris.eng@ocamlpro.com>
+
+	* cobc.h, pplex.l, ppparse.y: new >>IMP INCLUDE directive to include
+	  multiple header files in the C generated code. Has the same behavior as the
+	  --include compiler option.
+
 2024-04-24  Fabrice Le Fessant <fabrice.le_fessant@ocamlpro.com>
 
 	* replace.c: optimize speed and memory usage. For speed, we add two
@@ -156,6 +162,12 @@
 	  ones passed internally from the copy-replacing stream to the
 	  replace stream) and we use a circular buffer for the temporary
 	  queue of tokens instead of a list.
+
+2024-04-25  Boris Eng <boris.eng@ocamlpro.com>
+
+	* pplex.l, ppparse.y, scanner.l, cobc.h, codegen.c:
+	  new >>IMP INCLUDE directive to include one or multiple header files in
+	  the generated C code (same behavior as the --include compiler option)
 
 2024-03-17  Fabrice Le Fessant <fabrice.le_fessant@ocamlpro.com>
             Emilien Lemaire <emilien.lemaire@ocamlpro.com>

--- a/cobc/cobc.h
+++ b/cobc/cobc.h
@@ -481,7 +481,7 @@ extern struct cb_text_list	*cb_copy_list;
 extern struct cb_text_list	*cb_include_file_list; /* global */
 extern struct cb_text_list	*cb_include_file_list_directive; /* temporary */
 extern struct cb_text_list	*cb_include_list;
-extern struct cb_text_list *cb_include_file_list_directive;
+extern struct cb_text_list	*cb_include_file_list_directive;
 extern struct cb_text_list	*cb_intrinsic_list;
 extern struct cb_text_list	*cb_extension_list;
 extern struct cb_text_list	*cb_static_call_list;

--- a/cobc/cobc.h
+++ b/cobc/cobc.h
@@ -478,9 +478,9 @@ extern int			cb_depend_keep_missing;
 extern int			cb_flag_copybook_deps;
 extern struct cb_text_list	*cb_depend_list;
 extern struct cb_text_list	*cb_copy_list;
-extern struct cb_text_list	*cb_include_file_list;
+extern struct cb_text_list	*cb_include_file_list; /* global */
+extern struct cb_text_list	*cb_include_file_list_directive; /* temporary */
 extern struct cb_text_list	*cb_include_list;
-extern struct cb_text_list *cb_include_file_list_directive;
 extern struct cb_text_list	*cb_intrinsic_list;
 extern struct cb_text_list	*cb_extension_list;
 extern struct cb_text_list	*cb_static_call_list;

--- a/cobc/cobc.h
+++ b/cobc/cobc.h
@@ -481,6 +481,7 @@ extern struct cb_text_list	*cb_copy_list;
 extern struct cb_text_list	*cb_include_file_list; /* global */
 extern struct cb_text_list	*cb_include_file_list_directive; /* temporary */
 extern struct cb_text_list	*cb_include_list;
+extern struct cb_text_list *cb_include_file_list_directive;
 extern struct cb_text_list	*cb_intrinsic_list;
 extern struct cb_text_list	*cb_extension_list;
 extern struct cb_text_list	*cb_static_call_list;

--- a/cobc/cobc.h
+++ b/cobc/cobc.h
@@ -481,7 +481,6 @@ extern struct cb_text_list	*cb_copy_list;
 extern struct cb_text_list	*cb_include_file_list; /* global */
 extern struct cb_text_list	*cb_include_file_list_directive; /* temporary */
 extern struct cb_text_list	*cb_include_list;
-extern struct cb_text_list	*cb_include_file_list_directive;
 extern struct cb_text_list	*cb_intrinsic_list;
 extern struct cb_text_list	*cb_extension_list;
 extern struct cb_text_list	*cb_static_call_list;

--- a/cobc/cobc.h
+++ b/cobc/cobc.h
@@ -276,7 +276,7 @@ enum cb_sub_check {
 struct cb_text_list {
 	struct cb_text_list	*next;			/* next pointer */
 	struct cb_text_list	*last;
-	const char		*text;
+	char			*text;
 };
 
 /* Structure for extended filenames */
@@ -480,6 +480,7 @@ extern struct cb_text_list	*cb_depend_list;
 extern struct cb_text_list	*cb_copy_list;
 extern struct cb_text_list	*cb_include_file_list;
 extern struct cb_text_list	*cb_include_list;
+extern struct cb_text_list *cb_include_file_list_directive;
 extern struct cb_text_list	*cb_intrinsic_list;
 extern struct cb_text_list	*cb_extension_list;
 extern struct cb_text_list	*cb_static_call_list;

--- a/cobc/codegen.c
+++ b/cobc/codegen.c
@@ -1832,24 +1832,24 @@ output_gnucobol_defines (const char *formatted_date)
 		current_compile_tm.tm_sec;
 	output_line ("#define  COB_MODULE_TIME\t\t%d", i);
 
-	{
-		struct cb_text_list *l;
-		for (l = cb_include_file_list; l; l = l->next) {
-			if (l->text[0] == '<') {
-				output_line ("#include %s", l->text);
-			} else {
-				output_line ("#include \"%s\"", l->text);
-			}
-		}
-
-		for (l = cb_include_file_list_directive; l; l = l->next) {
-			if (l->text[0] == '<') {
-				output_line ("#include %s", l->text);
-			} else {
-				output_line ("#include \"%s\"", l->text);
-			}
+	struct cb_text_list *l;
+	for (l = cb_include_file_list; l; l = l->next) {
+		if (l->text[0] == '<') {
+			output_line ("#include %s", l->text);
+		} else {
+			output_line ("#include \"%s\"", l->text);
 		}
 	}
+
+	for (l = cb_include_file_list_directive; l; l = l->next) {
+		if (l->text[0] == '<') {
+			output_line ("#include %s", l->text);
+		} else {
+			output_line ("#include \"%s\"", l->text);
+		}
+	}
+
+	cb_include_file_list_directive = NULL;
 }
 
 /* CALL cache */

--- a/cobc/codegen.c
+++ b/cobc/codegen.c
@@ -1801,6 +1801,7 @@ static void
 output_gnucobol_defines (const char *formatted_date)
 {
 	int	i;
+	struct cb_text_list *l;
 
 	if (!strrchr (cb_source_file, '\\')
 	 && !strrchr (cb_source_file, '"')) {
@@ -1832,7 +1833,6 @@ output_gnucobol_defines (const char *formatted_date)
 		current_compile_tm.tm_sec;
 	output_line ("#define  COB_MODULE_TIME\t\t%d", i);
 
-	struct cb_text_list *l;
 	for (l = cb_include_file_list; l; l = l->next) {
 		if (l->text[0] == '<') {
 			output_line ("#include %s", l->text);

--- a/cobc/codegen.c
+++ b/cobc/codegen.c
@@ -1834,7 +1834,6 @@ output_gnucobol_defines (const char *formatted_date)
 
 	{
 		struct cb_text_list *l;
-		struct cb_text_list *last = NULL;
 		for (l = cb_include_file_list; l; l = l->next) {
 			if (l->text[0] == '<') {
 				output_line ("#include %s", l->text);
@@ -1844,11 +1843,6 @@ output_gnucobol_defines (const char *formatted_date)
 		}
 
 		for (l = cb_include_file_list_directive; l; l = l->next) {
-			if (last != NULL) {
-				cobc_free (last->text);
-				cobc_free (last);
-			}
-			last = l;
 			if (l->text[0] == '<') {
 				output_line ("#include %s", l->text);
 			} else {

--- a/cobc/codegen.c
+++ b/cobc/codegen.c
@@ -1833,16 +1833,29 @@ output_gnucobol_defines (const char *formatted_date)
 	output_line ("#define  COB_MODULE_TIME\t\t%d", i);
 
 	{
-		struct cb_text_list *l = cb_include_file_list ;
-		for (;l;l=l->next){
-			if (l->text[0] == '<'){
+		struct cb_text_list *l;
+		struct cb_text_list *last = NULL;
+		for (l = cb_include_file_list; l; l = l->next) {
+			if (l->text[0] == '<') {
+				output_line ("#include %s", l->text);
+			} else {
+				output_line ("#include \"%s\"", l->text);
+			}
+		}
+
+		for (l = cb_include_file_list_directive; l; l = l->next) {
+			if (last != NULL) {
+				cobc_free (last->text);
+				cobc_free (last);
+			}
+			last = l;
+			if (l->text[0] == '<') {
 				output_line ("#include %s", l->text);
 			} else {
 				output_line ("#include \"%s\"", l->text);
 			}
 		}
 	}
-
 }
 
 /* CALL cache */

--- a/cobc/pplex.l
+++ b/cobc/pplex.l
@@ -201,7 +201,7 @@ ALNUM_LITERAL_A	"\'"([^''\n]|("\'"[0-9][0-9, ]+"\'"))*"\'"
 ALNUM_LITERAL	{ALNUM_LITERAL_Q}|{ALNUM_LITERAL_A}
 SET_PAREN_LIT	\([^()\n]*\)
 DEFNUM_LITERAL	[+-]?[0-9]*[\.]*[0-9]+
-RAW_SEQ	[^ \n]+
+RAW_SEQ		[^ \n]+
 
 AREA_A		[ ]?#
 MAYBE_AREA_A	[ ]?#?

--- a/cobc/pplex.l
+++ b/cobc/pplex.l
@@ -201,6 +201,7 @@ ALNUM_LITERAL_A	"\'"([^''\n]|("\'"[0-9][0-9, ]+"\'"))*"\'"
 ALNUM_LITERAL	{ALNUM_LITERAL_Q}|{ALNUM_LITERAL_A}
 SET_PAREN_LIT	\([^()\n]*\)
 DEFNUM_LITERAL	[+-]?[0-9]*[\.]*[0-9]+
+RAW_SEQ	[^ \n]+
 
 AREA_A		[ ]?#
 MAYBE_AREA_A	[ ]?#?
@@ -224,6 +225,7 @@ MAYBE_AREA_A	[ ]?#?
 %x ALNUM_LITERAL_STATE
 %x CONTROL_STATEMENT_STATE
 %x DISPLAY_DIRECTIVE_STATE
+%x IMP_DIRECTIVE_STATE
 
 %%
 
@@ -355,6 +357,11 @@ MAYBE_AREA_A	[ ]?#?
 	BEGIN CALL_DIRECTIVE_STATE;
 	output_pending_newlines (ppout);
 	return CALL_DIRECTIVE;
+}
+
+^{MAYBE_AREA_A}[ ]*">>"[ ]?"IMP"	{
+	BEGIN IMP_DIRECTIVE_STATE;
+	return IMP_DIRECTIVE;
 }
 
 ^{MAYBE_AREA_A}[ ]*">>"[ ]*\n		{
@@ -721,6 +728,7 @@ ELSE_DIRECTIVE_STATE,
 ENDIF_DIRECTIVE_STATE,
 ALNUM_LITERAL_STATE,
 CONTROL_STATEMENT_STATE,
+IMP_DIRECTIVE_STATE,
 COBOL_WORDS_DIRECTIVE_STATE>{
   \n			{
 	BEGIN INITIAL;
@@ -988,6 +996,14 @@ ENDIF_DIRECTIVE_STATE>{
   {WORD}		{
 	return GARBAGE;
   }
+}
+
+<IMP_DIRECTIVE_STATE>{
+  "INCLUDE"		{ return INCLUDE; }		/* GnuCOBOL 3.3 extension */
+  {RAW_SEQ}		{
+	pplval.s = cobc_plex_strdup (yytext);
+	return TOKEN;
+	}
 }
 
 <IF_DIRECTIVE_STATE>{

--- a/cobc/ppparse.y
+++ b/cobc/ppparse.y
@@ -1375,7 +1375,7 @@ leap_second_directive:
 
 imp_directive:
   /* GnuCOBOL 3.3 extension */
-	INCLUDE
+  INCLUDE
   {
 	ppparse_error (_("Missing argument for IMP INCLUDE directive"));
   }

--- a/cobc/ppparse.y
+++ b/cobc/ppparse.y
@@ -1377,7 +1377,8 @@ imp_directive:
   /* GnuCOBOL 3.3 extension */
   INCLUDE
   {
-	ppparse_error (_("Missing argument for IMP INCLUDE directive"));
+	cb_error (_("invalid %s directive"), "IMP INCLUDE");
+	yyerrok;
   }
 | INCLUDE imp_include_sources
   {

--- a/cobc/ppparse.y
+++ b/cobc/ppparse.y
@@ -1376,9 +1376,9 @@ leap_second_directive:
 imp_directive:
   /* GnuCOBOL 3.3 extension */
 	INCLUDE
-	{
-		ppparse_error (_("Missing argument for IMP INCLUDE directive"));
-	}
+  {
+	ppparse_error (_("Missing argument for IMP INCLUDE directive"));
+  }
 | INCLUDE imp_include_sources
   {
 	struct cb_text_list *p = $2;

--- a/cobc/ppparse.y
+++ b/cobc/ppparse.y
@@ -741,6 +741,9 @@ ppparse_clear_vars (const struct cb_define_struct *p)
 %token WITH
 %token LOCATION
 
+%token IMP_DIRECTIVE
+%token INCLUDE
+
 %token TERMINATOR	"end of line"
 
 %token <s> TOKEN		"Word or Literal"
@@ -768,6 +771,7 @@ ppparse_clear_vars (const struct cb_define_struct *p)
 %type <l>	alnum_equality_list
 %type <l>	ec_list
 %type <s>	unquoted_literal
+%type <l>	imp_include_sources
 
 %type <r>	_copy_replacing
 %type <r>	replacing_list
@@ -838,6 +842,7 @@ directive:
 | TURN_DIRECTIVE turn_directive
 | LISTING_DIRECTIVE listing_directive
 | LEAP_SECOND_DIRECTIVE leap_second_directive
+| IMP_DIRECTIVE imp_directive
 | IF_DIRECTIVE
   {
 	current_cmd = PLEX_ACT_IF;
@@ -1366,6 +1371,29 @@ leap_second_directive:
 	CB_PENDING (_("LEAP-SECOND ON directive"));
   }
 | OFF
+;
+
+imp_directive:
+  /* GnuCOBOL 3.3 extension */
+  INCLUDE imp_include_sources
+  {
+	struct cb_text_list *p = $2;
+	while (p != NULL) {
+		fprintf (ppout, "#INCLUDE %s\n", p->text);
+		p = p->next;
+	}
+  }
+;
+
+imp_include_sources:
+  TOKEN
+  {
+	$$ = ppp_list_add (NULL, fix_filename ($1));
+  }
+| imp_include_sources TOKEN
+  {
+	$$ = ppp_list_add ($1, fix_filename ($2));
+  }
 ;
 
 turn_directive:

--- a/cobc/ppparse.y
+++ b/cobc/ppparse.y
@@ -1375,7 +1375,11 @@ leap_second_directive:
 
 imp_directive:
   /* GnuCOBOL 3.3 extension */
-  INCLUDE imp_include_sources
+	INCLUDE
+	{
+		ppparse_error (_("Missing argument for IMP INCLUDE directive"));
+	}
+| INCLUDE imp_include_sources
   {
 	struct cb_text_list *p = $2;
 	while (p != NULL) {

--- a/cobc/scanner.l
+++ b/cobc/scanner.l
@@ -2595,8 +2595,8 @@ scan_list_add (struct cb_text_list *list, const char *text)
 {
 	struct cb_text_list	*p;
 
-	p = cobc_malloc (sizeof (struct cb_text_list));
-	p->text = cobc_strdup (text);
+	p = cobc_parse_malloc (sizeof (struct cb_text_list));
+	p->text = cobc_parse_strdup (text);
 	if (!list) {
 		p->last = p;
 		return p;

--- a/cobc/scanner.l
+++ b/cobc/scanner.l
@@ -172,6 +172,8 @@ static size_t			pic2_size;
 static unsigned int		inside_bracket = 0;
 static char			err_msg[COB_MINI_BUFF];
 
+struct cb_text_list	*cb_include_file_list_directive = NULL;
+
 /* Function declarations */
 static void	read_literal (const char, const enum cb_literal_type);
 static int	scan_x (const char *, const char *);
@@ -189,6 +191,7 @@ static void	copy_two_words_in_quotes (char ** const, char ** const);
 static void	add_synonym (const int, const int);
 static void	make_synonym (void);
 static void clear_constants (void);
+static struct cb_text_list *scan_list_add (struct cb_text_list *, const char *);
 
 %}
 
@@ -318,6 +321,13 @@ AREA_A		"#AREA_A"\n
 
 <*>^[ ]?"#NOAREACHECK"\n {
 	cobc_areacheck = 0;
+}
+
+<*>^[ ]?"#INCLUDE".*/\n {
+	cb_include_file_list_directive = scan_list_add (
+		cb_include_file_list_directive,
+		yytext + 9
+	);
 }
 
 <*>^{AREA_A}[ ]*/"." {
@@ -2578,6 +2588,22 @@ clear_constants (void)
 		cobc_free (p78);
 	}
 	top_78_ptr = NULL;
+}
+
+static struct cb_text_list *
+scan_list_add (struct cb_text_list *list, const char *text)
+{
+	struct cb_text_list	*p;
+
+	p = cobc_malloc (sizeof (struct cb_text_list));
+	p->text = cobc_strdup (text);
+	if (!list) {
+		p->last = p;
+		return p;
+	}
+	list->last->next = p;
+	list->last = p;
+	return list;
 }
 
 /* Global functions */

--- a/cobc/scanner.l
+++ b/cobc/scanner.l
@@ -220,7 +220,7 @@ AREA_A		"#AREA_A"\n
 	cobc_in_area_a = 0;
 %}
 
-<*>^[ ]?"#CALLFH".*\n {
+<*>^"#CALLFH".*\n {
 	if (current_program) {
 		const char	*p1;
 		char		*p2;
@@ -243,11 +243,11 @@ AREA_A		"#AREA_A"\n
 }
 
 
-<*>^[ ]?"#DEFLIT".*\n {
+<*>^"#DEFLIT".*\n {
 	scan_define_options (yytext);
 }
 
-<*>^[ ]?"#ADDRSV".*\n {
+<*>^"#ADDRSV".*\n {
 	char	*word;
 
 	copy_word_in_quotes (&word);
@@ -255,25 +255,25 @@ AREA_A		"#AREA_A"\n
 	cobc_free (word);
 }
 
-<*>^[ ]?"#ADDSYN-STD".*\n {
+<*>^"#ADDSYN-STD".*\n {
 	add_synonym (1, 0);
 }
-<*>^[ ]?"#ADDSYN".*\n {
+<*>^"#ADDSYN".*\n {
 	add_synonym (0, 0);
 }
 
-<*>^[ ]?"#MAKESYN".*\n {
+<*>^"#MAKESYN".*\n {
 	make_synonym ();
  }
 
-<*>^[ ]?"#OVERRIDE-STD".*\n {
+<*>^"#OVERRIDE-STD".*\n {
 	add_synonym (1, 1);
 }
-<*>^[ ]?"#OVERRIDE".*\n {
+<*>^"#OVERRIDE".*\n {
 	add_synonym (0, 1);
 }
 
-<*>^[ ]?"#REMOVE-STD".*\n {
+<*>^"#REMOVE-STD".*\n {
 	char	*word;
 
 	copy_word_in_quotes (&word);
@@ -286,7 +286,7 @@ AREA_A		"#AREA_A"\n
 	cobc_free (word);
 }
 
-<*>^[ ]?"#REMOVE".*\n {
+<*>^"#REMOVE".*\n {
 	char	*word;
 
 	copy_word_in_quotes (&word);
@@ -294,19 +294,19 @@ AREA_A		"#AREA_A"\n
 	cobc_free (word);
 }
 
-<*>^[ ]?"#REFMOD_ZERO "[0-9]\n {
+<*>^"#REFMOD_ZERO "[0-9]\n {
 	cb_ref_mod_zero_length = (yytext[13] - '0');
 }
 
-<*>^[ ]?"#ODOSLIDE "[0-1]\n {
+<*>^"#ODOSLIDE "[0-1]\n {
 	cb_odoslide = (yytext[10] - '0');
 }
 
-<*>^[ ]?"#ASSIGN "[0-9]\n {
+<*>^"#ASSIGN "[0-9]\n {
 	cb_assign_type_default = (enum cb_assign_type)(yytext[8] - '0');
 }
 
-<*>^[ ]?"#TURN".*\n {
+<*>^"#TURN".*\n {
 	struct cb_turn_list	*l;
 
 	for (l = cb_turn_list; l && l->line != -1; l = l->next);
@@ -315,15 +315,15 @@ AREA_A		"#AREA_A"\n
 	}
 }
 
-<*>^[ ]?"#AREACHECK"\n {
+<*>^"#AREACHECK"\n {
 	cobc_areacheck = 1;
 }
 
-<*>^[ ]?"#NOAREACHECK"\n {
+<*>^"#NOAREACHECK"\n {
 	cobc_areacheck = 0;
 }
 
-<*>^[ ]?"#INCLUDE".*/\n {
+<*>^"#INCLUDE".*/\n {
 	cb_include_file_list_directive = scan_list_add (
 		cb_include_file_list_directive,
 		yytext + 9

--- a/doc/gnucobol.texi
+++ b/doc/gnucobol.texi
@@ -386,6 +386,8 @@ Add a @code{#include} @file{file.h} at the beginning of the generated
 C source file. The file name is put into quotes, unless it starts by
 @code{<}. Quoted files should be absolute paths, since C files are compiled
 in temporary directories.
+The directive @code{>>IMP INCLUDE "FILE.h"} or @code{>>IMP INCLUDE <FILE.h>}
+can be used as an alternative to this compiler option.
 The option also implies @option{-fno-gen-c-decl-static-call}.
 This option can be used to check function prototypes when
 static calls are used. When this option is used, the source file is

--- a/tests/testsuite.src/syn_misc.at
+++ b/tests/testsuite.src/syn_misc.at
@@ -8447,7 +8447,7 @@ AT_DATA([prog2.cob], [
 ])
 
 AT_CHECK([$COMPILE_ONLY prog2.cob], [1], [],
-[prog2.cob:2: error: Missing argument for IMP INCLUDE directive
+[prog2.cob:2: error: invalid IMP INCLUDE directive
 ])
 
 AT_CLEANUP
@@ -8464,6 +8464,10 @@ AT_DATA([prog.cob], [
            GOBACK.
 ])
 
-AT_CHECK([$COMPILE_ONLY prog.cob], [0], [], [])
+AT_CHECK([$COMPILE --save-temps -E -o prog.i prog.cob], [0], [], [])
+AT_CHECK([$GREP "#INCLUDE file1.h"   prog.i], [0], ignore, [])
+AT_CHECK([$GREP "#INCLUDE file2.h"   prog.i], [0], ignore, [])
+AT_CHECK([$GREP "#INCLUDE <file3.h>" prog.i], [0], ignore, [])
+AT_CHECK([$GREP "#INCLUDE <file4.h>" prog.i], [0], ignore, [])
 
 AT_CLEANUP

--- a/tests/testsuite.src/syn_misc.at
+++ b/tests/testsuite.src/syn_misc.at
@@ -8447,7 +8447,7 @@ AT_DATA([prog2.cob], [
 ])
 
 AT_CHECK([$COMPILE_ONLY prog2.cob], [1], [],
-[prog2.cob:2: error: prog2.cob:2: error: PROGRAM-ID header missing
+[prog2.cob:2: error: Missing argument for IMP INCLUDE directive
 ])
 
 AT_CLEANUP

--- a/tests/testsuite.src/syn_misc.at
+++ b/tests/testsuite.src/syn_misc.at
@@ -8464,10 +8464,22 @@ AT_DATA([prog.cob], [
            GOBACK.
 ])
 
+AT_DATA([prog2.cob], [
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. prog.
+       PROCEDURE DIVISION.
+           GOBACK.
+])
+
 AT_CHECK([$COMPILE --save-temps -E -o prog.i prog.cob], [0], [], [])
+AT_CHECK([$COMPILE -C prog.cob prog2.cob], [0], [], [])
 AT_CHECK([$GREP "#INCLUDE file1.h"   prog.i], [0], ignore, [])
 AT_CHECK([$GREP "#INCLUDE file2.h"   prog.i], [0], ignore, [])
 AT_CHECK([$GREP "#INCLUDE <file3.h>" prog.i], [0], ignore, [])
 AT_CHECK([$GREP "#INCLUDE <file4.h>" prog.i], [0], ignore, [])
+AT_CHECK([$GREP "#INCLUDE file1.h"   prog.c], [1], ignore, [])
+AT_CHECK([$GREP "#INCLUDE file2.h"   prog.c], [1], ignore, [])
+AT_CHECK([$GREP "#INCLUDE <file3.h>" prog.c], [1], ignore, [])
+AT_CHECK([$GREP "#INCLUDE <file4.h>" prog.c], [1], ignore, [])
 
 AT_CLEANUP

--- a/tests/testsuite.src/syn_misc.at
+++ b/tests/testsuite.src/syn_misc.at
@@ -8426,17 +8426,7 @@ AT_DATA([prog.cob], [
            GOBACK.
 ])
 
-AT_CHECK([$COMPILE_ONLY -fformat=fixed prog.cob], [0], [], [])
-
-AT_DATA([prog.cob], [
->>IMP INCLUDE "file.h"
-identification division.
-program-id. prog.
-procedure division.
-    goback.
-])
-
-AT_CHECK([$COMPILE_ONLY -fformat=free prog.cob], [0], [], [])
+AT_CHECK([$COMPILE_ONLY prog.cob], [0], [], [])
 
 AT_DATA([prog.cob], [
        >>IMP INCLUDE <file.h>
@@ -8446,9 +8436,9 @@ AT_DATA([prog.cob], [
            GOBACK.
 ])
 
-AT_CHECK([$COMPILE_ONLY -fformat=fixed prog.cob], [0], [], [])
+AT_CHECK([$COMPILE_ONLY prog.cob], [0], [], [])
 
-AT_DATA([prog.cob], [
+AT_DATA([prog2.cob], [
        >>IMP INCLUDE
        IDENTIFICATION DIVISION.
        PROGRAM-ID. prog.
@@ -8456,9 +8446,9 @@ AT_DATA([prog.cob], [
            GOBACK.
 ])
 
-AT_CHECK([$COMPILE_ONLY -fformat=fixed prog.cob], [1], [],
-[prog.cob:2: error: syntax error, unexpected end of line, expecting Word or Literal
-prog.cob:2: error: PROGRAM-ID header missing
+AT_CHECK([$COMPILE_ONLY prog2.cob], [1], [],
+[prog2.cob:2: error: syntax error, unexpected end of line, expecting Word or Literal
+prog2.cob:2: error: PROGRAM-ID header missing
 ])
 
 AT_CLEANUP
@@ -8468,13 +8458,13 @@ AT_SETUP([IMP INCLUDE directive multiple files])
 AT_KEYWORDS([IMP INCLUDE])
 
 AT_DATA([prog.cob], [
->>IMP INCLUDE "file1.h" file2.h <file3.h> "<file4.h>"
-identification division.
-program-id. prog.
-procedure division.
-    goback.
+       >>IMP INCLUDE "file1.h" file2.h <file3.h> "<file4.h>"
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. PROG.
+       PROCEDURE DIVISION.
+           GOBACK.
 ])
 
-AT_CHECK([$COMPILE_ONLY -fformat=free prog.cob], [0], [], [])
+AT_CHECK([$COMPILE_ONLY prog.cob], [0], [], [])
 
 AT_CLEANUP

--- a/tests/testsuite.src/syn_misc.at
+++ b/tests/testsuite.src/syn_misc.at
@@ -8414,3 +8414,67 @@ prog.cob:18: error: ANY LENGTH items may only be BY REFERENCE formal parameters
 
 AT_CLEANUP
 
+
+AT_SETUP([IMP INCLUDE directive])
+AT_KEYWORDS([IMP INCLUDE])
+
+AT_DATA([prog.cob], [
+       >>IMP INCLUDE "file.h"
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. prog.
+       PROCEDURE DIVISION.
+           GOBACK.
+])
+
+AT_CHECK([$COMPILE_ONLY -fformat=fixed prog.cob], [0], [], [])
+
+AT_DATA([prog.cob], [
+>>IMP INCLUDE "file.h"
+identification division.
+program-id. prog.
+procedure division.
+    goback.
+])
+
+AT_CHECK([$COMPILE_ONLY -fformat=free prog.cob], [0], [], [])
+
+AT_DATA([prog.cob], [
+       >>IMP INCLUDE <file.h>
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. prog.
+       PROCEDURE DIVISION.
+           GOBACK.
+])
+
+AT_CHECK([$COMPILE_ONLY -fformat=fixed prog.cob], [0], [], [])
+
+AT_DATA([prog.cob], [
+       >>IMP INCLUDE
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. prog.
+       PROCEDURE DIVISION.
+           GOBACK.
+])
+
+AT_CHECK([$COMPILE_ONLY -fformat=fixed prog.cob], [1], [],
+[prog.cob:2: error: syntax error, unexpected end of line, expecting Word or Literal
+prog.cob:2: error: PROGRAM-ID header missing
+])
+
+AT_CLEANUP
+
+
+AT_SETUP([IMP INCLUDE directive multiple files])
+AT_KEYWORDS([IMP INCLUDE])
+
+AT_DATA([prog.cob], [
+>>IMP INCLUDE "file1.h" file2.h <file3.h> "<file4.h>"
+identification division.
+program-id. prog.
+procedure division.
+    goback.
+])
+
+AT_CHECK([$COMPILE_ONLY -fformat=free prog.cob], [0], [], [])
+
+AT_CLEANUP

--- a/tests/testsuite.src/syn_misc.at
+++ b/tests/testsuite.src/syn_misc.at
@@ -8447,8 +8447,7 @@ AT_DATA([prog2.cob], [
 ])
 
 AT_CHECK([$COMPILE_ONLY prog2.cob], [1], [],
-[prog2.cob:2: error: syntax error, unexpected end of line, expecting Word or Literal
-prog2.cob:2: error: PROGRAM-ID header missing
+[prog2.cob:2: error: prog2.cob:2: error: PROGRAM-ID header missing
 ])
 
 AT_CLEANUP

--- a/tests/testsuite.src/used_binaries.at
+++ b/tests/testsuite.src/used_binaries.at
@@ -1168,9 +1168,6 @@ AT_CHECK([$COMPILE_MODULE -I . -fstatic-call prog3.cob], [0], [], [], [
   AT_CHECK([$COMPILE_MODULE -I . -fstatic-call -L. -lfilec prog3.cob], [0], ignore, ignore)]
 )
 
-# static build with correct function signature
-# AT_CHECK([$COBC -m -I . -fstatic-call prog3.cob], [0], [], [])
-
 AT_CLEANUP
 
 

--- a/tests/testsuite.src/used_binaries.at
+++ b/tests/testsuite.src/used_binaries.at
@@ -1074,7 +1074,7 @@ AT_CLEANUP
 
 
 AT_SETUP([check include header file])
-#AT_KEYWORDS([cobc copy])
+#AT_KEYWORDS([cobc copy include imp])
 
 AT_DATA([filec.h], [
 /* COB_EXT_IMPORT will be defined by libcob.h up-front */
@@ -1149,6 +1149,20 @@ AT_CHECK([$COMPILE_MODULE -Wno-unfinished --copy "f.copy" -fstatic-call prog2.co
   # Previous test "failed" --> retry with import library
   AT_CHECK([$COMPILE_MODULE -Wno-unfinished --copy "f.copy" -fstatic-call -L. -lfilec prog2.cob -o prog2c], [0], ignore, ignore)]
 )
+
+AT_DATA([prog3.cob], [
+       >> IMP INCLUDE "file.h"
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      prog.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01 long USAGE BINARY-C-LONG.
+       PROCEDURE        DIVISION.
+           CALL "f" USING "Hello" BY VALUE long RETURNING NOTHING.
+])
+
+# static build with correct function signature
+# AT_CHECK([$COBC -m -I . -fstatic-call prog3.cob], [0], [], [])
 
 AT_CLEANUP
 

--- a/tests/testsuite.src/used_binaries.at
+++ b/tests/testsuite.src/used_binaries.at
@@ -1074,7 +1074,7 @@ AT_CLEANUP
 
 
 AT_SETUP([check include header file])
-#AT_KEYWORDS([cobc copy include imp])
+AT_KEYWORDS([cobc copy directive imp])
 
 AT_DATA([filec.h], [
 /* COB_EXT_IMPORT will be defined by libcob.h up-front */
@@ -1150,8 +1150,9 @@ AT_CHECK([$COMPILE_MODULE -Wno-unfinished --copy "f.copy" -fstatic-call prog2.co
   AT_CHECK([$COMPILE_MODULE -Wno-unfinished --copy "f.copy" -fstatic-call -L. -lfilec prog2.cob -o prog2c], [0], ignore, ignore)]
 )
 
+# additional check via directive
 AT_DATA([prog3.cob], [
-       >> IMP INCLUDE "file.h"
+       >> IMP INCLUDE "filec.h"
        IDENTIFICATION   DIVISION.
        PROGRAM-ID.      prog.
        DATA DIVISION.
@@ -1160,6 +1161,12 @@ AT_DATA([prog3.cob], [
        PROCEDURE        DIVISION.
            CALL "f" USING "Hello" BY VALUE long RETURNING NOTHING.
 ])
+
+# static build with correct function signature
+AT_CHECK([$COMPILE_MODULE -I . -fstatic-call prog3.cob], [0], [], [], [
+  # Previous test "failed" --> retry with import library
+  AT_CHECK([$COMPILE_MODULE -I . -fstatic-call -L. -lfilec prog3.cob], [0], ignore, ignore)]
+)
 
 # static build with correct function signature
 # AT_CHECK([$COBC -m -I . -fstatic-call prog3.cob], [0], [], [])


### PR DESCRIPTION
Closes #114  and completes FR176 on SourceForge.

A new directive `>> IMP INCLUDE FILE_1 ... FILE_n` is introduced, allowing to include multiple C headers. Only files with name finishing by `.h` are allowed.

I'm not sure about that but I marked the feature with `/* GnuCOBOL 3.3 extension*/`.