### PR TITLE
Update macos.yml

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -54,6 +54,7 @@ jobs:
           cd _build
           ../configure --enable-cobc-internal-checks \
                        --enable-hardening \
+                       --with-curses=ncurses \
                        --prefix /opt/cobol/gnucobol-gcos \
 
       - name: make


### PR DESCRIPTION
explicit choose ncurses to let the panel library be found (alternative: install ncurses via brew and extend PKG_CONFIG_DIR)