### PR TITLE
Fix MSVC builds - missing profiling.c

### DIFF
--- a/build_windows/ChangeLog.txt
+++ b/build_windows/ChangeLog.txt
@@ -1,4 +1,8 @@
 
+2024-05-13  David Declerck <david.declerck@ocamlpro.com>
+
+	* general for libcob: add missing profiling.c
+
 2023-07-07  Simon Sobisch <simonsobisch@gnu.org>
 
 	* general for cobc: include new replace.c

--- a/build_windows/ocide/libcob.dll.cpj
+++ b/build_windows/ocide/libcob.dll.cpj
@@ -47,6 +47,7 @@
 				<FILE NAME="..\..\libcob\mlio.c" TITLE="mlio.c" CLEAN="0"/>
 				<FILE NAME="..\..\libcob\move.c" TITLE="move.c" CLEAN="0"/>
 				<FILE NAME="..\..\libcob\numeric.c" TITLE="numeric.c" CLEAN="0"/>
+				<FILE NAME="..\..\libcob\profiling.c" TITLE="profiling.c" CLEAN="0"/>
 				<FILE NAME="..\..\libcob\reportio.c" TITLE="reportio.c" CLEAN="0"/>
 				<FILE NAME="..\..\libcob\screenio.c" TITLE="screenio.c" CLEAN="0"/>
 				<FILE NAME="..\..\libcob\strings.c" TITLE="strings.c" CLEAN="0"/>

--- a/build_windows/vs2005/libcob.vcproj
+++ b/build_windows/vs2005/libcob.vcproj
@@ -228,6 +228,10 @@
 				>
 			</File>
 			<File
+				RelativePath="..\..\libcob\profiling.c"
+				>
+			</File>
+			<File
 				RelativePath="..\..\libcob\reportio.c"
 				>
 			</File>

--- a/build_windows/vs2008/libcob.vcproj
+++ b/build_windows/vs2008/libcob.vcproj
@@ -224,6 +224,10 @@
 				>
 			</File>
 			<File
+				RelativePath="..\..\libcob\profiling.c"
+				>
+			</File>
+			<File
 				RelativePath="..\..\libcob\reportio.c"
 				>
 			</File>

--- a/build_windows/vs2010/libcob.vcxproj
+++ b/build_windows/vs2010/libcob.vcxproj
@@ -174,6 +174,7 @@
     <ClCompile Include="..\..\libcob\mlio.c" />
     <ClCompile Include="..\..\libcob\move.c" />
     <ClCompile Include="..\..\libcob\numeric.c" />
+    <ClCompile Include="..\..\libcob\profiling.c" />
     <ClCompile Include="..\..\libcob\reportio.c" />
     <ClCompile Include="..\..\libcob\screenio.c" />
     <ClCompile Include="..\..\libcob\strings.c" />

--- a/build_windows/vs2010/libcob.vcxproj.filters
+++ b/build_windows/vs2010/libcob.vcxproj.filters
@@ -54,6 +54,9 @@
     <ClCompile Include="..\..\libcob\mlio.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\libcob\profiling.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\config.h">

--- a/build_windows/vs2012/libcob.vcxproj
+++ b/build_windows/vs2012/libcob.vcxproj
@@ -176,6 +176,7 @@
     <ClCompile Include="..\..\libcob\mlio.c" />
     <ClCompile Include="..\..\libcob\move.c" />
     <ClCompile Include="..\..\libcob\numeric.c" />
+    <ClCompile Include="..\..\libcob\profiling.c" />
     <ClCompile Include="..\..\libcob\reportio.c" />
     <ClCompile Include="..\..\libcob\screenio.c" />
     <ClCompile Include="..\..\libcob\strings.c" />

--- a/build_windows/vs2012/libcob.vcxproj.filters
+++ b/build_windows/vs2012/libcob.vcxproj.filters
@@ -54,6 +54,9 @@
     <ClCompile Include="..\..\libcob\mlio.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\libcob\profiling.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\config.h">

--- a/build_windows/vs2013/libcob.vcxproj
+++ b/build_windows/vs2013/libcob.vcxproj
@@ -177,6 +177,7 @@
     <ClCompile Include="..\..\libcob\mlio.c" />
     <ClCompile Include="..\..\libcob\move.c" />
     <ClCompile Include="..\..\libcob\numeric.c" />
+    <ClCompile Include="..\..\libcob\profiling.c" />
     <ClCompile Include="..\..\libcob\reportio.c" />
     <ClCompile Include="..\..\libcob\screenio.c" />
     <ClCompile Include="..\..\libcob\strings.c" />

--- a/build_windows/vs2013/libcob.vcxproj.filters
+++ b/build_windows/vs2013/libcob.vcxproj.filters
@@ -54,6 +54,9 @@
     <ClCompile Include="..\..\libcob\mlio.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\libcob\profiling.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\config.h">

--- a/build_windows/vs2015/libcob.vcxproj
+++ b/build_windows/vs2015/libcob.vcxproj
@@ -168,6 +168,7 @@
     <ClCompile Include="..\..\libcob\mlio.c" />
     <ClCompile Include="..\..\libcob\move.c" />
     <ClCompile Include="..\..\libcob\numeric.c" />
+    <ClCompile Include="..\..\libcob\profiling.c" />
     <ClCompile Include="..\..\libcob\reportio.c" />
     <ClCompile Include="..\..\libcob\screenio.c" />
     <ClCompile Include="..\..\libcob\strings.c" />

--- a/build_windows/vs2015/libcob.vcxproj.filters
+++ b/build_windows/vs2015/libcob.vcxproj.filters
@@ -54,6 +54,9 @@
     <ClCompile Include="..\..\libcob\mlio.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\libcob\profiling.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\config.h">

--- a/build_windows/vs2017/libcob.vcxproj
+++ b/build_windows/vs2017/libcob.vcxproj
@@ -173,6 +173,7 @@
     <ClCompile Include="..\..\libcob\mlio.c" />
     <ClCompile Include="..\..\libcob\move.c" />
     <ClCompile Include="..\..\libcob\numeric.c" />
+    <ClCompile Include="..\..\libcob\profiling.c" />
     <ClCompile Include="..\..\libcob\reportio.c" />
     <ClCompile Include="..\..\libcob\screenio.c" />
     <ClCompile Include="..\..\libcob\strings.c" />

--- a/build_windows/vs2017/libcob.vcxproj.filters
+++ b/build_windows/vs2017/libcob.vcxproj.filters
@@ -54,6 +54,9 @@
     <ClCompile Include="..\..\libcob\mlio.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\libcob\profiling.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\config.h">

--- a/build_windows/vs2019/libcob.vcxproj
+++ b/build_windows/vs2019/libcob.vcxproj
@@ -173,6 +173,7 @@
     <ClCompile Include="..\..\libcob\mlio.c" />
     <ClCompile Include="..\..\libcob\move.c" />
     <ClCompile Include="..\..\libcob\numeric.c" />
+    <ClCompile Include="..\..\libcob\profiling.c" />
     <ClCompile Include="..\..\libcob\reportio.c" />
     <ClCompile Include="..\..\libcob\screenio.c" />
     <ClCompile Include="..\..\libcob\strings.c" />

--- a/build_windows/vs2019/libcob.vcxproj.filters
+++ b/build_windows/vs2019/libcob.vcxproj.filters
@@ -54,6 +54,9 @@
     <ClCompile Include="..\..\libcob\mlio.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\libcob\profiling.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\config.h">

--- a/cobc/flag.def
+++ b/cobc/flag.def
@@ -119,11 +119,16 @@ CB_FLAG (cb_flag_winmain, COB_SHOW, "winmain",
 #undef COB_SHOW
 
 #ifdef HAVE_ATTRIBUTE_CONSTRUCTOR
-CB_FLAG_ON (cb_flag_use_constructor, 1, "use-constructor",
+#define CB_FLAG_M CB_FLAG_ON
+#define COB_SHOW 1
 #else
-CB_FLAG (cb_flag_use_constructor, 0, "use-constructor",
+#define CB_FLAG_M CB_FLAG
+#define COB_SHOW 0
 #endif
+CB_FLAG_M (cb_flag_use_constructor, COB_SHOW, "use-constructor",
 	_("  -fuse-constructor     generate internal one-time code via constructor"))
+#undef CB_FLAG_M
+#undef COB_SHOW
 
 CB_FLAG (cb_flag_computed_goto, 0, "computed-goto",
 	_("  -fcomputed-goto       generate computed goto C statements"))


### PR DESCRIPTION
Follow-up of https://github.com/OCamlPro/gnucobol/pull/110#issuecomment-2091486360.

Add missing profiling.c file in MSVC projects.
Also fix usage of preprocessor directives inside macro in `flag.def` (MSVC does not seem to like that).