### PR TITLE
Fix ORD/CHAR intrinsics

### DIFF
--- a/libcob/ChangeLog
+++ b/libcob/ChangeLog
@@ -1,4 +1,11 @@
 
+2025-09-09  David Declerck <david.declerck@ocamlpro.com>
+
+	* intrinsic.c (cob_intr_char, cob_intr_ord): consider
+	  the program collating sequence in CHAR and ORD
+	* intrinsic.c (cob_intr_char): raise COB_EC_ARGUMENT_FUNCTION
+	  when calling CHAR with an argument outside the collation range
+
 2025-07-28  Simon Sobisch <simonsobisch@gnu.org>
 
 	* common.h, fileio.c: new externalized typedef EXTFH_FUNC used in

--- a/libcob/intrinsic.c
+++ b/libcob/intrinsic.c
@@ -4318,8 +4318,7 @@ cob_intr_current_date (const int offset, const int length)
 	return curr_field;
 }
 
-/* implementation of FUNCTION CHAR - character from ordinal
-   FIXME: Should use the program's alphanumeric program collating sequence! */
+/* implementation of FUNCTION CHAR - character from ordinal */
 cob_field *
 cob_intr_char (cob_field *srcfield)
 {
@@ -4331,9 +4330,23 @@ cob_intr_char (cob_field *srcfield)
 
 	i = cob_get_int (srcfield);
 	if (i < 1 || i > 256) {
+		cob_set_exception (COB_EC_ARGUMENT_FUNCTION);
 		*curr_field->data = 0;
 	} else {
-		*curr_field->data = (unsigned char)i - 1;
+		const unsigned char *col = COB_MODULE_PTR->collating_sequence;
+		unsigned char chr;
+		cobglobptr->cob_exception_code = 0;
+		--i;
+		if (col == NULL) {
+			chr = (unsigned char)i;
+		} else {
+			for (chr = 0; chr < 255 && col[chr] != i; ++chr);
+			if (chr == 255 && col[chr] != i) {
+				cob_set_exception (COB_EC_ARGUMENT_FUNCTION);
+				chr = 0;
+			}
+		}
+		*curr_field->data = chr;
 	}
 	return curr_field;
 }
@@ -4341,7 +4354,18 @@ cob_intr_char (cob_field *srcfield)
 cob_field *
 cob_intr_ord (cob_field *srcfield)
 {
-	cob_alloc_set_field_uint ((cob_u32_t)(*srcfield->data + 1U));
+	switch (COB_FIELD_TYPE (srcfield)) {
+	case COB_TYPE_NATIONAL:
+		error_not_implemented();
+		break;
+	default: {
+		const unsigned char *col = COB_MODULE_PTR->collating_sequence;
+		unsigned char chr = *srcfield->data;
+		int ord = (col == NULL ? chr : col[chr]) + 1U;
+		cob_alloc_set_field_uint ((cob_u32_t)ord);
+		break;
+	}
+	}
 	return curr_field;
 }
 

--- a/tests/testsuite.src/run_misc.at
+++ b/tests/testsuite.src/run_misc.at
@@ -15436,7 +15436,7 @@ AT_DATA([prog1.cob], [
 
 AT_CHECK([$COMPILE prog1.cob], [0], [], [])
 AT_CHECK([$COBCRUN_DIRECT ./prog1], [0],
-[LOW-VALUE: 063 (064) HIGH-VALUE: 192 (193)], [])
+[LOW-VALUE: 063 (001) HIGH-VALUE: 192 (256)], [])
 
 AT_DATA([prog2.cob], [
        IDENTIFICATION DIVISION.
@@ -15483,7 +15483,7 @@ AT_DATA([prog2.cob], [
 
 AT_CHECK([$COMPILE prog2.cob], [0], [], [])
 AT_CHECK([$COBCRUN_DIRECT ./prog2], [0],
-[LOW-VALUE: 064 (065) HIGH-VALUE: 255 (256)], [])
+[LOW-VALUE: 064 (001) HIGH-VALUE: 255 (256)], [])
 
 AT_DATA([prog3.cob], [
        IDENTIFICATION DIVISION.
@@ -15529,7 +15529,7 @@ AT_DATA([prog3.cob], [
 
 AT_CHECK([$COMPILE -febcdic-table=ebcdic500_latin1 prog3.cob], [0], [], [])
 AT_CHECK([$COBCRUN_DIRECT ./prog3], [0],
-[LOW-VALUE: 000 (001) HIGH-VALUE: 159 (160)], [])
+[LOW-VALUE: 000 (001) HIGH-VALUE: 159 (256)], [])
 
 AT_DATA([prog4.cob], [
        IDENTIFICATION DIVISION.
@@ -15569,7 +15569,7 @@ AT_DATA([prog4.cob], [
 
 AT_CHECK([$COMPILE -fdefault-colseq=EBCDIC -febcdic-table=ebcdic500_latin1 prog4.cob], [0], [], [])
 AT_CHECK([$COBCRUN_DIRECT ./prog4], [0],
-[LOW-VALUE: 000 (001) HIGH-VALUE: 159 (160)], [])
+[LOW-VALUE: 000 (001) HIGH-VALUE: 159 (256)], [])
 
 AT_DATA([prog5.cob], [
        IDENTIFICATION DIVISION.
@@ -15656,7 +15656,7 @@ AT_DATA([prog5.cob], [
 
 AT_CHECK([$COMPILE -febcdic-table=ebcdic500_latin1 prog5.cob], [0], [], [])
 AT_CHECK([$COBCRUN_DIRECT ./prog5], [0],
-[P1 LOW-VALUE: 000 (001) HIGH-VALUE: 159 (160)
+[P1 LOW-VALUE: 000 (001) HIGH-VALUE: 159 (256)
 P2 LOW-VALUE: 000 (001) HIGH-VALUE: 255 (256)], [])
 
 AT_DATA([prog6.cob], [
@@ -15680,5 +15680,60 @@ AT_DATA([prog6.cob], [
 AT_CHECK([$COMPILE -fdefault-colseq=EBCDIC -febcdic-table=ebcdic500_latin1 prog6.cob], [0], [], [])
 AT_CHECK([$COBCRUN_DIRECT ./prog6], [0],
 [01 02 03 04 05 06 07 08 09 ], [])
+
+AT_CLEANUP
+
+
+AT_SETUP([CHAR/ORD/ORD-MIN/ORD-MAX when using non-native program collating sequence])
+AT_KEYWORDS([CHAR ORD ORD-MIN ORD-MAX ALPHABET])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. prog.
+       ENVIRONMENT DIVISION.
+       CONFIGURATION SECTION.
+       OBJECT-COMPUTER. x86,
+           PROGRAM COLLATING SEQUENCE IS alpha-custom.
+       SPECIAL-NAMES.
+           ALPHABET alpha-custom IS
+               64 THRU 1
+               65 THRU 192
+               256 THRU 193.
+       REPOSITORY.
+           FUNCTION CHAR ORD ORD-MIN ORD-MAX INTRINSIC.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       PROCEDURE DIVISION.
+           DISPLAY CHAR (1) CHAR (7) CHAR (16) CHAR (22) CHAR (31)
+                   CHAR (66) CHAR (91) CHAR (98) CHAR (123).
+           DISPLAY ORD ("?").
+           DISPLAY ORD ("9").
+           DISPLAY ORD ("0").
+           DISPLAY ORD ("*").
+           DISPLAY ORD ("!").
+           DISPLAY ORD ("A").
+           DISPLAY ORD ("Z").
+           DISPLAY ORD ("a").
+           DISPLAY ORD ("z").
+           DISPLAY ORD-MIN ("?" "9" "0" "*" "!" "A" "Z" "a" "z").
+           DISPLAY ORD-MAX ("?" "9" "0" "*" "!" "A" "Z" "a" "z").
+           STOP RUN.
+])
+
+AT_CHECK([$COMPILE prog.cob], [0], [], [])
+AT_CHECK([$COBCRUN_DIRECT ./prog], [0],
+[?90*!AZaz
+000000001
+000000007
+000000016
+000000022
+000000031
+000000066
+000000091
+000000098
+000000123
+000000001
+000000009
+], [])
 
 AT_CLEANUP


### PR DESCRIPTION
This fixes the ORD and CHAR intrisics in presence of collating sequences.