### PR TITLE
[4.x] Close stream first, close fd only if not stream

### DIFF
--- a/libcob/ChangeLog
+++ b/libcob/ChangeLog
@@ -1,4 +1,10 @@
 
+2025-01-28  David Declerck <david.declerck@ocamlpro.com>
+
+	* fileio.c (cob_file_close): try to close the file stream
+	  first, close the file descriptor only if the stream is NULL
+	  (fixes assertions under MSVC debug)
+
 2024-11-06  David Declerck <david.declerck@ocamlpro.com>
 
 	Reverted change 2022-02-21 to integrate change


### PR DESCRIPTION
This PR attemps to fix a debug assertion occuring under the MSVC CI (`Assertion failed: (_osfile(fh) & FOPEN)`).

Apparently, when a stream is created from a file descriptor via `fdopen`, it should always be closed by `fclose`. This is not always the case in the 4.x branch. While this seems to fail silently on most OSes, it triggers a debug assertion under MSVC debug.

This proposed fix just always tries to close the stream if it is not NULL, otherwise it just closes the file descriptor.
This fixes 40 (!) tests under MSVC debug.

References:
- Linux: https://linux.die.net/man/3/fdopen
- Windows: https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/fdopen-wfdopen?view=msvc-170
- BSD: https://man.freebsd.org/cgi/man.cgi?query=fdopen&sektion=3&n=1
- macOS: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/fdopen.3.html
- IBM: https://www.ibm.com/docs/en/i/7.5?topic=functions-fdopen-associates-stream-file-descriptor