### PR TITLE
Fix some tests under MSVC debug

### DIFF
--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -166,9 +166,6 @@ jobs:
         run: |
           cd tests
 
-          sed -i '/AT_SETUP(\[MF FIGURATIVE to NUMERIC\])/a AT_SKIP_IF(\[true\])' testsuite.src/run_misc.at
-          sed -i '/AT_SETUP(\[Default file external name\])/a AT_SKIP_IF(\[true\])' testsuite.src/run_file.at
-          sed -i '/AT_SETUP(\[EXTFH: SEQUENTIAL files\])/a AT_SKIP_IF(\[true\])' testsuite.src/run_file.at
           sed -i '/AT_SETUP(\[System routine CBL_GC_HOSTED\])/a AT_SKIP_IF(\[true\])' testsuite.src/run_extensions.at
 
           sed -i '/AT_SETUP(\[MOVE to edited item (4)\])/a AT_SKIP_IF(\[true\])' testsuite.src/run_fundamental.at

--- a/tests/ChangeLog
+++ b/tests/ChangeLog
@@ -1,4 +1,11 @@
 
+2024-08-03  David Declerck <david.declerck@ocamlpro.com>
+
+	* testsuite.src/run_file.at, testsuite.src/run_misc.at:
+	  fix a few tests that break under MSVC Debug while working
+	  under MSVC Release, by forcing a flush of stdout with
+	  fflush in C codes and using cob_free instead of free
+
 2024-06-19  David Declerck <david.declerck@ocamlpro.com>
 
 	* atlocal_win: fix path-related issues in Windows builds

--- a/tests/testsuite.src/run_file.at
+++ b/tests/testsuite.src/run_file.at
@@ -4297,7 +4297,7 @@ fexists_signed (char *fid, char *signature, int signature_size)
 					res = 0;
 				}
 		}
-		free (bfr);
+		cob_free (bfr);
 	}
 	return res;
 }
@@ -9040,6 +9040,7 @@ doOpenFile(
    printf("EXFTH did %s; Status=%c%c; File now %s\n",
        opmsg, fcd->fileStatus[0], fcd->fileStatus[1],
        (fcd->openMode & OPEN_NOT_OPEN) ? "Closed" : "Open");
+   fflush(stdout);
    return sts;
 }
 
@@ -9094,6 +9095,7 @@ TSTFH (unsigned char *opCodep, FCD3 *fcd)
    sts = EXTFH(opCodep, fcd);
    printf("EXFTH did %s; Status=%c%c\n", txtOpCode(opCode),
        fcd->fileStatus[0], fcd->fileStatus[1]);
+   fflush(stdout);
    return sts;
 }
 

--- a/tests/testsuite.src/run_misc.at
+++ b/tests/testsuite.src/run_misc.at
@@ -7486,6 +7486,7 @@ dump (unsigned char *data)
   for (i = 0; i < 4; i++)
     printf ("%02X", data[i]);
   puts (" .");
+  fflush(stdout);
   return 0;
 }
 ]])


### PR DESCRIPTION
This attemps to fix 3 tests that fail under MSVC Debug while OK in Release :
- MF FIGURATIVE to NUMERIC (run_misc)
- Default file external name (run_file)
- EXTFH: SEQUENTIAL files (run_file)

Note1: only "System routine CBL_GC_HOSTED" (run_extensions) remains failing under MSVC Debug while OK in Release, but this one seems a bit more tricky (as the test itself says: "test_errno.c must be compiled with same C runtime as libcob to match...")

Note2: all the tests mentionned above are not related to the runtime checker popups