### PR TITLE
Check for incompatible data only when a receiver field is of category numeric in `MOVE` or `SET`

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -25,6 +25,14 @@ NEWS - user visible changes				-*- outline -*-
 
   more work in progress
 
+* Changes that potentially effect recompilation of existing programs:
+
+** runtime checks for invalid numerical data in emitter fields of MOVE or SET
+   statements are now performed only when at least one receiver field
+   is of category numeric or numeric-edited.  This enables programming
+   patterns where invalid numerical data (e.g, SPACES) encode "absent"
+   data
+
 * Important Bugfixes
 
 ** #904: MOVE PACKED-DECIMAL unsigned to signed led to bad sign

--- a/cobc/ChangeLog
+++ b/cobc/ChangeLog
@@ -1,4 +1,13 @@
 
+2024-09-25  Nicolas Berthier <nicolas.berthier@ocamlpro.com>
+
+	* typeck.c (cb_tree_is_numeric_ref_or_field)
+	  (cb_tree_list_has_numeric_ref_or_field): new helper functions to check
+	  whether a given item is of category numeric (edited or not)
+	* typeck.c (cb_emit_incompat_data_checks): use new helper function
+	* typeck.c (cb_emit_move, cb_emit_set_to): do not check for incompatible
+	  data if no receiver field is of category numeric or numeric edited
+
 2024-08-28  David Declerck <david.declerck@ocamlpro.com>
 
 	* tree.c (char_to_precedence_idx, get_char_type_description, valid_char_order):

--- a/tests/testsuite.src/run_misc.at
+++ b/tests/testsuite.src/run_misc.at
@@ -1172,6 +1172,40 @@ AT_CHECK([$COBCRUN_DIRECT ./prog2], [1], [],
 AT_CLEANUP
 
 
+AT_SETUP([MOVE of invalid data from numeric to alphanumeric item])
+AT_KEYWORDS([runmisc])
+
+AT_DATA([prog.cob], [
+       PROGRAM-ID. prog.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       77 X-NUM                 PIC 9.
+       77 X-ALN REDEFINES X-NUM PIC X.
+       77 Y-ALN                 PIC X.
+       77 Z-NUM                 PIC +9,9.
+       77 Z-ALN REDEFINES Z-NUM PIC XX.
+       77 T-ALN                 PIC XX.
+       PROCEDURE DIVISION.
+       MAIN.
+           MOVE SPACES TO X-ALN
+           MOVE X-NUM  TO Y-ALN
+	   IF Y-ALN NOT EQUAL " " THEN
+	      DISPLAY "Y-ALN: '" Y-ALN "' (' ' EXPECTED)"
+	   END-IF
+           MOVE SPACES TO Z-ALN
+           MOVE Z-NUM  TO T-ALN
+	   IF T-ALN NOT EQUAL "  " THEN
+	      DISPLAY "T-ALN: '" T-ALN "' ('  ' EXPECTED)"
+	   END-IF
+           STOP RUN.
+])
+
+AT_CHECK([$COMPILE prog.cob], [0], [], [])
+AT_CHECK([$COBCRUN_DIRECT ./prog], [0], [], [])
+
+AT_CLEANUP
+
+
 ## CALL statement
 
 AT_SETUP([Dynamic call with static linking])


### PR DESCRIPTION
This PR alters `MOVE` and `SET` statements to check for numerical data in emitter fields only when at least one receiver field is of category numeric. This essentially permits statements like `MOVE SOME-NUMERIC TO SOME-ALPHANUM` to succeed even when `SOME-NUMERIC` holds invalid data.

---

(Old description:)

On *some* systems (GCOS), checks for non-numeric data in numeric items on MOVE appear to be performed on receiver fields instead of emitters, whereas in GnuCOBOL the checks are always performed on emitters. However, the former behavior seems convenient for encoding "absence" of relevant values (or, in more modern terms, null-ness) by putting `SPACES` in the associated storage area. This notably allows coding patterns where a `MOVE SOME-NUMERIC TO SOME-ALPHANUM` is followed by a check for "nullness" with `SOME-ALPHANUM IS EQUAL TO SPACES`.

Although disabling the (fatal) exception `EC-DATA-INCOMPATIBLE` permits such a coding pattern, it also disables some other checks that are relevant.

Another possible workaround is to use the (somewhat obscure) `-fcorrect-numeric`. Yet, this "solution" currently alters emitter fields on MOVES (to put `ZEROS` instead of `SPACES`), and this is an often undesirable side-effet.

This PR currently identifies changes required to implement the check on receiver fiels instead of emitters. Given that this changes the underlying semantics of `MOVE`/`SET` (albeit in possibly marginal/rare cases — and this fails a NIST test apparently), one could make this subject to a dialect option.