### PR TITLE
Add 32-bit Ubuntu workflow

### DIFF
--- a/.github/workflows/build_nightly.yml
+++ b/.github/workflows/build_nightly.yml
@@ -336,7 +336,93 @@ jobs:
             _build/tests/cobol85/**/duration.txt
 
 
-  minmal_build:
+  build_32_bit:
+    name: Build and test on 32-bit
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: true
+
+    steps:
+
+      - name: Get CI dist tarball
+        uses: actions/download-artifact@v4
+        with:
+          name: gnucobol-ci source distribution
+
+      - name: Extract CI dist tarball
+        run: tar -xvf gnucobol*.tar.* --strip-components=1
+
+      - name: Setup build environment
+        run: echo "TERM=vt100" >> $GITHUB_ENV
+
+      - name: Install packages
+        run: |
+          sudo dpkg --add-architecture i386
+          sudo apt -y update
+          sudo apt -y install make libtool gcc-9-multilib \
+                              gcc-9 libgmp-dev:i386 libncurses-dev:i386 \
+                              libdb5.3-dev:i386 libxml2-dev:i386 libcjson-dev:i386
+          sudo apt -y remove flex bison
+
+      - name: Configure GnuCOBOL
+        run: |
+          mkdir _build && cd _build
+          ../configure --with-db \
+                       --enable-cobc-internal-checks \
+                       --enable-hardening \
+                       --prefix=/opt/gnucobol \
+                       CC="gcc-9 -m32" \
+                       CFLAGS="-fno-tree-coalesce-vars"
+          # Note: we pass -fno-tree-coalesce-vars to workaround a bug
+          # occurring with gcc on x86 at optimization level -O1
+
+      - name: Build GnuCOBOL
+        run: make -C _build --jobs=$(($(nproc)+1))
+
+      - name: Upload config.log
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: config-${{ github.job }}.log
+          path: _build/config.log
+
+      - name: Run testsuite
+        run: |
+          make -C _build check TESTSUITEFLAGS="--jobs=$(($(nproc)+1))" || \
+          make -C _build check TESTSUITEFLAGS="--recheck --verbose"
+
+      - name: Upload testsuite.log
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: testsuite-${{ github.job }}.log
+          path: _build/tests/testsuite.log
+
+      - name: Cache newcob.val
+        uses: actions/cache@v4
+        with:
+          path: _build/tests/cobol85/newcob.val
+          key: newcob-val
+          enableCrossOsArchive: true
+
+      - name: Run NIST85 testsuite
+        run: make -C _build test --jobs=$(($(nproc)+1))
+
+      - name: Upload NIST85 Test Suite results
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: NIST85 results on ${{ github.job }}
+          path: |
+            _build/tests/cobol85/summary.*
+            _build/tests/cobol85/**/*.log
+            _build/tests/cobol85/**/*.out
+            _build/tests/cobol85/**/duration.txt
+
+
+  build_minimal:
     name: Build and test with minimal dependencies
     needs: build
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds a 32-bit Ubuntu CI.

This *almost* works, as there is still one failure:
```
## -------------------------------------------- ##
## GnuCOBOL 3.3-dev test suite: GnuCOBOL Tests. ##
## -------------------------------------------- ##
1190. run_extensions.at:2172: testing NUMBER-OF-CALL-PARAMETERS ...
../../tests/run_extensions.at:2210: $COMPILE caller.cob
../../tests/run_extensions.at:2213: $COMPILE_MODULE -fusing-optional=skip callee.cob
../../tests/run_extensions.at:2214: $COBCRUN_DIRECT ./caller
/home/runner/work/gnucobol/gnucobol/_build/tests/testsuite.dir/at-groups/1190/test-source: line 242: 73572 Segmentation fault      (core dumped) ( $at_check_trace; $COBCRUN_DIRECT ./caller ) >> "$at_stdout" 2>> "$at_stderr" 5>&-
--- /dev/null	2025-05-21 17:38:58.198580733 +0000
+++ /home/runner/work/gnucobol/gnucobol/_build/tests/testsuite.dir/at-groups/1190/stderr	2025-05-21 17:43:38.941743321 +0000
@@ -0,0 +1,3 @@
+
+caller.cob:12: attempt to reference invalid memory address (signal SIGSEGV)
+
--- -	2025-05-21 17:43:39.021375093 +0000
+++ /home/runner/work/gnucobol/gnucobol/_build/tests/testsuite.dir/at-groups/1190/stdout	2025-05-21 17:43:39.017744122 +0000
@@ -1,7 +1,2 @@
 +000000000
-+000000001
-+000000002
-+000000003
-+000000004
-+000000004
 
../../tests/run_extensions.at:2214: exit code was 139, expected 0
1190. run_extensions.at:2172:  FAILED (run_extensions.at:2214)```