### PR TITLE
Fix for missing "end verbatim" in doc

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,4 +1,8 @@
 
+2025-01-09  David Declerck <david.declerck@ocamlpro.com>
+
+	* cbrunt.tex.gen: fix for missing "@end verbatim"
+
 2024-10-30  Chuck Haatvedt <chuck.haatvedt@gmail.com>
 
 	* gnucobol.texi: document new multiple window function

--- a/doc/cbrunt.tex.gen
+++ b/doc/cbrunt.tex.gen
@@ -102,7 +102,7 @@ section == 0 { next }
 
 /^## / {
     sub( /^## /, "" )
-    if( section++ > 1 ) {
+    if( section++ >= 1 ) {
 	print "@end verbatim\n"
     }
     print "@section", $0


### PR DESCRIPTION
There was a missing "end verbatim" in the file generated by `cbrunt.tex.gen`. Seems it's been like this for ages, but we only notice now because the MacOS CI began to fail for no apparent reason (in fact brew's `texinfo` version was updated from 7.1 to 7.2, which is probably the reason for this error to be detected).