### PR TITLE
fix implicit overlapping move

### DIFF
--- a/cobc/typeck.c
+++ b/cobc/typeck.c
@@ -12062,13 +12062,7 @@ cb_build_move_copy (cb_tree src, cb_tree dst)
 	if (size == 1) {
 		return CB_BUILD_FUNCALL_2 ("$F", dst, src);
 	}
-	if (cb_move_ibm) {
-		overlapping = 0;
-		return CB_BUILD_FUNCALL_3 ("cob_move_ibm",
-					   CB_BUILD_CAST_ADDRESS (dst),
-					   CB_BUILD_CAST_ADDRESS (src),
-					   CB_BUILD_CAST_LENGTH (dst));
-	} else if (overlapping
+	else if (overlapping
 	|| CB_FIELD_PTR (src)->storage == CB_STORAGE_LINKAGE
 	|| CB_FIELD_PTR (dst)->storage == CB_STORAGE_LINKAGE
 	|| CB_FIELD_PTR (src)->flag_item_based
@@ -12645,7 +12639,14 @@ cb_build_move_field (cb_tree src, cb_tree dst)
 	int 		src_size;
 	int 		dst_size;
 
-	if (dst_f->flag_any_length || src_f->flag_any_length) {
+	if (cb_move_ibm) {
+		overlapping = 0;
+		return CB_BUILD_FUNCALL_3 ("cob_move_ibm",
+						 CB_BUILD_CAST_ADDRESS (dst),
+						 CB_BUILD_CAST_ADDRESS (src),
+						 CB_BUILD_CAST_LENGTH (dst));
+	}
+	else if (dst_f->flag_any_length || src_f->flag_any_length) {
 		return CB_BUILD_FUNCALL_2 ("cob_move", src, dst);
 	}
 	src_size = cb_field_size (src);

--- a/libcob/move.c
+++ b/libcob/move.c
@@ -312,8 +312,20 @@ cob_move_alphanum_to_display (cob_field *f1, cob_field *f2)
 	int		sign;
 	int		count;
 	int		size;
+	unsigned char *tmp_src_data = NULL;
+
 
 	/* Initialize */
+	if ( (s1 >= s2 && s1 < e2) || (s2 >= s1 && s2 < e1) ){
+		/* Only if the source and destination are overlapping,
+		   we copy the source in a temp buffer allocated in
+		   the heap and reclaimed at the end of the
+		   function. */
+		tmp_src_data = cob_malloc (f1->size);
+		memcpy (tmp_src_data, s1, f1->size);
+		s1 = tmp_src_data;
+		e1 = s1 + f1->size;
+	}
 	memset (f2->data, '0', f2->size);
 
 	/* Skip white spaces */
@@ -372,11 +384,14 @@ cob_move_alphanum_to_display (cob_field *f1, cob_field *f2)
 	}
 
 	COB_PUT_SIGN (f2, sign);
+	if (tmp_src_data) cob_free (tmp_src_data);
 	return;
 
 error:
 	memset (f2->data, '0', f2->size);
 	COB_PUT_SIGN (f2, 0);
+	if (tmp_src_data) cob_free (tmp_src_data);
+	return;
 }
 
 static void

--- a/tests/testsuite.src/run_file.at
+++ b/tests/testsuite.src/run_file.at
@@ -15910,11 +15910,9 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([$COMPILE prog.cob -o prog], [0], [],
-[prog.cob:16: warning: overlapping MOVE may produce unpredictable results
-])
+AT_CHECK([$COMPILE -fmove-ibm prog.cob -o prog], [0], [], [])
 
-AT_CHECK([./prog], [0], [00000
+AT_CHECK([./prog], [0], [01234
 ])
 
 AT_CLEANUP

--- a/tests/testsuite.src/run_file.at
+++ b/tests/testsuite.src/run_file.at
@@ -15882,3 +15882,40 @@ AT_CHECK([$COMPILE -fdefault-file-colseq=EBCDIC prog.cob])
 AT_CHECK([$COBCRUN_DIRECT ./prog])
 
 AT_CLEANUP
+
+
+AT_SETUP([READ INTO NUMERIC FD RECORD])
+AT_KEYWORDS([move overlap])
+
+AT_DATA([testfile], [01234
+])
+AT_DATA([prog.cob], [
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. prog.
+       ENVIRONMENT DIVISION.
+       INPUT-OUTPUT SECTION.
+       FILE-CONTROL.
+           SELECT MY-FILE ASSIGN TO "testfile"
+               ORGANIZATION IS LINE SEQUENTIAL.
+       DATA DIVISION.
+       FILE SECTION.
+       FD  MY-FILE.
+       01  MY-REC PIC 9(5).
+       PROCEDURE DIVISION.
+
+           OPEN INPUT MY-FILE.
+	   READ MY-FILE INTO MY-REC.
+	   DISPLAY MY-REC.
+           CLOSE MY-FILE.
+           STOP RUN.
+])
+
+AT_CHECK([$COMPILE prog.cob -o prog], [0], [],
+[prog.cob:16: warning: overlapping MOVE may produce unpredictable results
+])
+
+AT_CHECK([./prog], [0], [00000
+])
+
+AT_CLEANUP
+

--- a/tests/testsuite.src/run_file.at
+++ b/tests/testsuite.src/run_file.at
@@ -15910,7 +15910,14 @@ AT_DATA([prog.cob], [
            STOP RUN.
 ])
 
-AT_CHECK([$COMPILE -fmove-ibm prog.cob -o prog], [0], [], [])
+AT_CHECK([$COMPILE -fmove-ibm prog.cob -o prog])
+
+AT_CHECK([./prog], [0], [01234
+])
+
+AT_CHECK([$COMPILE prog.cob -o prog], [0], [],
+[prog.cob:16: warning: overlapping MOVE may produce unpredictable results
+])
 
 AT_CHECK([./prog], [0], [01234
 ])


### PR DESCRIPTION
I ran into a small issue: `READ FILE-FD INTO RECORD` where `RECORD` is declared as the `FD` of `FILE-FD` with a numeric type will end up always reading zeroes (because of an overlapping move). The compiler already issues a warning, but I think it is still better to get the correct behavior when possible, so I modified the `cob_move_alphanum_to_display` to correctly handle overlaps (the extra cost is only paid in case of overlap).