### PR TITLE
Fix coverage for recent lcov (>= 2)

### DIFF
--- a/.github/workflows/build_nightly.yml
+++ b/.github/workflows/build_nightly.yml
@@ -500,10 +500,7 @@ jobs:
   coverage:
     name: Coverage and Warnings
     needs: build
-# Since the latest Ubuntu image, lcov fails complaining about negative branch counts,
-# and using fprofile-update=atomic as suggested does not help, so use the previous image
-#    runs-on: ubuntu-latest
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:
@@ -551,6 +548,8 @@ jobs:
           # make -C _build check-code-coverage # <- (ignores errors)
           make -C _build check TESTSUITEFLAGS="--jobs=$(($(nproc)+1))"
           make -C _build code-coverage-capture \
+                         CODE_COVERAGE_LCOV_SHOPTS_DEFAULT="--rc branch_coverage=1" \
+                         CODE_COVERAGE_GENHTML_OPTIONS_DEFAULT="--rc branch_coverage=1" \
                          CODE_COVERAGE_DIRECTORY="$(realpath .)/_build"
 
       - name: Upload testsuite.log
@@ -576,7 +575,9 @@ jobs:
       - name: Extended coverage
         run: |
           make -C _build test --jobs=$(($(nproc)+1)) --keep-going
-          make -C _build code-coverage-capture                            \
+          make -C _build code-coverage-capture \
+                         CODE_COVERAGE_LCOV_SHOPTS_DEFAULT="--rc branch_coverage=1" \
+                         CODE_COVERAGE_GENHTML_OPTIONS_DEFAULT="--rc branch_coverage=1" \
                          CODE_COVERAGE_OUTPUT_DIRECTORY=extended-coverage \
                          CODE_COVERAGE_OUTPUT_FILE=extended-coverage.info \
                          CODE_COVERAGE_DIRECTORY="$(realpath .)/_build"


### PR DESCRIPTION
This PR attemps to fix coverage with recent versions of lcov.

This is achieved through different options, each solving a different problem.

```
CODE_COVERAGE_LCOV_RMOPTS_DEFAULT="--ignore-errors unused"
```
This is required because this appears in the logs:
```
lcov: ERROR: 'exclude' pattern '/tmp/*' is unused.
	(use "lcov --ignore-errors unused ..." to bypass this error)
```
Note that the `/tmp/*` pattern is added by `m4/ax_code_coverage.m4`, so maybe an updated version of this M4 script would work with newer versions of lcov ?

```
CODE_COVERAGE_LCOV_OPTIONS_DEFAULT="--ignore-errors source"
```
This is required because this appears in the logs:
```
geninfo: ERROR: unable to open /home/runner/work/gnucobol/gnucobol/_build/cobc/ppparse.c: No such file or directory
	(use "geninfo --ignore-errors source ..." to bypass this error)
```
This error occurs for all generated files (`cobc/pplex.c`, `cobc/scanner.c`, `cobc/ppparse.c`, `cobc/parser.c`), probably because they are in the source tarball and hence missing from the build directory (copying them here would also workaround the error). Since all these files are in `CODE_COVERAGE_IGNORE_PATTERN`, it seems safe to ignore this error anyways, as we're doing here.

Then, we also apply a "fixup" for a warning:
```
CODE_COVERAGE_LCOV_OPTIONS_DEFAULT="--rc geninfo_unexecuted_blocks=1"
```
Needed because we have this:
```
geninfo: WARNING: /home/runner/work/gnucobol/gnucobol/libcob/numeric.c:469: unexecuted block on non-branch line with non-zero hit count.  Use "geninfo --rc geninfo_unexecuted_blocks=1 to set count to zero.
	(use "geninfo --ignore-errors gcov,gcov ..." to suppress this warning)
```

Finally, to be more future-proof, we define those:
```
CODE_COVERAGE_LCOV_SHOPTS_DEFAULT="--rc branch_coverage=1"
CODE_COVERAGE_GENHTML_OPTIONS_DEFAULT="--rc genhtml_branch_coverage=1"
```
Because we have these warnings:
```
geninfo: WARNING: RC option 'lcov_branch_coverage' is deprecated.  Consider using 'branch_coverage. instead.  (Backward-compatible support will be removed in the future
```
```
genhtml: WARNING: RC option 'genhtml_branch_coverage' is deprecated.  Consider using 'branch_coverage. instead.  (Backward-compatible support will be removed in the future
```
But maybe an updated version of `ax_code_coverage.m4` could work ?
