### PR TITLE
Add COB_SIGNAL_REGIME config option to control how runtime signal handler is registered

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,14 +1,8 @@
 
-2025-11-19	Oğuzcan Kırmemiş <oguzcan.kirmemis@gmail.com>
+2025-11-19  Oğuzcan Kırmemiş <oguzcan.kirmemis@gmail.com>
 
-	* common.c (cob_set_signal): add the enum COB_SIGNAL_REGIME to toggle
-	  whether signal handler registration should be skipped or only registered
-	  when there is no other external handler registered for the signal
-	* common.h: export cob_sig_handler for use by external signal handlers
-	* coblocal.h (cob_settings): add COB_SIGNAL_REGIME so that it can be
-	  displayed under cobcrun --runtime
-	* configure.ac, atlocal.in, atlocal_win: pass HAVE_SIGNAL_H to the tests to
-	  indicate whether signal.h exists
+	* configure.ac: pass HAVE_SIGNAL_H to the tests to indicate whether
+	  signal.h exists
 
 2025-11-11  Simon Sobisch <simonsobisch@gnu.org>
 
@@ -25,7 +19,7 @@
 	* DEPENDENCIES, DEPENDENCIES.md: reformatted, add libxml2 version and
 	  new website as well as fixing MIT/Expat ambiguity
 
-2025-07-28	Simon Sobisch <simonsobisch@gnu.org>
+2025-07-28  Simon Sobisch <simonsobisch@gnu.org>
 
 	* configure.ac: check timezone and designated initializers with -Werror
 	* m4/ax_code_coverage.m4, m4/ax_check_define.m4:

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,15 @@
 
+2025-11-19	Oğuzcan Kırmemiş <oguzcan.kirmemis@gmail.com>
+
+	* common.c (cob_set_signal): add the enum COB_SIGNAL_REGIME to toggle
+	  whether signal handler registration should be skipped or only registered
+	  when there is no other external handler registered for the signal
+	* common.h: export cob_sig_handler for use by external signal handlers
+	* coblocal.h (cob_settings): add COB_SIGNAL_REGIME so that it can be
+	  displayed under cobcrun --runtime
+	* configure.ac, atlocal.in, atlocal_win: pass HAVE_SIGNAL_H to the tests to
+	  indicate whether signal.h exists
+
 2025-11-11  Simon Sobisch <simonsobisch@gnu.org>
 
 	* configure.ac: prefer "inline" over "__inline" as the second raises
@@ -14,7 +25,7 @@
 	* DEPENDENCIES, DEPENDENCIES.md: reformatted, add libxml2 version and
 	  new website as well as fixing MIT/Expat ambiguity
 
-2025-07-28  Simon Sobisch <simonsobisch@gnu.org>
+2025-07-28	Simon Sobisch <simonsobisch@gnu.org>
 
 	* configure.ac: check timezone and designated initializers with -Werror
 	* m4/ax_code_coverage.m4, m4/ax_check_define.m4:

--- a/NEWS
+++ b/NEWS
@@ -29,6 +29,12 @@ NEWS - user visible changes				-*- outline -*-
 ** new runtime configuration COB_HIDE_CURSOR, allows to hide the cursor during
    extended ScreenIO operations
 
+** new runtime configuration COB_SIGNAL_REGIME, allows to skip registration of
+   the signal handler of GnuCOBOL. The registration can be skipped either for
+   all signals or for those that do already have a registered handler. This
+   configuration allows users to preserve their own signal handlers during the
+   initialization of the GnuCOBOL runtime.
+
 ** added multiple window functionality with new system function CBL_GC_WINDOW
 
 ** New system functions

--- a/config/runtime.cfg
+++ b/config/runtime.cfg
@@ -149,6 +149,25 @@
 #             Note:  format of GC2.2 and older:
 #                    "PROGRAM-ID: %I 	Line: %L 	%S"
 
+# Environment name:  COB_SIGNAL_REGIME
+#   Parameter name:  cob_signal_regime
+#          Purpose:  to enable control over how the signal handler of the
+                     runtime is registered for the signals used by the runtime
+              Type:  0   registers the signal handler to all default signals
+                     1   registers the signal handler to all default signals
+                         only if there is not any other handler already
+                         registered for a signal
+                     2   skips signal handler registration for all signals
+           Default:  0
+           Example:  core_signal_regime 2
+              Note:  The signal handler of the runtime can be called manually
+                     by the external signal handler in environments where two
+                     different handlers have to co-exist. If the signal handler
+                     is skipped for a signal, any runtime functionality that
+                     depends on it will not work. This may lead to undefined
+                     behavior, as the runtime will be unable to clean up
+                     properly.
+
 # Environment name:  COB_CORE_ON_ERROR
 #   Parameter name:  core_on_error
 #          Purpose:  to enable operating system handling of signals and to

--- a/config/runtime.cfg
+++ b/config/runtime.cfg
@@ -152,21 +152,21 @@
 # Environment name:  COB_SIGNAL_REGIME
 #   Parameter name:  cob_signal_regime
 #          Purpose:  to enable control over how the signal handler of the
-                     runtime is registered for the signals used by the runtime
-              Type:  0   registers the signal handler to all default signals
-                     1   registers the signal handler to all default signals
-                         only if there is not any other handler already
-                         registered for a signal
-                     2   skips signal handler registration for all signals
-           Default:  0
-           Example:  core_signal_regime 2
-              Note:  The signal handler of the runtime can be called manually
-                     by the external signal handler in environments where two
-                     different handlers have to co-exist. If the signal handler
-                     is skipped for a signal, any runtime functionality that
-                     depends on it will not work. This may lead to undefined
-                     behavior, as the runtime will be unable to clean up
-                     properly.
+#                    runtime is registered for the signals used by the runtime
+#             Type:  0   registers the signal handler to all default signals
+#                    1   registers the signal handler to all default signals
+#                        only if there is not any other handler already
+#                        registered for a signal
+#                    2   skips signal handler registration for all signals
+#          Default:  0
+#          Example:  core_signal_regime 2
+#             Note:  The signal handler of the runtime can be called manually
+#                    by the external signal handler in environments where two
+#                    different handlers have to co-exist. If the signal handler
+#                    is skipped for a signal, any runtime functionality that
+#                    depends on it will not work. This may lead to undefined
+#                    behavior, as the runtime will be unable to clean up
+#                    properly.
 
 # Environment name:  COB_CORE_ON_ERROR
 #   Parameter name:  core_on_error

--- a/configure.ac
+++ b/configure.ac
@@ -714,7 +714,7 @@ AC_FUNC_VPRINTF
 AC_CHECK_FUNCS([memmove memset setlocale fcntl strerror strcasecmp
 	strchr strrchr strdup strstr strtol gettimeofday localeconv
 	getexecname canonicalize_file_name popen raise readlink realpath
-	setenv strcoll flockfile])
+	setenv strcoll flockfile kill signal])
 
 # more things to save...
 AC_CACHE_SAVE

--- a/configure.ac
+++ b/configure.ac
@@ -2761,6 +2761,7 @@ AC_SUBST([PROGRAMS_LIBS])
 AC_SUBST([LIBCOB_LIBS])
 AC_SUBST([LIBCOB_CPPFLAGS])
 AC_SUBST([COB_ENABLE_DEBUG], [$enable_debug]) # needed for tests/atlocal
+AC_SUBST([HAVE_SIGNAL_H], ["$ac_cv_header_signal_h"]) # needed for tests/atlocal
 
 dnl was used in bin/Makefile.am - seems not to be needed
 dnl AC_SUBST([COB_EXPORT_DYN])

--- a/configure.ac
+++ b/configure.ac
@@ -714,7 +714,7 @@ AC_FUNC_VPRINTF
 AC_CHECK_FUNCS([memmove memset setlocale fcntl strerror strcasecmp
 	strchr strrchr strdup strstr strtol gettimeofday localeconv
 	getexecname canonicalize_file_name popen raise readlink realpath
-	setenv strcoll flockfile kill signal])
+	setenv strcoll flockfile])
 
 # more things to save...
 AC_CACHE_SAVE

--- a/libcob/ChangeLog
+++ b/libcob/ChangeLog
@@ -1,4 +1,13 @@
 
+2025-11-19  Oğuzcan Kırmemiş <oguzcan.kirmemis@gmail.com>
+
+	* common.c (cob_set_signal): add the enum COB_SIGNAL_REGIME to toggle
+	  whether signal handler registration should be skipped or only registered
+	  when there is no other external handler registered for the signal
+	* common.h: export cob_sig_handler for use by external signal handlers
+	* coblocal.h (cob_settings): add COB_SIGNAL_REGIME so that it can be
+	  displayed under cobcrun --runtime
+
 2025-11-13  Simon Sobisch <simonsobisch@gnu.org>
 
 	* coblocal.h [__GNUC__]: only use C11's _Thread_local for gcc 5+

--- a/libcob/coblocal.h
+++ b/libcob/coblocal.h
@@ -377,7 +377,10 @@ typedef struct __cob_settings {
 	int		cob_prof_max_depth;	/* Max stack depth during profiling (255 by default) */
 	char		*cob_prof_format;	/* Format of prof CSV line */
 	int		cob_dump_width;		/* Max line width for dump */
-	unsigned int	cob_signal_regime;		/* Whether signal handler is registered */
+	unsigned int	cob_signal_regime;		/* signal handler registration strategy
+											   not directly used by the runtime instead read directly with getenv
+											   because it is required before the initialization of cob_settings
+											   captured here extra for runtime information purposes */
 	unsigned int	cob_core_on_error;		/* signal handling and possible raise of SIGABRT
 											   / creation of coredumps on runtime errors */
 	char		*cob_core_filename;	/* filename for coredump creation */

--- a/libcob/coblocal.h
+++ b/libcob/coblocal.h
@@ -377,6 +377,7 @@ typedef struct __cob_settings {
 	int		cob_prof_max_depth;	/* Max stack depth during profiling (255 by default) */
 	char		*cob_prof_format;	/* Format of prof CSV line */
 	int		cob_dump_width;		/* Max line width for dump */
+	unsigned int	cob_signal_regime;		/* Whether signal handler is registered */
 	unsigned int	cob_core_on_error;		/* signal handling and possible raise of SIGABRT
 											   / creation of coredumps on runtime errors */
 	char		*cob_core_filename;	/* filename for coredump creation */

--- a/libcob/common.c
+++ b/libcob/common.c
@@ -1527,7 +1527,7 @@ cob_set_signal (void)
 	struct sigaction	osa;
 
 	signal_regime = getenv ("COB_SIGNAL_REGIME");
-	if (*signal_regime == '2') {
+	if (signal_regime && *signal_regime == '2') {
 		/* Don't set any signal */
 		return;
 	}
@@ -1544,7 +1544,7 @@ cob_set_signal (void)
 
 	for (k = 0; k < NUM_SIGNALS; k++) {
 		if (signals[k].for_set) {
-			if (*signal_regime == '1') {
+			if (signal_regime && *signal_regime == '1') {
 				/* Only take control if no handler is registered (=SIG_DFL) */
 				(void)sigaction (signals[k].sig, NULL, &osa);
 				if (osa.sa_handler == SIG_DFL) {
@@ -1571,14 +1571,14 @@ cob_set_signal (void)
 	void (*ohdlr) (int);
 
 	signal_regime = getenv ("COB_SIGNAL_REGIME");
-	if (*signal_regime == '2') {
+	if (signal && *signal_regime == '2') {
 		/* Don't set any signal */
 		return;
 	}
 
 	for (k = 0; k < NUM_SIGNALS; k++) {
 		if (signals[k].for_set) {
-			if (*signal_regime == '1') {
+			if (signal && *signal_regime == '1') {
 				/* Only take control if no handler is registered (=SIG_DFL) */
 				ohdlr = signal (signals[k].sig, cob_sig_handler);
 				if (ohdlr != SIG_DFL) {

--- a/libcob/common.c
+++ b/libcob/common.c
@@ -531,7 +531,7 @@ static struct config_enum beepopts[] = {{"FLASH", "1"}, {"SPEAKER", "2"}, {"FALS
 static struct config_enum timeopts[] = {{"0", "1000"}, {"1", "100"}, {"2", "10"}, {"3", "1"}, {NULL, NULL}};
 static struct config_enum syncopts[] = {{"P", "1"}, {NULL, NULL}};
 static struct config_enum varseqopts[] = {{"0", "0"}, {"1", "1"}, {"2", "2"}, {"3", "3"}, {NULL, NULL}};
-static struct config_enum sighdlrregopts[] = {{"0", "0"}, {"1", "1"}, {"2", "2"}, {NULL, NULL}};
+static struct config_enum sighdlrregopts[] = {{"DEFAULT", "0"}, {"AVAILABLE", "1"}, {"IGNORE", "2"}, {NULL, NULL}};
 static struct config_enum coeopts[] = {{"0", "0"}, {"1", "1"}, {"2", "2"}, {"3", "3"}, {NULL, NULL}};
 static char	varseq_dflt[8] = "0";
 static unsigned char min_conf_length = 0;
@@ -1175,7 +1175,23 @@ create_dumpfile (void)
 	return ret;
 }
 
+/** \brief default signal handler of the runtime
 
+	In most cases when a signal is received, the signal handler is configured
+	to terminate the program after tidying up the runtime, unless an external
+	signal handler is registered. In such cases, the external handler is
+	invoked before the signal is raised again, which is then handled by the
+	default handler of the host operating system.
+
+	If the signal is received during a \ref cob_call_with_exception_check call,
+	the signal handler aborts the call and notifies that it has been aborted by
+	the signal handler.
+	
+	Additionaly, the signal handler can be configured to create a coredump when
+	a signal occurs. See \ref COB_CORE_ON_ERROR option for more details.
+
+	\param sig number of the signal
+ */
 void
 cob_sig_handler (int sig)
 {
@@ -1522,17 +1538,23 @@ cob_set_signal (void)
 {
 #if	defined (HAVE_SIGNAL_H)
 	int k;
-	char *signal_regime;
+	char *s;
+	char signal_regime;
 #ifdef	HAVE_SIGACTION
 	struct sigaction	sa;
 	struct sigaction	osa;
+#else
+	void (*ohdlr) (int);
+#endif
 
-	signal_regime = getenv ("COB_SIGNAL_REGIME");
-	if (signal_regime && *signal_regime == '2') {
+	s = getenv ("COB_SIGNAL_REGIME");
+	signal_regime = s ? *s : '0';
+	if (signal_regime == '2') {
 		/* Don't set any signal */
 		return;
 	}
 
+#ifdef HAVE_SIGACTION
 	memset (&sa, 0, sizeof (sa));
 	memset (&osa, 0, sizeof (osa));
 	sa.sa_handler = cob_sig_handler;
@@ -1545,7 +1567,7 @@ cob_set_signal (void)
 
 	for (k = 0; k < NUM_SIGNALS; k++) {
 		if (signals[k].for_set) {
-			if (signal_regime && *signal_regime == '1') {
+			if (signal_regime == '1') {
 				/* Only take control if no handler is registered (=SIG_DFL) */
 				(void)sigaction (signals[k].sig, NULL, &osa);
 				if (osa.sa_handler == SIG_DFL) {
@@ -1569,17 +1591,9 @@ cob_set_signal (void)
 		}
 	}
 #else	/* still defined (HAVE_SIGNAL_H) */
-	void (*ohdlr) (int);
-
-	signal_regime = getenv ("COB_SIGNAL_REGIME");
-	if (signal && *signal_regime == '2') {
-		/* Don't set any signal */
-		return;
-	}
-
 	for (k = 0; k < NUM_SIGNALS; k++) {
 		if (signals[k].for_set) {
-			if (signal && *signal_regime == '1') {
+			if (signal_regime == '1') {
 				/* Only take control if no handler is registered (=SIG_DFL) */
 				ohdlr = signal (signals[k].sig, cob_sig_handler);
 				if (ohdlr != SIG_DFL) {

--- a/libcob/common.c
+++ b/libcob/common.c
@@ -1176,10 +1176,10 @@ create_dumpfile (void)
 }
 
 
-#ifdef	HAVE_SIGNAL_H
 void
 cob_sig_handler (int sig)
 {
+#ifdef	HAVE_SIGNAL_H
 	char buff [COB_MEDIUM_BUFF];
 	char signal_text[COB_MINI_BUFF];
 	const char *signal_name;
@@ -1371,8 +1371,9 @@ exit_handler:
          so exit in all other cases*/
 	exit (sig);
 #endif
-}
 #endif /* HAVE_SIGNAL_H */
+}
+
 
 /* Raise signal (run both internal and external handlers)
    may return, depending on the signal

--- a/libcob/common.c
+++ b/libcob/common.c
@@ -531,6 +531,7 @@ static struct config_enum beepopts[] = {{"FLASH", "1"}, {"SPEAKER", "2"}, {"FALS
 static struct config_enum timeopts[] = {{"0", "1000"}, {"1", "100"}, {"2", "10"}, {"3", "1"}, {NULL, NULL}};
 static struct config_enum syncopts[] = {{"P", "1"}, {NULL, NULL}};
 static struct config_enum varseqopts[] = {{"0", "0"}, {"1", "1"}, {"2", "2"}, {"3", "3"}, {NULL, NULL}};
+static struct config_enum sighdlrregopts[] = {{"0", "0"}, {"1", "1"}, {"2", "2"}, {NULL, NULL}};
 static struct config_enum coeopts[] = {{"0", "0"}, {"1", "1"}, {"2", "2"}, {"3", "3"}, {NULL, NULL}};
 static char	varseq_dflt[8] = "0";
 static unsigned char min_conf_length = 0;
@@ -570,6 +571,7 @@ static struct config_tbl gc_conf[] = {
 	{"COB_TRACE_FILE", "trace_file", 		NULL, 	NULL, GRP_MISC, ENV_FILE, SETPOS (cob_trace_filename)},
 	{"COB_TRACE_FORMAT", "trace_format",	"%P %S Line: %L", NULL, GRP_MISC, ENV_STR, SETPOS (cob_trace_format)},
 	{"COB_STACKTRACE", "stacktrace", 	"1", 	NULL, GRP_MISC, ENV_BOOL, SETPOS (cob_stacktrace)},
+	{"COB_SIGNAL_REGIME", "signal_regime", 	"0", 	sighdlrregopts, GRP_MISC, ENV_UINT | ENV_ENUMVAL, SETPOS (cob_signal_regime)},
 	{"COB_CORE_ON_ERROR", "core_on_error", 	"0", 	coeopts, GRP_MISC, ENV_UINT | ENV_ENUMVAL, SETPOS (cob_core_on_error)},
 	{"COB_CORE_FILENAME", "core_filename", 	"./core.libcob", 	NULL, GRP_MISC, ENV_FILE, SETPOS (cob_core_filename)},
 	{"COB_DUMP_FILE", "dump_file",		NULL,	NULL, GRP_MISC, ENV_FILE, SETPOS (cob_dump_filename)},
@@ -1175,7 +1177,7 @@ create_dumpfile (void)
 
 
 #ifdef	HAVE_SIGNAL_H
-static void
+void
 cob_sig_handler (int sig)
 {
 	char buff [COB_MEDIUM_BUFF];
@@ -1519,9 +1521,16 @@ cob_set_signal (void)
 {
 #if	defined (HAVE_SIGNAL_H)
 	int k;
+	char *signal_regime;
 #ifdef	HAVE_SIGACTION
 	struct sigaction	sa;
 	struct sigaction	osa;
+
+	signal_regime = getenv ("COB_SIGNAL_REGIME");
+	if (*signal_regime == '2') {
+		/* Don't set any signal */
+		return;
+	}
 
 	memset (&sa, 0, sizeof (sa));
 	memset (&osa, 0, sizeof (osa));
@@ -1535,37 +1544,57 @@ cob_set_signal (void)
 
 	for (k = 0; k < NUM_SIGNALS; k++) {
 		if (signals[k].for_set) {
-			/* Take direct control of some hard errors */
-			if (signals[k].for_set == 2) {
-				(void)sigemptyset (&sa.sa_mask);
-				(void)sigaction (signals[k].sig, &sa, NULL);
-			} else {
-				/* for the others: only register if not configured
-				   from the OS side to be ignored */
+			if (*signal_regime == '1') {
+				/* Only take control if no handler is registered (=SIG_DFL) */
 				(void)sigaction (signals[k].sig, NULL, &osa);
-				if (osa.sa_handler != SIG_IGN) {
+				if (osa.sa_handler == SIG_DFL) {
 					(void)sigemptyset (&sa.sa_mask);
 					(void)sigaction (signals[k].sig, &sa, NULL);
 				}
-				/* CHECKME: how should we handle externally registered
-				            error handlers (handler != SIG_DFL)? */
+			} else {
+				/* Take direct control of some hard errors */
+				if (signals[k].for_set == 2) {
+					(void)sigemptyset (&sa.sa_mask);
+					(void)sigaction (signals[k].sig, &sa, NULL);
+				} else {
+					/* for the others: only register if not configured
+					from the OS side to be ignored */
+					if (osa.sa_handler != SIG_IGN) {
+						(void)sigemptyset (&sa.sa_mask);
+						(void)sigaction (signals[k].sig, &sa, NULL);
+					}
+				}
 			}
 		}
 	}
 #else	/* still defined (HAVE_SIGNAL_H) */
+	void (*ohdlr) (int);
+
+	signal_regime = getenv ("COB_SIGNAL_REGIME");
+	if (*signal_regime == '2') {
+		/* Don't set any signal */
+		return;
+	}
+
 	for (k = 0; k < NUM_SIGNALS; k++) {
 		if (signals[k].for_set) {
-			/* Take direct control of some hard errors */
-			if (signals[k].for_set == 2) {
-				(void)signal (signals[k].sig, cob_sig_handler);
-			} else {
-				/* for the others: only register if not configured
-				   from the OS side to be ignored */
-				if (signal (signals[k].sig, SIG_IGN) != SIG_IGN) {
-					(void)signal (signals[k].sig, cob_sig_handler);
+			if (*signal_regime == '1') {
+				/* Only take control if no handler is registered (=SIG_DFL) */
+				ohdlr = signal (signals[k].sig, cob_sig_handler);
+				if (ohdlr != SIG_DFL) {
+					(void)signal (signals[k].sig, ohdlr);
 				}
-				/* CHECKME: how should we handle externally registered
-				            error handlers (handler != SIG_DFL)? */
+			} else {
+				/* Take direct control of some hard errors */
+				if (signals[k].for_set == 2) {
+					(void)signal (signals[k].sig, cob_sig_handler);
+				} else {
+					/* for the others: only register if not configured
+					from the OS side to be ignored */
+					if (signal (signals[k].sig, SIG_IGN) != SIG_IGN) {
+						(void)signal (signals[k].sig, cob_sig_handler);
+					}
+				}
 			}
 		}
 	}

--- a/libcob/common.c
+++ b/libcob/common.c
@@ -1544,7 +1544,7 @@ cob_init_sig_descriptions (void)
 static void
 cob_set_signal (void)
 {
-#if	defined (HAVE_SIGNAL_H)
+#ifdef HAVE_SIGNAL_H
 	int k;
 	const char *s = getenv ("COB_SIGNAL_REGIME");
 	const char signal_regime = s ? *s : '0';

--- a/libcob/common.c
+++ b/libcob/common.c
@@ -1195,7 +1195,6 @@ create_dumpfile (void)
 void
 cob_sig_handler (int sig)
 {
-#ifdef	HAVE_SIGNAL_H
 	char buff [COB_MEDIUM_BUFF];
 	char signal_text[COB_MINI_BUFF];
 	const char *signal_name;
@@ -1211,7 +1210,9 @@ cob_sig_handler (int sig)
 #ifdef	HAVE_RAISE
 		raise (sig);
 #else
+#ifdef HAVE_KILL
 		kill (getpid (), sig);
+#endif
 #endif
 		exit (sig);
 	}
@@ -1292,7 +1293,9 @@ cob_sig_handler (int sig)
 	(void)sigaction (sig, &sa, NULL);
 #endif
 #else
+#ifdef HAVE_SIGNAL
 	(void)signal (sig, SIG_DFL);
+#endif
 #endif
 	cob_exit_screen_from_signal (1);
 
@@ -1373,21 +1376,26 @@ exit_handler:
 #endif
 	/* if an explicit requested coredump could not
 	   be created - raise SIGABRT here */
+#ifdef SIGABRT
 	if (cobsetptr && cobsetptr->cob_core_on_error == 4) {
 		sig = SIGABRT;
 	}
+#endif
+#ifdef HAVE_SIGNAL
 	signal (sig, SIG_DFL);
+#endif
 #ifdef	HAVE_RAISE
 	raise (sig);
 #else
+#ifdef HAVE_KILL
 	kill (cob_sys_getpid (), sig);
 #endif
-
+#endif
+	
 #if 0 /* we don't necessarily want the OS to handle this,
          so exit in all other cases*/
 	exit (sig);
 #endif
-#endif /* HAVE_SIGNAL_H */
 }
 
 
@@ -1538,8 +1546,8 @@ cob_set_signal (void)
 {
 #if	defined (HAVE_SIGNAL_H)
 	int k;
-	char *s;
-	char signal_regime;
+	const char *s = getenv ("COB_SIGNAL_REGIME");
+	const char signal_regime = s ? *s : '0';
 #ifdef	HAVE_SIGACTION
 	struct sigaction	sa;
 	struct sigaction	osa;
@@ -1547,8 +1555,6 @@ cob_set_signal (void)
 	void (*ohdlr) (int);
 #endif
 
-	s = getenv ("COB_SIGNAL_REGIME");
-	signal_regime = s ? *s : '0';
 	if (signal_regime == '2') {
 		/* Don't set any signal */
 		return;

--- a/libcob/common.c
+++ b/libcob/common.c
@@ -1210,7 +1210,7 @@ cob_sig_handler (int sig)
 #ifdef	HAVE_RAISE
 		raise (sig);
 #else
-#ifdef HAVE_KILL
+#ifdef HAVE_SIGNAL_H
 		kill (getpid (), sig);
 #endif
 #endif
@@ -1293,7 +1293,7 @@ cob_sig_handler (int sig)
 	(void)sigaction (sig, &sa, NULL);
 #endif
 #else
-#ifdef HAVE_SIGNAL
+#ifdef HAVE_SIGNAL_H
 	(void)signal (sig, SIG_DFL);
 #endif
 #endif
@@ -1381,13 +1381,13 @@ exit_handler:
 		sig = SIGABRT;
 	}
 #endif
-#ifdef HAVE_SIGNAL
+#ifdef HAVE_SIGNAL_H
 	signal (sig, SIG_DFL);
 #endif
 #ifdef	HAVE_RAISE
 	raise (sig);
 #else
-#ifdef HAVE_KILL
+#ifdef HAVE_SIGNAL_H
 	kill (cob_sys_getpid (), sig);
 #endif
 #endif

--- a/libcob/common.h
+++ b/libcob/common.h
@@ -1671,9 +1671,8 @@ struct cobjmp_buf {
 
 /*******************************/
 /* Functions in common.c */
-#ifdef HAVE_SIGNAL_H
+
 COB_EXPIMP void		cob_sig_handler (int);
-#endif
 COB_EXPIMP const char*	cob_get_sig_name (int);
 COB_EXPIMP const char*	cob_get_sig_description (int);
 COB_EXPIMP void		print_info	(void);

--- a/libcob/common.h
+++ b/libcob/common.h
@@ -1671,6 +1671,9 @@ struct cobjmp_buf {
 
 /*******************************/
 /* Functions in common.c */
+#ifdef HAVE_SIGNAL_H
+COB_EXPIMP void		cob_sig_handler (int);
+#endif
 COB_EXPIMP const char*	cob_get_sig_name (int);
 COB_EXPIMP const char*	cob_get_sig_description (int);
 COB_EXPIMP void		print_info	(void);

--- a/tests/ChangeLog
+++ b/tests/ChangeLog
@@ -1,4 +1,9 @@
 
+2025-11-19  Oğuzcan Kırmemiş <oguzcan.kirmemis@gmail.com>
+
+	* testsuite.src/run_misc.at: add tests for COB_SIGNAL_REGIME configuration
+	* atlocal.in, atlocal_win: pass HAVE_SIGNAL_H to the tests
+
 2025-11-17  Simon Sobisch <simonsobisch@gnu.org>
 
 	* atlocal.in, atlocal_win: adjusted return_path function and its use

--- a/tests/atlocal.in
+++ b/tests/atlocal.in
@@ -344,6 +344,8 @@ if test "$GNUCOBOL_TEST_LOCAL" != "1"; then
 	done
 fi
 
+HAVE_SIGNAL_H="@HAVE_SIGNAL_H@"
+
 COB_STACKTRACE=0
 export COB_STACKTRACE
 

--- a/tests/atlocal_win
+++ b/tests/atlocal_win
@@ -29,6 +29,7 @@ TEMPLATE="${abs_top_srcdir}/tests/testsuite.src"
 COB_SRC_PATH="${abs_top_srcdir}"
 
 [ -z "${COB_WIN_BUILDPATH}" ] && COB_WIN_BUILDPATH="$COB_SRC_PATH/build_windows/x64/Debug"
+WINDOWS_COMPILATION_TARGET="$(printf %s ${COB_WIN_BUILDPATH} | rev | cut -d '/' -f 1 | rev)"
 
 COBC="cobc.exe"
 COBCRUN="cobcrun.exe"

--- a/tests/atlocal_win
+++ b/tests/atlocal_win
@@ -192,6 +192,8 @@ if test "$GNUCOBOL_TEST_LOCAL" != "1"; then
 	done
 fi
 
+HAVE_SIGNAL_H="@HAVE_SIGNAL_H@"
+
 COB_STACKTRACE=0
 export COB_STACKTRACE
 

--- a/tests/atlocal_win
+++ b/tests/atlocal_win
@@ -192,7 +192,7 @@ if test "$GNUCOBOL_TEST_LOCAL" != "1"; then
 	done
 fi
 
-HAVE_SIGNAL_H="@HAVE_SIGNAL_H@"
+HAVE_SIGNAL_H="yes"
 
 COB_STACKTRACE=0
 export COB_STACKTRACE

--- a/tests/testsuite.src/run_misc.at
+++ b/tests/testsuite.src/run_misc.at
@@ -15792,7 +15792,7 @@ main (int argc, char **argv)
 ]])
 
 AT_CHECK([$COMPILE caller.c], [0], [], [])
-AT_CHECK([$COMPILE_MODULE callee.cob], [0], [], [])
+AT_CHECK([$COMPILE_MODULE callee.cob -fno-ec=all], [0], [], [])
 AT_CHECK([COB_SIGNAL_REGIME=0 $COBCRUN_DIRECT ./caller], [0], [],
 [
 callee.cob:8: attempt to reference invalid memory address (signal SIGSEGV)
@@ -15880,7 +15880,7 @@ main (int argc, char **argv)
 ]])
 
 AT_CHECK([$COMPILE caller.c], [0], [], [])
-AT_CHECK([$COMPILE_MODULE callee.cob], [0], [], [])
+AT_CHECK([$COMPILE_MODULE callee.cob -fno-ec=all], [0], [], [])
 AT_CHECK([COB_SIGNAL_REGIME=1 $COBCRUN_DIRECT ./caller], [0], [],
 [
 callee.cob:8: attempt to reference invalid memory address (signal SIGSEGV)

--- a/tests/testsuite.src/run_misc.at
+++ b/tests/testsuite.src/run_misc.at
@@ -15740,7 +15740,7 @@ AT_CLEANUP
 
 
 AT_SETUP([COB_SIGNAL_REGIME={0,1} registers runtime signal handler])
-AT_KEYWORDS([runmisc COB_SIGNAL_REGIME])
+AT_KEYWORDS([runmisc cob_call_with_exception_check COB_SIGNAL_REGIME])
 
 AT_SKIP_IF([test "$HAVE_SIGNAL_H" != "yes"])
 
@@ -15793,7 +15793,7 @@ main (int argc, char **argv)
 
 AT_CHECK([$COMPILE caller.c], [0], [], [])
 AT_CHECK([$COMPILE_MODULE callee.cob], [0], [], [])
-AT_CHECK([COB_SIGNAL_REGIME=0 ./caller], [0], [],
+AT_CHECK([COB_SIGNAL_REGIME=0 $COBCRUN_DIRECT ./caller], [0], [],
 [
 callee.cob:8: attempt to reference invalid memory address (signal SIGSEGV)
 
@@ -15808,7 +15808,7 @@ AT_CLEANUP
 
 
 AT_SETUP([COB_SIGNAL_REGIME={1,2} does not register runtime signal handler])
-AT_KEYWORDS([runmisc COB_SIGNAL_REGIME])
+AT_KEYWORDS([runmisc cob_call_with_exception_check COB_SIGNAL_REGIME])
 
 AT_SKIP_IF([test "$HAVE_SIGNAL_H" != "yes"])
 
@@ -15838,7 +15838,7 @@ int signal_received = 0;
 void sig_handler(int signum)
 {
     if (signum != SIGSEGV) {
-        exit (1);
+        exit (3);
     }
     signal_received = 1;
     cob_sig_handler (signum);
@@ -15875,13 +15875,13 @@ main (int argc, char **argv)
         return 0;
     }
 
-    return 1;
+    return 2;
 }
 ]])
 
 AT_CHECK([$COMPILE caller.c], [0], [], [])
 AT_CHECK([$COMPILE_MODULE callee.cob], [0], [], [])
-AT_CHECK([COB_SIGNAL_REGIME=1 ./caller], [0], [],
+AT_CHECK([COB_SIGNAL_REGIME=1 $COBCRUN_DIRECT ./caller], [0], [],
 [
 callee.cob:8: attempt to reference invalid memory address (signal SIGSEGV)
 

--- a/tests/testsuite.src/run_misc.at
+++ b/tests/testsuite.src/run_misc.at
@@ -15743,6 +15743,11 @@ AT_SETUP([COB_SIGNAL_REGIME={0,1} registers runtime signal handler])
 AT_KEYWORDS([runmisc cob_call_with_exception_check COB_SIGNAL_REGIME])
 
 AT_SKIP_IF([test "$HAVE_SIGNAL_H" != "yes"])
+# In some environments (e.g. MSVC), Windows does not forward signals for
+# critical errors like segmentation faults to user-defined signal handler
+# when the target program/library is compiled under the debug target, which
+# breaks COB_SIGNAL_REGIME tests.
+AT_SKIP_IF([test "$WINDOWS_COMPILATION_TARGET" == "Debug"])
 
 AT_DATA([callee.cob], [
        IDENTIFICATION DIVISION.
@@ -15756,7 +15761,6 @@ AT_DATA([callee.cob], [
 ])
 
 AT_DATA([caller.c], [[
-#include <stdio.h>
 #include <libcob.h>
 
 int
@@ -15770,22 +15774,14 @@ main (int argc, char **argv)
     cob_argv[0] = NULL;
 
     /* initialize the COBOL run-time library */
-    printf ("log0\n");
-    fflush(stdout);
     cob_init (0, NULL);
 
     /* call COBOL program */
-    printf ("log1\n");
-    fflush(stdout);
     cob_ret = cob_call_with_exception_check ("callee", 1, cob_argv);
 
     /* Clean up and terminate runtime */
-    printf ("log2\n");
-    fflush(stdout);
     cob_tidy ();
 
-    printf ("log3\n");
-    fflush(stdout);
     /* Check exit by signal handler */
     if (cob_ret != -3) {
         return 1;
@@ -15815,6 +15811,7 @@ AT_SETUP([COB_SIGNAL_REGIME={1,2} does not register runtime signal handler])
 AT_KEYWORDS([runmisc cob_call_with_exception_check COB_SIGNAL_REGIME])
 
 AT_SKIP_IF([test "$HAVE_SIGNAL_H" != "yes"])
+AT_SKIP_IF([test "$WINDOWS_COMPILATION_TARGET" == "Debug"])
 
 AT_DATA([callee.cob], [
        IDENTIFICATION DIVISION.

--- a/tests/testsuite.src/run_misc.at
+++ b/tests/testsuite.src/run_misc.at
@@ -15759,10 +15759,6 @@ AT_DATA([caller.c], [[
 #include <stdio.h>
 #include <libcob.h>
 
-#ifndef NULL
-#define NULL (void*)0
-#endif
-
 int
 main (int argc, char **argv)
 {
@@ -15774,14 +15770,22 @@ main (int argc, char **argv)
     cob_argv[0] = NULL;
 
     /* initialize the COBOL run-time library */
+    printf ("log0\n");
+    fflush(stdout);
     cob_init (0, NULL);
 
     /* call COBOL program */
+    printf ("log1\n");
+    fflush(stdout);
     cob_ret = cob_call_with_exception_check ("callee", 1, cob_argv);
 
     /* Clean up and terminate runtime */
+    printf ("log2\n");
+    fflush(stdout);
     cob_tidy ();
 
+    printf ("log3\n");
+    fflush(stdout);
     /* Check exit by signal handler */
     if (cob_ret != -3) {
         return 1;
@@ -15825,13 +15829,8 @@ AT_DATA([callee.cob], [
 
 AT_DATA([caller.c], [[
 #include <stdlib.h>
-#include <stdio.h>
 #include <signal.h>
 #include <libcob.h>
-
-#ifndef NULL
-#define NULL (void*)0
-#endif
 
 int signal_received = 0;
 

--- a/tests/testsuite.src/run_misc.at
+++ b/tests/testsuite.src/run_misc.at
@@ -15737,3 +15737,159 @@ AT_CHECK([$COBCRUN_DIRECT ./prog], [0],
 ], [])
 
 AT_CLEANUP
+
+
+AT_SETUP([COB_SIGNAL_REGIME={0,1} registers runtime signal handler])
+AT_KEYWORDS([runmisc COB_SIGNAL_REGIME])
+
+AT_SKIP_IF([test "$HAVE_SIGNAL_H" != "yes"])
+
+AT_DATA([callee.cob], [
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. callee.
+       DATA DIVISION.
+       LINKAGE SECTION.
+       01 VAR1 PIC X(4) VALUE "TEST".
+       PROCEDURE DIVISION USING VAR1.
+           DISPLAY VAR1.
+           STOP RUN RETURNING 0.
+])
+
+AT_DATA([caller.c], [[
+#include <stdio.h>
+#include <libcob.h>
+
+#ifndef NULL
+#define NULL (void*)0
+#endif
+
+int
+main (int argc, char **argv)
+{
+    /* for storing libcob return state */
+    int cob_ret;
+
+    /* for COBOL parameters */
+    void *cob_argv[1];
+    cob_argv[0] = NULL;
+
+    /* initialize the COBOL run-time library */
+    cob_init (0, NULL);
+
+    /* call COBOL program */
+    cob_ret = cob_call_with_exception_check ("callee", 1, cob_argv);
+
+    /* Clean up and terminate runtime */
+    cob_tidy ();
+
+    /* Check exit by signal handler */
+    if (cob_ret != -3) {
+        return 1;
+    }
+    
+    return 0;
+}
+]])
+
+AT_CHECK([$COMPILE caller.c], [0], [], [])
+AT_CHECK([$COMPILE_MODULE callee.cob], [0], [], [])
+AT_CHECK([COB_SIGNAL_REGIME=0 ./caller], [0], [],
+[
+callee.cob:8: attempt to reference invalid memory address (signal SIGSEGV)
+
+])
+AT_CHECK([COB_SIGNAL_REGIME=1 ./caller], [0], [],
+[
+callee.cob:8: attempt to reference invalid memory address (signal SIGSEGV)
+
+])
+
+AT_CLEANUP
+
+
+AT_SETUP([COB_SIGNAL_REGIME={1,2} does not register runtime signal handler])
+AT_KEYWORDS([runmisc COB_SIGNAL_REGIME])
+
+AT_SKIP_IF([test "$HAVE_SIGNAL_H" != "yes"])
+
+AT_DATA([callee.cob], [
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. callee.
+       DATA DIVISION.
+       LINKAGE SECTION.
+       01 VAR1 PIC X(4) VALUE "TEST".
+       PROCEDURE DIVISION USING VAR1.
+           DISPLAY VAR1.
+           STOP RUN RETURNING 0.
+])
+
+AT_DATA([caller.c], [[
+#include <stdlib.h>
+#include <stdio.h>
+#include <signal.h>
+#include <libcob.h>
+
+#ifndef NULL
+#define NULL (void*)0
+#endif
+
+int signal_received = 0;
+
+void sig_handler(int signum)
+{
+    if (signum != SIGSEGV) {
+        exit (1);
+    }
+    signal_received = 1;
+    cob_sig_handler (signum);
+}
+
+int
+main (int argc, char **argv)
+{
+    /* for storing libcob return state */
+    int cob_ret;
+
+    /* for COBOL parameters */
+    void *cob_argv[1];
+
+    /* register custom signal handler */
+    (void)signal (SIGSEGV, sig_handler);
+
+    /* initialize the COBOL run-time library */
+    cob_init (0, NULL);
+
+    /* call COBOL program */
+    cob_argv[0] = NULL;
+    cob_ret = cob_call_with_exception_check ("callee", 1, cob_argv);
+
+    /* Clean up and terminate runtime */
+    cob_tidy ();
+
+    /* Check exit by signal handler */
+    if (cob_ret != -3) {
+        return 1;
+    }
+    
+    if (signal_received == 1) {
+        return 0;
+    }
+
+    return 1;
+}
+]])
+
+AT_CHECK([$COMPILE caller.c], [0], [], [])
+AT_CHECK([$COMPILE_MODULE callee.cob], [0], [], [])
+AT_CHECK([COB_SIGNAL_REGIME=1 ./caller], [0], [],
+[
+callee.cob:8: attempt to reference invalid memory address (signal SIGSEGV)
+
+])
+AT_CHECK([COB_SIGNAL_REGIME=2 ./caller], [0], [],
+[
+callee.cob:8: attempt to reference invalid memory address (signal SIGSEGV)
+
+])
+
+AT_CLEANUP


### PR DESCRIPTION
This PR adds a config option `COB_SIGNAL_REGIME` which allows control over how the signal handler of the runtime is registered for a signal in `common.c.`/`cob_set_signal`.

# Motivation
Current implementation overwrites the signal handlers of the main program under which the runtime operates. In some environments, such as the Java Virtual Machine, this can create potential issues where signals intended for the main program are caught by the COBOL runtime, leading to corruption. For reference, Micro Focus compiler provides [a similar flag](https://www.microfocus.com/documentation/visual-cobol/vc100/DevHub/HRRTRHRTCF0J.html).

With this flag, the main program can either completely skip signal registration or skip it for specific signals it uses. Furthermore, this PR also exposes the signal handler of the runtime, allowing the main program to register it manually if desired or to combine it with its own signal handler. The latter mechanism is for instance provided by the `libjsig` [library of the Java Runtime](https://docs.oracle.com/javase/8/docs/technotes/guides/vm/signal-chaining.html).

# Implementation
- export `cob_sig_handler` function in `common.c`
- add `COB_SIGNAL_REGIME` as a configuration
- add documentation to `runtime.cfg` about `COB_SIGNAL_REGIME``
- pass HAVE_SIGNAL_H variable to tests so that the tests for COB_SIGNAL_REGIME only run when the OS provides signal handling