### PR TITLE
Set init-justify to no in gcos-strict.conf

### DIFF
--- a/config/ChangeLog
+++ b/config/ChangeLog
@@ -1,4 +1,8 @@
 
+2025-01-10  David Declerck <david.declerck@ocamlpro.com>
+
+        * gcos-strict.conf: set init-justify to no after testing on GCOS
+
 2024-08-17 Ammar Almoris <ammaralmorsi@gmail.com>
 
 	FR #474: add runtime configuration to hide cursor for extended screenio

--- a/config/gcos-strict.conf
+++ b/config/gcos-strict.conf
@@ -196,7 +196,7 @@ dpc-in-data:			xml
 subscript-check:		max	# not verified, may need "record"
 
 # Functionality of JUSTIFY for INITIALIZE verb and initialization of storage
-init-justify:			yes	# TODO: verify
+init-justify:			no
 
 # Dialect features
 # Value: 'ok', 'warning', 'archaic', 'obsolete', 'skip', 'ignore', 'error',


### PR DESCRIPTION
After testing on GCOS, I confirm we should set init-justify to no.

(yeah, a PR for this is maybe a bit too much ;))
