### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/windows-msys2.yml
+++ b/.github/workflows/windows-msys2.yml
@@ -71,7 +71,7 @@ jobs:
   build:
     needs: prepare
     runs-on: windows-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:

--- a/cobc/ChangeLog
+++ b/cobc/ChangeLog
@@ -1,4 +1,9 @@
 
+2025-07-28  David Declerck <david.declerck@ocamlpro.com>
+
+	* codegen.c (output_module_init_function): replace "module" by
+	  "module__" to avoid name clashes with COBOL programs named "module"
+
 2025-07-15  Simon Sobisch <simonsobisch@gnu.org>
 
 	* cobc.h, tree.h, replace.c, scanner.l: fixed enum and forward definitions

--- a/cobc/codegen.c
+++ b/cobc/codegen.c
@@ -11292,12 +11292,12 @@ output_module_init_function (struct cb_program *prog)
 	if (!prog->nested_level) {
 		output_line ("/* Initialize module structure for %s */",
 			prog->orig_program_id);
-		output_line ("static void %s_module_init (cob_module *module)",
+		output_line ("static void %s_module_init (cob_module *module__)",
 			prog->program_id);
 	} else {
 		output_line ("/* Initialize module structure for %s (nested %d) */",
 			prog->program_id, prog->toplev_count);
-		output_line ("static void %s_%d_module_init (cob_module *module)",
+		output_line ("static void %s_%d_module_init (cob_module *module__)",
 			prog->program_id, prog->toplev_count);
 	}
 	output_block_open ();
@@ -11319,50 +11319,50 @@ output_module_init_function (struct cb_program *prog)
 #endif
 
 	/* Do not initialize next pointer, parameter list pointer + count */
-	output_line ("module->module_name = \"%s\";", prog->orig_program_id);
-	output_line ("module->module_formatted_date = COB_MODULE_FORMATTED_DATE;");
-	output_line ("module->module_source = COB_SOURCE_FILE;");
-	output_line ("module->gc_version = COB_PACKAGE_VERSION;");
+	output_line ("module__->module_name = \"%s\";", prog->orig_program_id);
+	output_line ("module__->module_formatted_date = COB_MODULE_FORMATTED_DATE;");
+	output_line ("module__->module_source = COB_SOURCE_FILE;");
+	output_line ("module__->gc_version = COB_PACKAGE_VERSION;");
 	if (!prog->nested_level) {
-		output_line ("module->module_entry.funcptr = (void *(*)())%s;",
+		output_line ("module__->module_entry.funcptr = (void *(*)())%s;",
 			     prog->program_id);
 		if (prog->prog_type == COB_MODULE_TYPE_FUNCTION) {
-			output_line ("module->module_cancel.funcptr = NULL;");
+			output_line ("module__->module_cancel.funcptr = NULL;");
 		} else {
-			output_line ("module->module_cancel.funcptr = (void *(*)())%s_;",
+			output_line ("module__->module_cancel.funcptr = (void *(*)())%s_;",
 				     prog->program_id);
 		}
 	} else {
-		output_line ("module->module_entry.funcvoid = NULL;");
-		output_line ("module->module_cancel.funcvoid = NULL;");
+		output_line ("module__->module_entry.funcvoid = NULL;");
+		output_line ("module__->module_cancel.funcvoid = NULL;");
 	}
 
 	if (!cobc_flag_main && non_nested_count > 1) {
-		output_line ("module->module_ref_count = &cob_reference_count;");
+		output_line ("module__->module_ref_count = &cob_reference_count;");
 	} else {
-		output_line ("module->module_ref_count = NULL;");
+		output_line ("module__->module_ref_count = NULL;");
 	}
-	output_line ("module->module_path = &cob_module_path;");
-	output_line ("module->module_active = 0;");
-	output_line ("module->module_date = COB_MODULE_DATE;");
-	output_line ("module->module_time = COB_MODULE_TIME;");
-	output_line ("module->module_type = %u;", prog->prog_type);
-	output_line ("module->module_param_cnt = %u;", prog->num_proc_params);
+	output_line ("module__->module_path = &cob_module_path;");
+	output_line ("module__->module_active = 0;");
+	output_line ("module__->module_date = COB_MODULE_DATE;");
+	output_line ("module__->module_time = COB_MODULE_TIME;");
+	output_line ("module__->module_type = %u;", prog->prog_type);
+	output_line ("module__->module_param_cnt = %u;", prog->num_proc_params);
 #if 0 /* currently not checked anywhere, may use for void or more general type */
-	output_line ("module->module_returning = %u;", prog->flag_void ? 0 : 1);
+	output_line ("module__->module_returning = %u;", prog->flag_void ? 0 : 1);
 #endif
-	output_line ("module->ebcdic_sign = %d;", cb_ebcdic_sign);
-	output_line ("module->decimal_point = '%c';", prog->decimal_point);
-	output_line ("module->currency_symbol = '%c';", prog->currency_symbol);
-	output_line ("module->numeric_separator = '%c';", prog->numeric_separator);
-	output_line ("module->flag_filename_mapping = %d;", cb_filename_mapping);
-	output_line ("module->flag_binary_truncate = %d;", cb_binary_truncate);
-	output_line ("module->flag_pretty_display = %d;", cb_pretty_display);
-	output_line ("module->flag_host_sign = %d;", cb_host_sign);
-	output_line ("module->flag_no_phys_canc = %d;", no_physical_cancel);
-	output_line ("module->flag_main = %d;", cobc_flag_main);
-	output_line ("module->flag_fold_call = %d;", cb_fold_call);
-	output_line ("module->flag_exit_program = 0;");
+	output_line ("module__->ebcdic_sign = %d;", cb_ebcdic_sign);
+	output_line ("module__->decimal_point = '%c';", prog->decimal_point);
+	output_line ("module__->currency_symbol = '%c';", prog->currency_symbol);
+	output_line ("module__->numeric_separator = '%c';", prog->numeric_separator);
+	output_line ("module__->flag_filename_mapping = %d;", cb_filename_mapping);
+	output_line ("module__->flag_binary_truncate = %d;", cb_binary_truncate);
+	output_line ("module__->flag_pretty_display = %d;", cb_pretty_display);
+	output_line ("module__->flag_host_sign = %d;", cb_host_sign);
+	output_line ("module__->flag_no_phys_canc = %d;", no_physical_cancel);
+	output_line ("module__->flag_main = %d;", cobc_flag_main);
+	output_line ("module__->flag_fold_call = %d;", cb_fold_call);
+	output_line ("module__->flag_exit_program = 0;");
 	{
 		int	opt = 0;
 		if (cb_flag_traceall) {
@@ -11378,16 +11378,16 @@ output_module_init_function (struct cb_program *prog)
 			opt |= COB_MODULE_DEBUG;
 		}
 #endif
-		output_line ("module->flag_debug_trace = %d;", opt);
+		output_line ("module__->flag_debug_trace = %d;", opt);
 	}
-	output_line ("module->flag_dump_ready = %u;", cb_flag_dump ? 1 : 0);
-	output_line ("module->xml_mode = %u;", cb_xml_parse_xmlss);
-	output_line ("module->module_stmt = 0;");
+	output_line ("module__->flag_dump_ready = %u;", cb_flag_dump ? 1 : 0);
+	output_line ("module__->xml_mode = %u;", cb_xml_parse_xmlss);
+	output_line ("module__->module_stmt = 0;");
 	if (source_cache) {
-		output_line ("module->module_sources = %ssource_files;",
+		output_line ("module__->module_sources = %ssource_files;",
 			CB_PREFIX_STRING);
 	} else {
-		output_line ("module->module_sources = NULL;");
+		output_line ("module__->module_sources = NULL;");
 	}
 
 	output_block_close ();

--- a/libcob/ChangeLog
+++ b/libcob/ChangeLog
@@ -1,4 +1,9 @@
 
+2025-07-28  David Declerck <david.declerck@ocamlpro.com>
+
+	* fileio.c (cob_file_sort_giving_extfh): use cob_call_union to silence
+	  pedantic warning about invalid cast from pointer to pointer-to-function
+
 2025-07-15  Simon Sobisch <simonsobisch@gnu.org>
 
 	initial (unfinished) support for XML PARSE

--- a/libcob/fileio.c
+++ b/libcob/fileio.c
@@ -8690,8 +8690,10 @@ cob_file_sort_giving_extfh (cob_file *sort_file, const size_t varcnt, ...)
 	i_fh = 0;
 	va_start (args, varcnt);
 	for (i = 0; i < varcnt; i += 2) {
+		cob_call_union f;
 		fbase[i_fh] = va_arg (args, cob_file *);
-		callfh[i_fh++] = va_arg (args, void *);
+		f.funcvoid = va_arg (args, void *);
+		callfh[i_fh++] = (int (*)(unsigned char *, FCD3 *))f.funcint;
 	}
 	va_end (args);
 	cob_file_sort_giving_internal (sort_file, i_fh, fbase, callfh);

--- a/tests/testsuite.src/run_fundamental.at
+++ b/tests/testsuite.src/run_fundamental.at
@@ -3647,25 +3647,25 @@ AT_DATA([prog.cob], [
        PROGRAM-ID.      prog.
        DATA DIVISION.
        PROCEDURE        DIVISION.
-           CALL 'module'
-           CALL 'modulepart'
+           CALL 'mod'
+           CALL 'modpart'
            STOP RUN.
 ])
 
-AT_DATA([module.cob], [
+AT_DATA([mod.cob], [
        IDENTIFICATION   DIVISION.
-       PROGRAM-ID.      module.
+       PROGRAM-ID.      mod.
        DATA DIVISION.
        PROCEDURE        DIVISION.
            DISPLAY 'A' WITH NO ADVANCING
            GOBACK.
-       ENTRY 'modulepart'.
+       ENTRY 'modpart'.
            DISPLAY 'B' WITH NO ADVANCING
            GOBACK.
 ])
 
 AT_CHECK([$COMPILE prog.cob], [0], [], [])
-AT_CHECK([$COMPILE_MODULE module.cob], [0], [], [])
+AT_CHECK([$COMPILE_MODULE mod.cob], [0], [], [])
 AT_CHECK([$COBCRUN_DIRECT ./prog], [0], [AB], [])
 
 AT_CLEANUP

--- a/tests/testsuite.src/run_fundamental.at
+++ b/tests/testsuite.src/run_fundamental.at
@@ -3647,25 +3647,25 @@ AT_DATA([prog.cob], [
        PROGRAM-ID.      prog.
        DATA DIVISION.
        PROCEDURE        DIVISION.
-           CALL 'mod'
-           CALL 'modpart'
+           CALL 'module'
+           CALL 'modulepart'
            STOP RUN.
 ])
 
-AT_DATA([mod.cob], [
+AT_DATA([module.cob], [
        IDENTIFICATION   DIVISION.
-       PROGRAM-ID.      mod.
+       PROGRAM-ID.      module.
        DATA DIVISION.
        PROCEDURE        DIVISION.
            DISPLAY 'A' WITH NO ADVANCING
            GOBACK.
-       ENTRY 'modpart'.
+       ENTRY 'modulepart'.
            DISPLAY 'B' WITH NO ADVANCING
            GOBACK.
 ])
 
 AT_CHECK([$COMPILE prog.cob], [0], [], [])
-AT_CHECK([$COMPILE_MODULE mod.cob], [0], [], [])
+AT_CHECK([$COMPILE_MODULE module.cob], [0], [], [])
 AT_CHECK([$COBCRUN_DIRECT ./prog], [0], [AB], [])
 
 AT_CLEANUP

--- a/tests/testsuite.src/run_misc.at
+++ b/tests/testsuite.src/run_misc.at
@@ -4947,9 +4947,10 @@ cprog (void *cb)
    char *p1;
    int  p2 = 42;
    char *p3 = "CALLBACK";
+   cob_call_union f = { .funcvoid = cb };
 
    p1 = p3;
-   ((int (*)(char *, int, char *))cb)(p1, p2, p3);
+   ((int (*)(char *, int, char *))f.funcint)(p1, p2, p3);
    return 0;
 }
 ]])
@@ -5023,9 +5024,10 @@ cprog (void *cb)
    char *p1;
    int  p2 = 42;
    char *p3 = "CALLBACK";
+   cob_call_union f = { .funcvoid = cb };
 
    p1 = p3;
-   ((int (*)(char *, int, char *))cb)(p1, p2, p3);
+   ((int (*)(char *, int, char *))f.funcint)(p1, p2, p3);
    return 0;
 }
 ]])

--- a/tests/testsuite.src/used_binaries.at
+++ b/tests/testsuite.src/used_binaries.at
@@ -1108,7 +1108,7 @@ AT_DATA([prog2.cob], [
 AT_DATA([filec.c], [
 /* for COB_EXT_EXPORT */
 #include <libcob.h>
-COB_EXT_EXPORT void f (char *str, long num);
+COB_EXT_EXPORT void f (char *str, long num) {}
 ])
 AT_CHECK([$COMPILE_MODULE --save-temps filec.c -o libfilec.$COB_MODULE_EXT], [0], [], [])
 # cater for environments that do not use a lib prefix


### PR DESCRIPTION
Recent CI failures have two reasons:

- SVN commit 5549 changed a test in `used_binaries.at`, removing the body of a function: this broke test `27: check include header file` on MacOS, MSVC and MSYS2. I restored the (empty) function body.

- MSYS2 updated the perl package version from 5.38.2 to 5.38.4, yet forgot to update other packages that install perl modules: as a result, those are still installed in the 5.38.2 perl module folder. This broke a perl script invoked when installing tex, causing errors when generating the GnuCOBOL documentation. I opened an [issue](https://github.com/msys2/MINGW-packages/issues/24906) on the MSYS2 repo. Meanwhile, I'm using a very hackish workaround (which I don't intend to merge) to get the CI working. I hope this will be fixed in MSYS2 soon.