### PR TITLE
Fix STRING/UNSTRING/INSPECT bug

### DIFF
--- a/libcob/ChangeLog
+++ b/libcob/ChangeLog
@@ -1,4 +1,10 @@
 
+2024-12-18  David Declerck <david.declerck@ocamlpro.com>
+
+	* string.c: fix a bug where the source of STRING/UNSTRING/INSPECT
+	  is overwritten, by restoring the *_copy fields that were removed
+	  with the change on 2024-02-26
+
 2024-12-11  Emilien Lemaire <emilien.lemaire@ocamlpro.com>
 
 	* fileio.c: fixed Bug #1032 by always using global thread-static variable
@@ -296,6 +302,7 @@
 	* common.c: add missing include libxml/parser.h
 
 2024-02-26  Boris Eng <boris.eng@ocamlpro.com>
+
 	FR #488: using state structures instead of state vars for strings
 	* strings.c: moved static variables to structures
 

--- a/tests/testsuite.src/run_misc.at
+++ b/tests/testsuite.src/run_misc.at
@@ -2949,6 +2949,76 @@ AT_CHECK([$COBCRUN_DIRECT ./prog], [0],
 AT_CLEANUP
 
 
+AT_SETUP([STRING preserve source])
+AT_KEYWORDS([runmisc])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. prog.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01 SRC.
+         10 SRC-X PIC X(3) VALUE "123".
+         10 SRC-Y PIC X(8) VALUE SPACES.
+       01 DST OCCURS 1.
+         10 DST-X PIC X(8) VALUE SPACES.
+       PROCEDURE DIVISION.
+           DISPLAY "SRC-Y BEFORE: '" SRC-Y "'".
+           STRING "DATA " SRC-X(1:3) INTO DST (1).
+           DISPLAY "SRC-Y AFTER:  '" SRC-Y "'".
+           DISPLAY "DST-X AFTER:  '" DST-X (1) "'".
+           STOP RUN.
+])
+
+AT_CHECK([$COMPILE prog.cob], [0], [], [])
+AT_CHECK([$COBCRUN_DIRECT ./prog], [0],
+[SRC-Y BEFORE: '        '
+SRC-Y AFTER:  '        '
+DST-X AFTER:  'DATA 123'
+], [])
+
+AT_CLEANUP
+
+
+AT_SETUP([INSPECT preserve source])
+AT_KEYWORDS([runmisc])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. prog.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01 SRC OCCURS 1.
+         10 SRC-X PIC S9(3) VALUE 123.
+         10 SRC-Y PIC S9(3) VALUE 456.
+       01 DST OCCURS 1.
+         10 DST-X PIC S9(7) VALUE -6540321.
+       PROCEDURE DIVISION.
+           DISPLAY "SRC-X BEFORE: '" SRC-X (1) "'".
+           DISPLAY "SRC-Y BEFORE: '" SRC-Y (1) "'".
+           DISPLAY "DST-X BEFORE: '" DST-X (1) "'".
+           INSPECT DST-X (1) REPLACING
+             LEADING "654" BY SRC-X (1)
+             ALL "321" BY SRC-Y (1).
+           DISPLAY "SRC-X AFTER: '" SRC-X (1) "'".
+           DISPLAY "SRC-Y AFTER: '" SRC-Y (1) "'".
+           DISPLAY "DST-X AFTER: '" DST-X (1) "'".
+           STOP RUN.
+])
+
+AT_CHECK([$COMPILE prog.cob], [0], [], [])
+AT_CHECK([$COBCRUN_DIRECT ./prog], [0],
+[SRC-X BEFORE: '+123'
+SRC-Y BEFORE: '+456'
+DST-X BEFORE: '-6540321'
+SRC-X AFTER: '+123'
+SRC-Y AFTER: '+456'
+DST-X AFTER: '-1230456'
+], [])
+
+AT_CLEANUP
+
+
 AT_SETUP([UNSTRING DELIMITED ALL LOW-VALUE])
 AT_KEYWORDS([runmisc])
 


### PR DESCRIPTION
This fixes a bug introduced by PR #137.

The bug causes some source fields in STRING/UNSTRING/INSPECT to be altered under some circumstances, as highlighted by the new test in `run_misc.at`, which produces the following result when not fixed:
```
SRC-Y AFTER:  '  123   '
DST-X AFTER:  'DATA    '
```

This bug was caused by the removal of the `*_copy` fields, that were suspected to be useless (cf. [this comment](https://github.com/OCamlPro/gnucobol/pull/137#discussion_r1643854996) on PR #137).

This PR restores all those `*_copy` fields (which were present since SVN revision 1).
