### PR TITLE
Fix configure.ac : unused command line argument triggers erros

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -52,7 +52,6 @@ jobs:
       - name: configure
         run: |
           cd _build
-          export CFLAGS="-Wno-unused-command-line-argument $CFLAGS"
           ../configure --enable-cobc-internal-checks \
                        --enable-hardening \
                        --with-curses=ncurses \

--- a/configure.ac
+++ b/configure.ac
@@ -461,6 +461,7 @@ AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
 	# error macro not defined
 	#endif]])],
 	[COB_USES_CLANG_ONLY=yes
+	 CFLAGS="$CFLAGS -Wno-unused-command-line-argument"
 	 AC_MSG_RESULT([yes])],
 	[AC_MSG_RESULT([no])])
 


### PR DESCRIPTION
As mentionned in a previous comment, unused arguments trigger errors in the configure script :
```
error: argument unused during compilation: '-fstack-clash-protection' [-Werror,-Wunused-command-line-argument]
```
This makes detection of some features (`-fstack-clash-protection` on macOS) fail even if they are available.
This is even worst in 4.x (in the yet-to-be-merged batch), as it fails to detect "gcc pointer sign", which causes many testsuite failures.

This PR simply adds `-Wno-unused-command-line-argument` to the CFLAGS under gcc and Clang (and removes if from the CI workflow). Not sure if this should come earlier in the configure file ?

Should be merged in 4.x once upstream in 3.x.
