### PR TITLE
Handle BDB keys of different length

### DIFF
--- a/libcob/ChangeLog
+++ b/libcob/ChangeLog
@@ -20,6 +20,12 @@
 	  (indirect_move): fixed bug when calculating scale of 
 	  the intermediate cob field
 
+2024-07-09  Boris Eng <boris.eng@ocamlpro.com>
+
+	* fileio.c (bdb_bt_compare, indexed_open): handle BDB keys of different
+	  length with a flag USE_BDB_KEYDIFF (passed with preparser flag CPPFLAGS)
+	* common.c (cob_cmp_strings), coblocal.h (cob_cmp_strings):
+	  extracted from (cob_cmp_alnum)
 
 2024-07-02  Chuck Haatvedt <chuck.haatvedt+cobol@gmail.com>
 

--- a/libcob/coblocal.h
+++ b/libcob/coblocal.h
@@ -494,6 +494,9 @@ COB_HIDDEN const char	*cob_get_last_exception_name	(void);
 COB_HIDDEN void		cob_parameter_check	(const char *, const int);
 COB_HIDDEN char*        cob_get_strerror (void);
 
+COB_HIDDEN int		cob_cmp_strings (unsigned char*, unsigned char*,
+						 size_t, size_t, const unsigned char*);
+
 enum cob_case_modifier {
 	CCM_NONE,
 	CCM_LOWER,

--- a/libcob/common.c
+++ b/libcob/common.c
@@ -1975,16 +1975,14 @@ cob_cmp_all (cob_field *f1, cob_field *f2)
 	return ret;
 }
 
-/* compare content of field 'f1' to content of 'f2', space padded,
-   using the optional collating sequence of the program */
-static int
-cob_cmp_alnum (cob_field *f1, cob_field *f2)
+/* compare string 'data1' to string 'data2', of size 'size1' and 'size2'
+   respectively, space padded, using a given collating sequence */
+int
+cob_cmp_strings (
+	unsigned char* data1, unsigned char* data2,
+	size_t size1, size_t size2,
+	const unsigned char *col)
 {
-	const unsigned char	*col = COB_MODULE_PTR->collating_sequence;
-	const unsigned char	*data1 = COB_FIELD_DATA (f1);
-	const unsigned char	*data2 = COB_FIELD_DATA (f2);
-	const size_t		size1 = COB_FIELD_SIZE (f1);
-	const size_t		size2 = COB_FIELD_SIZE (f2);	
 	const size_t	min = (size1 < size2) ? size1 : size2;
 	int		ret;
 
@@ -2023,6 +2021,20 @@ cob_cmp_alnum (cob_field *f1, cob_field *f2)
 	}
 
 	return 0;
+}
+
+/* compare content of field 'f1' to content of 'f2', space padded,
+   using the optional collating sequence of the program */
+static int
+cob_cmp_alnum (cob_field *f1, cob_field *f2)
+{
+	return cob_cmp_strings (
+		(unsigned char *)COB_FIELD_DATA (f1),
+		(unsigned char *)COB_FIELD_DATA (f2),
+		COB_FIELD_SIZE (f1),
+		COB_FIELD_SIZE (f2),
+		COB_MODULE_PTR->collating_sequence
+	);
 }
 
 /* comparision of all key fields for SORT (without explicit collation)


### PR DESCRIPTION
Fix for issue #154 

# Problem

The function `libcob/fileio.c:bdb_bt_compare` fails on keys of different length passed in arguments. This is necessary since valid BDB files containing additional data interpreted as keys of different length may be used with GnuCOBOL  (example given from one of our customers). Such files may be produced by external tools but still meant to be readable.

# Solution

Use the already implemented `libcob/common.c:cob_cmp_alnum` function (now made external) to compare keys as alphanumeric fields of possibly different length (padded with spaces).

This PR introduces a new preparser flag `USE_BDB_KEYDIFF` with may be passed in the following way when compiling GnuCOBOL sources:
```
CPPFLAGS=-DUSE_BDB_KEYDIFF ./configure
make
```

This flag allows such BDB keys of different length as an option since it has an overhead cost.

#  Notes

I have also been suggested to

> also include the variant that operates on not 100% confirming BDB files (always using a sort function) (from @GitMensch, cf. issue #154)

Which is something I do not currently understand.