### PR TITLE
Fix MacOS CI

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: make
         run: |
-          make -C _build --jobs=$((${NPROC}+1))  || cat po/Makevars po/Makefile
+          make -C _build --jobs=$((${NPROC}+1))
 
       - name: Upload config.log
         uses: actions/upload-artifact@v4

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -55,11 +55,11 @@ jobs:
           ../configure --enable-cobc-internal-checks \
                        --enable-hardening \
                        --with-curses=ncurses \
-                       --prefix /opt/cobol/gnucobol-gcos \
+                       --prefix /opt/cobol/gnucobol-gcos
 
       - name: make
         run: |
-          make -C _build --jobs=$((${NPROC}+1))
+          make -C _build --jobs=$((${NPROC}+1))  || cat po/Makevars po/Makefile
 
       - name: Upload config.log
         uses: actions/upload-artifact@v4

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: bootstrap
         run: |
-          ./build_aux/bootstrap install
+          ./autogen.sh install
 
       - name: Build environment setup
         run: |

--- a/build_aux/bootstrap
+++ b/build_aux/bootstrap
@@ -3,7 +3,7 @@
 # Bootstrap gnucobol package from checked-out sources
 # Note:  call as ./bootstrap if you don't have readlink -f
 #
-# Copyright (C) 2017-2023 Free Software Foundation, Inc.
+# Copyright (C) 2017-2023, 2025 Free Software Foundation, Inc.
 # Written by Simon Sobisch
 #
 # This file is part of GnuCOBOL.
@@ -61,11 +61,11 @@ done
 
 if test "$1" = "install"; then
 
-  echo; echo "running autopoint..."
+  echo; echo "running autopoint to update gettext components..."
   ret=0
 
-#  (cd $MAINPATH; autopoint -f); ret=$?
-  (cd $MAINPATH; gettextize -f); ret=$?
+  (cd $MAINPATH; rm -f m4/gettext.m4; autopoint -f); ret=$?
+  #gettextize --no-changelog -f $MAINPATH; ret=$?
 
   if test $ret -ne 0; then
     echo; echo "ERROR, autopoint returned $ret - aborting bootstrap" && exit $ret

--- a/build_aux/bootstrap
+++ b/build_aux/bootstrap
@@ -61,14 +61,16 @@ done
 
 if test "$1" = "install"; then
 
-  echo; echo "running autopoint to update gettext components..."
+  echo; echo "running gettext to force updated gettext components..."
   ret=0
 
-  (cd $MAINPATH; rm -f m4/gettext.m4 m4/po.m4; autopoint -f); ret=$?
-  #gettextize --no-changelog -f $MAINPATH; ret=$?
+  # note: autopoint -f is already included as part of autoreconf -f
+  #(cd $MAINPATH; autopoint -f); ret=$?
+  #(cd $MAINPATH; rm -f m4/gettext.m4 m4/po.m4; autopoint -f); ret=$?
+  gettextize --no-changelog -f $MAINPATH; ret=$?
 
   if test $ret -ne 0; then
-    echo; echo "ERROR, autopoint returned $ret - aborting bootstrap" && exit $ret
+    echo; echo "ERROR, gettext returned $ret - aborting bootstrap" && exit $ret
   fi
 
 fi

--- a/build_aux/bootstrap
+++ b/build_aux/bootstrap
@@ -59,6 +59,20 @@ for file in $scripts ; do
   fi
 done
 
+if test "$1" = "install"; then
+
+  echo; echo "running autopoint..."
+  ret=0
+
+#  (cd $MAINPATH; autopoint -f); ret=$?
+  (cd $MAINPATH; gettextize -f); ret=$?
+
+  if test $ret -ne 0; then
+    echo; echo "ERROR, autopoint returned $ret - aborting bootstrap" && exit $ret
+  fi
+
+fi
+
 echo; echo "running autoreconf..."
 ret=0
 

--- a/build_aux/bootstrap
+++ b/build_aux/bootstrap
@@ -64,7 +64,7 @@ if test "$1" = "install"; then
   echo; echo "running autopoint to update gettext components..."
   ret=0
 
-  (cd $MAINPATH; rm -f m4/gettext.m4; autopoint -f); ret=$?
+  (cd $MAINPATH; rm -f m4/gettext.m4 m4/po.m4; autopoint -f); ret=$?
   #gettextize --no-changelog -f $MAINPATH; ret=$?
 
   if test $ret -ne 0; then


### PR DESCRIPTION
The MacOS CI has been down since the latest image update.
Apparently something to do with `gettext`.
Adding `gettextize -f` after the bootstrap step seems to solve the problem.