### PR TITLE
CI adjustments for `gcos4gnucobol-3.x`

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -100,6 +100,7 @@ jobs:
           path: _build/tests/cobol85/newcob.val
           key: newcob-val
           save-always: true
+          enableCrossOsArchive: true
 
       - name: NIST85 Test Suite
         run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -94,24 +94,14 @@ jobs:
           name: testsuite-${{ matrix.os }}.log
           path: _build/tests/testsuite.log
 
-      - name: Cache newcob.val.tar.gz
+      - name: Cache newcob.val
         uses: actions/cache@v4
-        id: newcob
         with:
-          path: tests/cobol85/newcob.val.tar.gz.cached
-          key: newcob
+          path: _build/tests/cobol85/newcob.val
+          key: newcob-val
           save-always: true
-
-      - name: Download newcob.val.tar.gz
-        if: steps.newcob.outputs.cache-hit != 'true'
-        run: |
-          make -C _build/tests/cobol85 newcob.val.tar.gz
-          ln   -f _build/tests/cobol85/newcob.val.tar.gz        \
-                         tests/cobol85/newcob.val.tar.gz.cached
 
       - name: NIST85 Test Suite
         run: |
-          ln   -f        tests/cobol85/newcob.val.tar.gz.cached \
-                         tests/cobol85/newcob.val.tar.gz
           make -C _build/tests/cobol85 EXEC85 test              \
-                         --jobs=$(($(nproc)+1))
+                         --jobs=$((${NPROC}+1))

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -94,22 +94,24 @@ jobs:
           name: testsuite-${{ matrix.os }}.log
           path: _build/tests/testsuite.log
 
-      - name: Cache newcob.val.Z
-        uses: actions/cache@v3
+      - name: Cache newcob.val.tar.gz
+        uses: actions/cache@v4
         id: newcob
         with:
-          path: _build/tests/cobol85/newcob.val.Z.cached
+          path: tests/cobol85/newcob.val.tar.gz.cached
           key: newcob
+          save-always: true
 
-      - name: Download newcob.val.Z
+      - name: Download newcob.val.tar.gz
         if: steps.newcob.outputs.cache-hit != 'true'
         run: |
-          cd _build/tests/cobol85
-          make newcob.val.Z
-          ln -f newcob.val.Z newcob.val.Z.cached
+          make -C _build/tests/cobol85 newcob.val.tar.gz
+          ln   -f _build/tests/cobol85/newcob.val.tar.gz        \
+                         tests/cobol85/newcob.val.tar.gz.cached
 
       - name: NIST85 Test Suite
         run: |
-          cd _build/tests/cobol85
-          ln -f newcob.val.Z.cached newcob.val.Z
-          make EXEC85 && make --jobs=$(($(nproc)+1)) test
+          ln   -f        tests/cobol85/newcob.val.tar.gz.cached \
+                         tests/cobol85/newcob.val.tar.gz
+          make -C _build/tests/cobol85 EXEC85 test              \
+                         --jobs=$(($(nproc)+1))

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -24,7 +24,7 @@ jobs:
 
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install packages
         run: |
@@ -55,44 +55,44 @@ jobs:
       - name: configure
         run: |
           cd _build
-          ../configure --enable-cobc-internal-checks --enable-hardening --prefix /opt/cobol/gnucobol-gcos --exec-prefix /opt/cobol/gnucobol-gcos
+          ../configure --enable-cobc-internal-checks \
+                       --enable-hardening \
+                       --prefix /opt/cobol/gnucobol-gcos \
+                       --exec-prefix /opt/cobol/gnucobol-gcos
 
       - name: Upload config.log
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: config.log
+          name: config-${{ matrix.os }}.log
           path: _build/config.log
         if: failure()
 
       - name: make
         run: |
-          cd _build
-          make --jobs=$((${NPROC}+1))
+          make -C _build --jobs=$((${NPROC}+1))
 
 # make install must be done before make check, otherwise execution of
 # generated COBOL files fail for a missing /usr/local/lib/libcob.dylib
       - name: make install
         run: |
-          cd _build
-          sudo make install
-          find /opt/cobol > install.log
+          sudo make -C _build install
+          find /opt/cobol > _build/install.log
 
       - name: Upload install.log
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: install.log
+          name: install-${{ matrix.os }}.log
           path: _build/install.log
 
       - name: check
         run: |
-          cd _build
-          make check TESTSUITEFLAGS="--jobs=$((${NPROC}+1))"
+          make -C _build check TESTSUITEFLAGS="--jobs=$((${NPROC}+1))"
 
       - name: Upload testsuite.log
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: testsuite.log
+          name: testsuite-${{ matrix.os }}.log
           path: _build/tests/testsuite.log
 
       - name: Cache newcob.val.Z

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -56,7 +56,6 @@ jobs:
           ../configure --enable-cobc-internal-checks \
                        --enable-hardening \
                        --prefix /opt/cobol/gnucobol-gcos \
-                       --exec-prefix /opt/cobol/gnucobol-gcos
 
       - name: Upload config.log
         uses: actions/upload-artifact@v4
@@ -69,8 +68,9 @@ jobs:
         run: |
           make -C _build --jobs=$((${NPROC}+1))
 
-# make install must be done before make check, otherwise execution of
-# generated COBOL files fail for a missing /usr/local/lib/libcob.dylib
+      # make install must be done before make check, otherwise
+      # execution of generated COBOL files fail for a missing
+      # /usr/local/lib/libcob.dylib
       - name: make install
         run: |
           sudo make -C _build install
@@ -84,7 +84,8 @@ jobs:
 
       - name: check
         run: |
-          make -C _build check TESTSUITEFLAGS="--jobs=$((${NPROC}+1))"
+          make -C _build check \
+                         TESTSUITEFLAGS="--jobs=$((${NPROC}+1))"
 
       - name: Upload testsuite.log
         uses: actions/upload-artifact@v4

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches: [ gcos4gnucobol-3.x ]
   push:
-    branches: [ gcos4gnucobol-3.x ]
   # manual run in actions tab - for all branches
   workflow_dispatch:
 
@@ -14,7 +13,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-latest
+          # - macos-latest-large  # macos 14, amd64
+          - macos-latest        # macos 14, arm64
 
     runs-on: ${{ matrix.os }}
 
@@ -41,9 +41,7 @@ jobs:
 
       - name: bootstrap
         run: |
-          ./autogen.sh
-          autoconf
-          autoreconf --install --force
+          ./build_aux/bootstrap install
 
       - name: Build environment setup
         run: |

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -13,12 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-latest
-        include:
-          - os: ubuntu-latest
-            skip_test: true
-
+        os: [ ubuntu-latest ]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -37,7 +32,7 @@ jobs:
           git config --global user.name github-actions
           git config --global user.email github-actions-bot@users.noreply.github.com
 
-      - name: bootstrap
+      - name: Bootstrap
         run: |
           ./build_aux/bootstrap
 
@@ -62,7 +57,7 @@ jobs:
           echo "TERM=$TERM" >> $GITHUB_ENV
           echo "INSTALL_PATH=$(pwd)/_install" >> $GITHUB_ENV
 
-      - name: configure
+      - name: Configure
         run: |
           cd _build
           ../configure --enable-cobc-internal-checks \
@@ -78,12 +73,12 @@ jobs:
           name: config-${{ matrix.os }}.log
           path: _build/config.log
 
-      - name: make
+      - name: Build
         run: |
           make -C _build --jobs=$(($(nproc)+1))
 
       # note: distcheck also creates the dist tarball
-      - name: distcheck
+      - name: Build distribution archive & run tests
         run: |
           make -C _build distcheck                                \
                          TESTSUITEFLAGS="--jobs=$(($(nproc)+1))"  \
@@ -107,27 +102,30 @@ jobs:
           if-no-files-found: error
           retention-days: 0
 
-      - name: Cache newcob.val.Z
-        uses: actions/cache@v3
+      - name: Cache newcob.val.tar.gz
+        uses: actions/cache@v4
         id: newcob
         with:
-          path: _build/tests/cobol85/newcob.val.Z.cached
+          path: tests/cobol85/newcob.val.tar.gz.cached
           key: newcob
+          save-always: true
 
-      - name: Download newcob.val.Z
+      - name: Download newcob.val.tar.gz
         if: steps.newcob.outputs.cache-hit != 'true'
         run: |
-          cd _build/tests/cobol85
-          make newcob.val.Z
-          ln -f newcob.val.Z newcob.val.Z.cached
+          make -C _build/tests/cobol85 newcob.val.tar.gz
+          ln   -f _build/tests/cobol85/newcob.val.tar.gz        \
+                         tests/cobol85/newcob.val.tar.gz.cached
 
       - name: NIST85 Test Suite
         run: |
-          cd _build/tests/cobol85
-          ln -f newcob.val.Z.cached newcob.val.Z
-          make EXEC85 && make --jobs=$(($(nproc)+1)) test
+          ln   -f        tests/cobol85/newcob.val.tar.gz.cached           \
+                         tests/cobol85/newcob.val.tar.gz
+          make -C _build/tests/cobol85 EXEC85 test \
+                                       --jobs=$(($(nproc)+1))
 
-      - uses: actions/upload-artifact@v4
+      - name: Upload NIST85 Test Suite results
+        uses: actions/upload-artifact@v4
         with:
           name: NIST85 results on ${{ matrix.os }}
           path: |
@@ -140,7 +138,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
 
       # note: less dependencies as we don't generate a dist tarball, one additional for lcov
       - name: Install dependencies
@@ -148,7 +147,7 @@ jobs:
           sudo apt-get install automake libtool libdb5.3-dev libxml2-dev \
                                libcjson-dev bison flex help2man gettext lcov
 
-      - name: bootstrap
+      - name: Bootstrap
         run: |
           ./build_aux/bootstrap
 
@@ -162,40 +161,80 @@ jobs:
       # _another_ CI run
       #
       # TODO: try and pass -pedantic via CPPFLAGS
-      - name: configure
+      - name: Configure
         run: |
           cd _build
           ../configure --enable-code-coverage \
                        CPPFLAGS="-Werror=declaration-after-statement" \
                        CC="gcc -std=c89"
 
-      - uses: actions/upload-artifact@v4
+      - name: Upload config.log
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: config-${{ matrix.os }}.log
           path: _build/config.log
 
-      - name: make
+      - name: Build
         run: |
           make -C _build --jobs=$(($(nproc)+1))
 
-      - name: coverage
+      - name: Coverage
         run: |
-          make -C _build check-code-coverage \
+          # make -C _build check-code-coverage # <- (ignores errors)
+          make -C _build check \
                          TESTSUITEFLAGS="--jobs=$(($(nproc)+1))"
+          make -C _build code-coverage-capture \
+                         CODE_COVERAGE_DIRECTORY="$(realpath .)/_build"
 
-      - uses: actions/upload-artifact@v4
+      - name: Upload testsuite.log
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: testsuite-${{ matrix.os }}.log
           path: _build/tests/testsuite.log
 
-      - uses: actions/upload-artifact@v4
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-${{ matrix.os }}
-          path: _build/GnuCOBOL-**-coverage/
+          path: _build/GnuCOBOL-**-coverage
 
-      - uses: codecov/codecov-action@v2
+      - name: Cache newcob.val.tar.gz
+        uses: actions/cache@v4
+        id: newcob
+        with:
+          path: tests/cobol85/newcob.val.tar.gz.cached
+          key: newcob
+          save-always: true
+
+      - name: Download newcob.val.tar.gz
+        if: steps.newcob.outputs.cache-hit != 'true'
+        run: |
+          make -C _build/tests/cobol85 newcob.val.tar.gz
+          ln   -f _build/tests/cobol85/newcob.val.tar.gz        \
+                         tests/cobol85/newcob.val.tar.gz.cached
+
+      - name: Extended coverage
+        run: |
+          ln   -f        tests/cobol85/newcob.val.tar.gz.cached           \
+                         tests/cobol85/newcob.val.tar.gz
+          make -C _build/tests/cobol85 EXEC85 test                        \
+                         --jobs=$(($(nproc)+1))                           \
+                         --keep-going
+          make -C _build code-coverage-capture                            \
+                         CODE_COVERAGE_OUTPUT_DIRECTORY=extended-coverage \
+                         CODE_COVERAGE_OUTPUT_FILE=extended-coverage.info \
+                         CODE_COVERAGE_DIRECTORY="$(realpath .)/_build"
+
+      - name: Upload extended coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: extended-coverage-${{ matrix.os }}
+          path: _build/extended-coverage
+
+      - name: Upload coverage to codecov
+        uses: codecov/codecov-action@v2
         with:
           # token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
           directory: _build

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches: [ gcos4gnucobol-3.x ]
   push:
-    branches: [ gcos4gnucobol-3.x ]
   # manual run in actions tab - for all branches
   workflow_dispatch:
 
@@ -30,7 +29,8 @@ jobs:
       - name: Install packages
         run: |
           sudo apt-get update
-          sudo apt-get install automake libtool libdb5.3-dev libxml2-dev libcjson-dev bison flex help2man gettext texlive
+          sudo apt-get install automake libtool libdb5.3-dev libxml2-dev libcjson-dev \
+                               bison flex help2man gettext texlive
 
       - name: Set git user
         run: |
@@ -68,7 +68,8 @@ jobs:
           ../configure --enable-cobc-internal-checks \
                        --enable-hardening \
                        --prefix ${INSTALL_PATH}
-          echo "VERSION=PACKAGE_VERSION" | cpp -P -imacros config.h | tr -d \" >> $GITHUB_ENV
+          echo "VERSION=PACKAGE_VERSION" | cpp -P -imacros config.h | tr -d \" \
+            >> $GITHUB_ENV
 
       - name: Upload config.log
         uses: actions/upload-artifact@v4
@@ -81,17 +82,14 @@ jobs:
         run: |
           make -C _build --jobs=$(($(nproc)+1))
 
-      # - name: check
-      #   run: |
-      #     cd _build
-      #     make check TESTSUITEFLAGS="--jobs=$(($(nproc)+1))"
-
       # note: distcheck also creates the dist tarball
       - name: distcheck
         run: |
-          make -C _build distcheck \
-                         TESTSUITEFLAGS="--jobs=$(($(nproc)+1))" \
-                         --jobs=$(($(nproc)+1)) 
+          make -C _build distcheck                                \
+                         TESTSUITEFLAGS="--jobs=$(($(nproc)+1))"  \
+                         --jobs=$(($(nproc)+1)) ||                \
+          make -C _build/gnucobol-$VERSION/_build/sub/tests check \
+                         TESTSUITEFLAGS="--recheck --verbose"
 
       - name: Upload testsuite.log
         uses: actions/upload-artifact@v4
@@ -136,10 +134,6 @@ jobs:
             _build/tests/cobol85/**/*.log
             _build/tests/cobol85/**/*.out
 
-      - name: install
-        run: |
-          make -C _build install
-
 
   coverage:
     name: Coverage and Warnings
@@ -169,7 +163,8 @@ jobs:
         run: |
           cd _build
           ../configure --enable-code-coverage \
-                       CPPFLAGS="-Werror=declaration-after-statement"
+                       CPPFLAGS="-Werror=declaration-after-statement -pedantic" \
+                       CC="gcc -std=c89"
 
       - uses: actions/upload-artifact@v4
         if: failure()

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -158,12 +158,15 @@ jobs:
           export TERM="vt100"
           echo "TERM=$TERM" >> $GITHUB_ENV
 
-      # note: w add additional C compiler syntax checks here to not need _another_ CI run
+      # note: add additional C compiler syntax checks here to not need
+      # _another_ CI run
+      #
+      # TODO: try and pass -pedantic via CPPFLAGS
       - name: configure
         run: |
           cd _build
           ../configure --enable-code-coverage \
-                       CPPFLAGS="-Werror=declaration-after-statement -pedantic" \
+                       CPPFLAGS="-Werror=declaration-after-statement" \
                        CC="gcc -std=c89"
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -102,25 +102,15 @@ jobs:
           if-no-files-found: error
           retention-days: 0
 
-      - name: Cache newcob.val.tar.gz
+      - name: Cache newcob.val
         uses: actions/cache@v4
-        id: newcob
         with:
-          path: tests/cobol85/newcob.val.tar.gz.cached
-          key: newcob
+          path: _build/tests/cobol85/newcob.val
+          key: newcob-val
           save-always: true
-
-      - name: Download newcob.val.tar.gz
-        if: steps.newcob.outputs.cache-hit != 'true'
-        run: |
-          make -C _build/tests/cobol85 newcob.val.tar.gz
-          ln   -f _build/tests/cobol85/newcob.val.tar.gz        \
-                         tests/cobol85/newcob.val.tar.gz.cached
 
       - name: NIST85 Test Suite
         run: |
-          ln   -f        tests/cobol85/newcob.val.tar.gz.cached           \
-                         tests/cobol85/newcob.val.tar.gz
           make -C _build/tests/cobol85 EXEC85 test \
                                        --jobs=$(($(nproc)+1))
 
@@ -200,25 +190,15 @@ jobs:
           name: coverage-${{ matrix.os }}
           path: _build/GnuCOBOL-**-coverage
 
-      - name: Cache newcob.val.tar.gz
+      - name: Cache newcob.val
         uses: actions/cache@v4
-        id: newcob
         with:
-          path: tests/cobol85/newcob.val.tar.gz.cached
-          key: newcob
+          path: _build/tests/cobol85/newcob.val
+          key: newcob-val
           save-always: true
-
-      - name: Download newcob.val.tar.gz
-        if: steps.newcob.outputs.cache-hit != 'true'
-        run: |
-          make -C _build/tests/cobol85 newcob.val.tar.gz
-          ln   -f _build/tests/cobol85/newcob.val.tar.gz        \
-                         tests/cobol85/newcob.val.tar.gz.cached
 
       - name: Extended coverage
         run: |
-          ln   -f        tests/cobol85/newcob.val.tar.gz.cached           \
-                         tests/cobol85/newcob.val.tar.gz
           make -C _build/tests/cobol85 EXEC85 test                        \
                          --jobs=$(($(nproc)+1))                           \
                          --keep-going

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install packages
         run: |
@@ -65,20 +65,21 @@ jobs:
       - name: configure
         run: |
           cd _build
-          ../configure --enable-cobc-internal-checks --enable-hardening --prefix ${INSTALL_PATH}
+          ../configure --enable-cobc-internal-checks \
+                       --enable-hardening \
+                       --prefix ${INSTALL_PATH}
           echo "VERSION=PACKAGE_VERSION" | cpp -P -imacros config.h | tr -d \" >> $GITHUB_ENV
 
       - name: Upload config.log
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: config.log
+          name: config-${{ matrix.os }}.log
           path: _build/config.log
 
       - name: make
         run: |
-          cd _build
-          make --jobs=$(($(nproc)+1))
+          make -C _build --jobs=$(($(nproc)+1))
 
       # - name: check
       #   run: |
@@ -88,19 +89,20 @@ jobs:
       # note: distcheck also creates the dist tarball
       - name: distcheck
         run: |
-          cd _build
-          make --jobs=$(($(nproc)+1)) distcheck TESTSUITEFLAGS="--jobs=$(($(nproc)+1))"
+          make -C _build distcheck \
+                         TESTSUITEFLAGS="--jobs=$(($(nproc)+1))" \
+                         --jobs=$(($(nproc)+1)) 
 
       - name: Upload testsuite.log
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           # Assume there's only one directory matching `_build/gnucobol-*`:
-          name: testsuite.log
+          name: testsuite-${{ matrix.os }}.log
           path: _build/gnucobol-${{ env.VERSION }}/_build/sub/tests/testsuite.log
 
       - name: Upload dist tarball
-        uses: actions/upload-artifact@v3.1.0
+        uses: actions/upload-artifact@v4
         with:
           name: gnucobol-ci source distribution
           path: _build/gnucobol*.tar*
@@ -127,17 +129,16 @@ jobs:
           ln -f newcob.val.Z.cached newcob.val.Z
           make EXEC85 && make --jobs=$(($(nproc)+1)) test
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          name: NIST85 results
+          name: NIST85 results on ${{ matrix.os }}
           path: |
             _build/tests/cobol85/**/*.log
             _build/tests/cobol85/**/*.out
 
       - name: install
         run: |
-          cd _build
-          make install
+          make -C _build install
 
 
   coverage:
@@ -145,12 +146,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # note: less dependencies as we don't generate a dist tarball, one additional for lcov
       - name: Install dependencies
         run: |
-          sudo apt-get install automake libtool libdb5.3-dev libxml2-dev libcjson-dev bison flex help2man gettext lcov
+          sudo apt-get install automake libtool libdb5.3-dev libxml2-dev \
+                               libcjson-dev bison flex help2man gettext lcov
 
       - name: bootstrap
         run: |
@@ -166,33 +168,33 @@ jobs:
       - name: configure
         run: |
           cd _build
-          ../configure --enable-code-coverage CPPFLAGS="-Werror=declaration-after-statement"
+          ../configure --enable-code-coverage \
+                       CPPFLAGS="-Werror=declaration-after-statement"
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: config.log
+          name: config-${{ matrix.os }}.log
           path: _build/config.log
 
       - name: make
         run: |
-          cd _build
-          make --jobs=$(($(nproc)+1))
+          make -C _build --jobs=$(($(nproc)+1))
 
       - name: coverage
         run: |
-          cd _build
-          make check-code-coverage TESTSUITEFLAGS="--jobs=$(($(nproc)+1))"
+          make -C _build check-code-coverage \
+                         TESTSUITEFLAGS="--jobs=$(($(nproc)+1))"
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: testsuite.log
+          name: testsuite-${{ matrix.os }}.log
           path: _build/tests/testsuite.log
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          name: coverage
+          name: coverage-${{ matrix.os }}
           path: _build/GnuCOBOL-**-coverage/
 
       - uses: codecov/codecov-action@v2

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -108,6 +108,7 @@ jobs:
           path: _build/tests/cobol85/newcob.val
           key: newcob-val
           save-always: true
+          enableCrossOsArchive: true
 
       - name: NIST85 Test Suite
         run: |
@@ -196,6 +197,7 @@ jobs:
           path: _build/tests/cobol85/newcob.val
           key: newcob-val
           save-always: true
+          enableCrossOsArchive: true
 
       - name: Extended coverage
         run: |

--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -196,6 +196,7 @@ jobs:
           autom4te --lang=autotest -I ./testsuite.src ./testsuite.at -o ./testsuite
 
       - name: Run testsuite
+        continue-on-error: ${{ matrix.target == 'Debug' }}
         run: |
           cd tests
           set CL=/I "%VCPKG_ROOT%\installed\${{ matrix.arch }}-windows\include"

--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -195,7 +195,6 @@ jobs:
           autom4te --lang=autotest -I ./testsuite.src ./testsuite.at -o ./testsuite
 
       - name: Run testsuite
-        continue-on-error: ${{ matrix.target == 'Debug' }}
         run: |
           cd tests
           set CL=/I "%VCPKG_ROOT%\installed\${{ matrix.arch }}-windows\include"

--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches: [ gcos4gnucobol-3.x ]
   push:
-    branches: [ gcos4gnucobol-3.x ]
   # manual run in actions tab - for all branches
   workflow_dispatch:
 

--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -41,8 +41,8 @@ jobs:
         target:
           - Debug
           - Release
-
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
 
     steps:
 

--- a/.github/workflows/windows-msys1.yml
+++ b/.github/workflows/windows-msys1.yml
@@ -40,8 +40,8 @@ jobs:
         target:
           - debug
           - release
-
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
 
     steps:
 

--- a/.github/workflows/windows-msys1.yml
+++ b/.github/workflows/windows-msys1.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches: [ gcos4gnucobol-3.x ]
   push:
-    branches: [ gcos4gnucobol-3.x ]
   # manual run in actions tab - for all branches
   workflow_dispatch:
 

--- a/.github/workflows/windows-msys2.yml
+++ b/.github/workflows/windows-msys2.yml
@@ -75,29 +75,16 @@ jobs:
       - name: Build GnuCOBOL
         shell: msys2 {0}
         run: |
-          cd _build
-          make --jobs=$(($(nproc)+1))
-
-      - name: Install GnuCOBOL
-        shell: msys2 {0}
-        run: |
-          cd _build
-          make install
-          find /opt/cobol > install.log
-
-      - name: Upload install-${{ matrix.target }}.log
-        uses: actions/upload-artifact@v4
-        with:
-          name: install-${{ matrix.target }}.log
-          path: ${{ env.GITHUB_WORKSPACE }}/_build/install.log
+          make -C _build --jobs=$(($(nproc)+1))
 
       - name: Run testuite
         shell: msys2 {0}
         run: |
-          sed -i '/AT_SETUP(\[temporary path invalid\])/a AT_SKIP_IF(\[true\])' tests/testsuite.src/used_binaries.at
-          cd _build/tests
-          make check TESTSUITEFLAGS="--jobs=$(($(nproc)+1))"
-          make test
+          sed '/AT_SETUP(\[temporary path invalid\])/a \
+                AT_SKIP_IF(\[true\])' \
+              -i tests/testsuite.src/used_binaries.at
+          make -C _build/tests check TESTSUITEFLAGS="--jobs=$(($(nproc)+1))"
+          make -C _build/tests test
 
       - name: Upload testsuite-${{ matrix.target }}.log
         uses: actions/upload-artifact@v4
@@ -105,11 +92,22 @@ jobs:
           name: testsuite-${{ matrix.target }}.log
           path: ${{ env.GITHUB_WORKSPACE }}/_build/tests/testsuite.log
 
+      - name: Install GnuCOBOL
+        shell: msys2 {0}
+        run: |
+          make -C _build install
+          find /opt/cobol > _build/install.log
+
+      - name: Upload install-${{ matrix.target }}.log
+        uses: actions/upload-artifact@v4
+        with:
+          name: install-${{ matrix.target }}.log
+          path: ${{ env.GITHUB_WORKSPACE }}/_build/install.log
+
       - name: Package GnuCOBOL
         shell: msys2 {0}
         run: |
-          cd _build
-          make distmingw
+          make -C _build distmingw
 
       - name: Upload GnuCOBOL_mingw-${{ matrix.target }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/windows-msys2.yml
+++ b/.github/workflows/windows-msys2.yml
@@ -80,6 +80,14 @@ jobs:
         run: |
           make -C _build --jobs=$(($(nproc)+1))
 
+      - name: Cache newcob.val
+        uses: actions/cache@v4
+        with:
+          path: _build/tests/cobol85/newcob.val
+          key: newcob-val
+          save-always: true
+          enableCrossOsArchive: true
+
       - name: Run testuite
         shell: msys2 {0}
         run: |

--- a/.github/workflows/windows-msys2.yml
+++ b/.github/workflows/windows-msys2.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches: [ gcos4gnucobol-3.x ]
   push:
-    branches: [ gcos4gnucobol-3.x ]
   # manual run in actions tab - for all branches
   workflow_dispatch:
 
@@ -13,15 +12,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - windows-latest
-        arch:
-          - x64
-        target:
-          - debug
-          - release
-
-    runs-on: ${{ matrix.os }}
+        include:
+          - { os: windows-latest, target: release, sys: mingw64, env: x86_64       }
+          - { os: windows-latest, target: debug,   sys: mingw64, env: x86_64       }
+          - { os: windows-latest, target: debug,   sys: ucrt64,  env: ucrt-x86_64  }
+          - { os: windows-latest, target: debug,   sys: clang64, env: clang-x86_64 }
+          # - { target: debug,   sys: mingw32, env: i686         }
+    runs-on: ${{matrix.os}}
 
     steps:
 
@@ -44,19 +41,24 @@ jobs:
             echo CFGOPT="--enable-debug --enable-cobc-internal-checks --enable-hardening" >> $env:GITHUB_ENV
           }
 
-      - name: Install MSYS2 packages
+      - name: Install packages
         uses: msys2/setup-msys2@v2
         with:
           update: true
-          msystem: ucrt64
-          install: autoconf automake libtool make mingw-w64-ucrt-x86_64-ncurses mingw-w64-ucrt-x86_64-libxml2 mingw-w64-ucrt-x86_64-cjson mingw-w64-ucrt-x86_64-db mingw-w64-ucrt-x86_64-gmp libdb-devel mingw-w64-ucrt-x86_64-gcc flex bison gmp-devel help2man texinfo gettext-devel
+          msystem: ${{matrix.sys}}
+          install: autoconf automake libtool make flex bison help2man texinfo
+                   mingw-w64-${{matrix.env}}-cc
+                   mingw-w64-${{matrix.env}}-gmp                 gmp-devel
+                   mingw-w64-${{matrix.env}}-gettext-runtime gettext-devel
+                   mingw-w64-${{matrix.env}}-ncurses
+                   mingw-w64-${{matrix.env}}-libxml2
+                   mingw-w64-${{matrix.env}}-cjson
+                   mingw-w64-${{matrix.env}}-db                libdb-devel
 
       - name: Bootstrap GnuCOBOL
         shell: msys2 {0}
         run: |
-          ./autogen.sh
-          autoconf
-          autoreconf --install --force
+          ./build_aux/bootstrap install
 
       - name: Configure GnuCOBOL
         shell: msys2 {0}
@@ -65,11 +67,11 @@ jobs:
           cd _build
           ../configure $CFGOPT --with-db --prefix=/opt/cobol/gnucobol
 
-      - name: Upload config-${{ matrix.target }}.log
+      - name: Upload config-${{matrix.sys}}-${{matrix.target}}.log
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: config-${{ matrix.target }}.log
+          name: config-${{matrix.sys}}-${{matrix.target}}.log
           path: ${{ env.GITHUB_WORKSPACE }}/_build/config.log
 
       - name: Build GnuCOBOL
@@ -83,34 +85,25 @@ jobs:
           sed '/AT_SETUP(\[temporary path invalid\])/a \
                 AT_SKIP_IF(\[true\])' \
               -i tests/testsuite.src/used_binaries.at
-          make -C _build/tests check TESTSUITEFLAGS="--jobs=$(($(nproc)+1))"
-          make -C _build/tests test
+          make -C _build/tests checkall \
+                               --jobs=$(($(nproc)+1)) \
+                               TESTSUITEFLAGS="--jobs=$(($(nproc)+1))" || \
+          make -C _build/tests check \
+                               TESTSUITEFLAGS="--recheck --verbose"
 
-      - name: Upload testsuite-${{ matrix.target }}.log
+      - name: Upload testsuite-${{matrix.sys}}-${{matrix.target}}.log
         uses: actions/upload-artifact@v4
         with:
-          name: testsuite-${{ matrix.target }}.log
+          name: testsuite-${{matrix.sys}}-${{matrix.target}}.log
           path: ${{ env.GITHUB_WORKSPACE }}/_build/tests/testsuite.log
-
-      - name: Install GnuCOBOL
-        shell: msys2 {0}
-        run: |
-          make -C _build install
-          find /opt/cobol > _build/install.log
-
-      - name: Upload install-${{ matrix.target }}.log
-        uses: actions/upload-artifact@v4
-        with:
-          name: install-${{ matrix.target }}.log
-          path: ${{ env.GITHUB_WORKSPACE }}/_build/install.log
 
       - name: Package GnuCOBOL
         shell: msys2 {0}
         run: |
           make -C _build distmingw
 
-      - name: Upload GnuCOBOL_mingw-${{ matrix.target }}
+      - name: Upload GnuCOBOL_mingw-${{matrix.sys}}-${{matrix.target}}
         uses: actions/upload-artifact@v4
         with:
-          name: GnuCOBOL_mingw-${{ matrix.target }}
+          name: GnuCOBOL_mingw-${{matrix.sys}}-${{matrix.target}}
           path: ${{ env.GITHUB_WORKSPACE }}/_build/${{ env.DISTDIR }}

--- a/.github/workflows/windows-msys2.yml
+++ b/.github/workflows/windows-msys2.yml
@@ -19,6 +19,7 @@ jobs:
           - { os: windows-latest, target: debug,   sys: clang64, env: clang-x86_64 }
           # - { target: debug,   sys: mingw32, env: i686         }
     runs-on: ${{matrix.os}}
+    timeout-minutes: 45
 
     steps:
 

--- a/.github/workflows/windows-msys2.yml
+++ b/.github/workflows/windows-msys2.yml
@@ -111,8 +111,15 @@ jobs:
         run: |
           make -C _build distmingw
 
-      - name: Upload GnuCOBOL_mingw-${{matrix.sys}}-${{matrix.target}}
+      - name: Tar GnuCOBOL_mingw-${{matrix.sys}}-${{matrix.target}}
+        shell: msys2 {0}
+        run: |
+          cd _build
+          tar -cvf ../GnuCOBOL_mingw-${{matrix.sys}}-${{matrix.target}}.tar \
+                   "${{ env.DISTDIR }}"
+
+      - name: Upload GnuCOBOL_mingw-${{matrix.sys}}-${{matrix.target}}.tar
         uses: actions/upload-artifact@v4
         with:
-          name: GnuCOBOL_mingw-${{matrix.sys}}-${{matrix.target}}
-          path: ${{ env.GITHUB_WORKSPACE }}/_build/${{ env.DISTDIR }}
+          name: GnuCOBOL_mingw-${{matrix.sys}}-${{matrix.target}}.tar
+          path: GnuCOBOL_mingw-${{matrix.sys}}-${{matrix.target}}.tar


### PR DESCRIPTION
- Upgrade versions of github actions (some are being deprecated);
- Perform tests before install when doing the opposite is not very well justified.