### PR TITLE
Print with overflow multiline

### DIFF
--- a/cobc/ChangeLog
+++ b/cobc/ChangeLog
@@ -1,3 +1,4 @@
+
 2025-10-17  Roger Bowler <rbowler@snipix.net>
 
 	* cob.c (print_with_overflow): Print multiple continuation lines on listing

--- a/cobc/ChangeLog
+++ b/cobc/ChangeLog
@@ -1,3 +1,6 @@
+2025-10-17  Roger Bowler <rbowler@snipix.net>
+
+	* cob.c (print_with_overflow): Print multiple continuation lines on listing
 
 2025-07-30  Simon Sobisch <simonsobisch@gnu.org>
 

--- a/cobc/cobc.c
+++ b/cobc/cobc.c
@@ -7000,31 +7000,81 @@ static void
 print_with_overflow (const char *prefix, char *content)
 {
 	const unsigned int	max_chars_on_line = cb_listing_wide ? 120 : 80;
-	int offset;
+	size_t			prefix_len_raw;
+	size_t			prefix_len;
+	const char		*remaining;
+	unsigned int		allowed;
+	size_t			rlen;
+	size_t			breakpos;
 
-	offset = snprintf (print_data, max_chars_on_line, "%s%s", prefix, content);
-	if (offset >= 0) {	/* snprintf returns -1 in MS and on HPUX if max is reached */
-		pd_off = offset;
-	} else {
-		pd_off = max_chars_on_line;
-		print_data[max_chars_on_line - 1] = 0;
-	}
-	if (pd_off >= max_chars_on_line) {
-		size_t prefix_offset;
-		/* trim "current line" on last space */
-		pd_off = strlen (print_data) - 1;
-		while (pd_off && !isspace ((unsigned char)print_data[pd_off])) {
-			pd_off--;
-		}
-		print_data[pd_off] = '\0';
+	/* determine visual width for prefix and continuation alignment */
+	prefix_len_raw = strlen (prefix);
+	prefix_len = (prefix_len_raw < 2) ? 2 : prefix_len_raw;
+	remaining = content;
+
+	/* First line: print with original prefix */
+	allowed = (unsigned int)(max_chars_on_line - prefix_len);
+	rlen = strlen (remaining);
+	if (rlen <= allowed) {
+		(void)snprintf (print_data, max_chars_on_line, "%s%s", prefix, remaining);
+		pd_off = (int)strlen (print_data);
 		print_program_data (print_data);
-		prefix_offset = strlen (prefix);
-		pd_off = strlen (print_data) - prefix_offset;
-		if (prefix_offset < 2) prefix_offset = 2;
-		memset (print_data, ' ', prefix_offset - 1);
-		snprintf (print_data + prefix_offset - 2, max_chars_on_line, "%c%s", '+', content + pd_off);
+		return;
+	}
+	/* break at last space strictly within the allowed window */
+	breakpos = (allowed > 0) ? (allowed - 1) : 0;
+	while (breakpos > 0 && !isspace ((unsigned char)remaining[breakpos])) {
+		breakpos--;
+	}
+	if (breakpos == 0) {
+		/* no space found in window (or only at index 0), force break at allowed */
+		breakpos = allowed;
+	}
+	(void)snprintf (print_data, max_chars_on_line, "%s%.*s", prefix, (int)breakpos, remaining);
+	pd_off = (int)strlen (print_data);
+	while (pd_off > 0 && isspace ((unsigned char)print_data[pd_off - 1])) {
+		print_data[--pd_off] = '\0';
 	}
 	print_program_data (print_data);
+	/* advance to continuation without collapsing leading spaces */
+	remaining += breakpos;
+
+	/* Continuation lines: prefix is spaces with leading '+' aligned under content */
+	for (;;) {
+		char *out;
+		unsigned int content_cap;
+		/* build continuation prefix */
+		memset (print_data, ' ', prefix_len - 1);
+		out = print_data + prefix_len - 2;
+		allowed = (unsigned int)(max_chars_on_line - (prefix_len - 1));
+		/* capacity for content excludes the '+' itself */
+		content_cap = (allowed > 0) ? (allowed - 1) : 0;
+
+		rlen = strlen (remaining);
+		if (rlen <= content_cap) {
+			(void)snprintf (out, max_chars_on_line, "%c%s", '+', remaining);
+			pd_off = (int)strlen (print_data);
+			print_program_data (print_data);
+			break;
+		}
+
+		breakpos = (content_cap > 0) ? (content_cap - 1) : 0;
+		while (breakpos > 0 && !isspace ((unsigned char)remaining[breakpos])) {
+			breakpos--;
+		}
+		if (breakpos == 0) {
+			/* no space found in window (or only at index 0), force break at capacity */
+			breakpos = content_cap;
+		}
+		(void)snprintf (out, max_chars_on_line, "%c%.*s", '+', (int)breakpos, remaining);
+		pd_off = (int)strlen (print_data);
+		while (pd_off > 0 && isspace ((unsigned char)print_data[pd_off - 1])) {
+			print_data[--pd_off] = '\0';
+		}
+		print_program_data (print_data);
+		/* advance to next continuation without collapsing leading spaces */
+		remaining += breakpos;
+	}
 }
 
 static void

--- a/cobc/cobc.c
+++ b/cobc/cobc.c
@@ -6999,19 +6999,14 @@ print_free_line (const int line_num, char pch, char *line)
 static void
 print_with_overflow (const char *prefix, char *content)
 {
-	const unsigned int	max_chars_on_line = cb_listing_wide ? 120 : 80;
-	size_t			prefix_len_raw;
-	size_t			prefix_len;
+	const size_t		max_chars_on_line = cb_listing_wide ? 120 : 80;
+	const size_t		prefix_len_raw = strlen (prefix);
+	const size_t		prefix_len = (prefix_len_raw < 2) ? 2 : prefix_len_raw;
+	const size_t		allowed = max_chars_on_line - prefix_len;
+	char			*out = print_data + prefix_len - 2;
 	const char		*remaining;
-	unsigned int		allowed;
-	size_t			rlen;
+	size_t			rlen = strlen (content);
 	size_t			breakpos;
-
-	/* determine visual width for prefix and continuation alignment */
-	prefix_len_raw = strlen (prefix);
-	prefix_len = (prefix_len_raw < 2) ? 2 : prefix_len_raw;
-	allowed = (unsigned int)(max_chars_on_line - prefix_len);
-	rlen = strlen (content);
 
 	/* print entire content if it fits within the allowed window */
 	if (rlen <= allowed) {
@@ -7022,8 +7017,8 @@ print_with_overflow (const char *prefix, char *content)
 	}
 
 	/* break at last space strictly within the allowed window */
-	breakpos = (allowed > 0) ? (allowed - 1) : 0;
-	while (breakpos > 0 && !isspace ((unsigned char)content[breakpos])) {
+	breakpos = (allowed > 1) ? (allowed - 1) : 0;
+	while (breakpos && !isspace ((unsigned char)content[breakpos])) {
 		breakpos--;
 	}
 	if (breakpos == 0) {
@@ -7042,27 +7037,24 @@ print_with_overflow (const char *prefix, char *content)
 	rlen -= breakpos;
 
 	/* Continuation lines: prefix is spaces with leading '+' aligned under content */
-	allowed = (unsigned int)(max_chars_on_line - (prefix_len - 1));
-	char *out = print_data + prefix_len - 2;
-	unsigned int content_cap = (allowed > 0) ? (allowed - 1) : 0;
 	for (;;) {
 		/* build continuation prefix */
 		memset (print_data, ' ', prefix_len - 1);
 		/* print entire remaining content if it fits within the allowed window */
-		if (rlen <= content_cap) {
+		if (rlen <= allowed) {
 			(void)snprintf (out, max_chars_on_line, "%c%s", '+', remaining);
 			pd_off = (int)strlen (print_data);
 			print_program_data (print_data);
 			break;
 		}
 		/* look for last space strictly within the allowed window */
-		breakpos = content_cap;
-		while (breakpos > 0 && !isspace ((unsigned char)remaining[breakpos])) {
+		breakpos = allowed;
+		while (breakpos && !isspace ((unsigned char)remaining[breakpos])) {
 			breakpos--;
 		}
 		if (breakpos == 0) {
 			/* no space found in window (or only at index 0), force break at capacity */
-			breakpos = content_cap;
+			breakpos = allowed;
 		}
 		/* print continuation line with prefix */
 		(void)snprintf (out, max_chars_on_line, "%c%.*s", '+', (int)breakpos, remaining);

--- a/cobc/cobc.c
+++ b/cobc/cobc.c
@@ -7056,7 +7056,7 @@ print_with_overflow (const char *prefix, char *content)
 			break;
 		}
 		/* look for last space strictly within the allowed window */
-		breakpos = (content_cap > 0) ? (content_cap - 1) : 0;
+		breakpos = content_cap;
 		while (breakpos > 0 && !isspace ((unsigned char)remaining[breakpos])) {
 			breakpos--;
 		}

--- a/cobc/cobc.c
+++ b/cobc/cobc.c
@@ -7010,54 +7010,52 @@ print_with_overflow (const char *prefix, char *content)
 	/* determine visual width for prefix and continuation alignment */
 	prefix_len_raw = strlen (prefix);
 	prefix_len = (prefix_len_raw < 2) ? 2 : prefix_len_raw;
-	remaining = content;
-
-	/* First line: print with original prefix */
 	allowed = (unsigned int)(max_chars_on_line - prefix_len);
-	rlen = strlen (remaining);
+	rlen = strlen (content);
+
+	/* print entire content if it fits within the allowed window */
 	if (rlen <= allowed) {
-		(void)snprintf (print_data, max_chars_on_line, "%s%s", prefix, remaining);
+		(void)snprintf (print_data, max_chars_on_line, "%s%s", prefix, content);
 		pd_off = (int)strlen (print_data);
 		print_program_data (print_data);
 		return;
 	}
+
 	/* break at last space strictly within the allowed window */
 	breakpos = (allowed > 0) ? (allowed - 1) : 0;
-	while (breakpos > 0 && !isspace ((unsigned char)remaining[breakpos])) {
+	while (breakpos > 0 && !isspace ((unsigned char)content[breakpos])) {
 		breakpos--;
 	}
 	if (breakpos == 0) {
 		/* no space found in window (or only at index 0), force break at allowed */
 		breakpos = allowed;
 	}
-	(void)snprintf (print_data, max_chars_on_line, "%s%.*s", prefix, (int)breakpos, remaining);
+	/* print first line of content with original prefix */
+	(void)snprintf (print_data, max_chars_on_line, "%s%.*s", prefix, (int)breakpos, content);
 	pd_off = (int)strlen (print_data);
 	while (pd_off > 0 && isspace ((unsigned char)print_data[pd_off - 1])) {
 		print_data[--pd_off] = '\0';
 	}
 	print_program_data (print_data);
 	/* advance to continuation without collapsing leading spaces */
-	remaining += breakpos;
+	remaining = content + breakpos;
+	rlen -= breakpos;
 
 	/* Continuation lines: prefix is spaces with leading '+' aligned under content */
+	allowed = (unsigned int)(max_chars_on_line - (prefix_len - 1));
+	char *out = print_data + prefix_len - 2;
+	unsigned int content_cap = (allowed > 0) ? (allowed - 1) : 0;
 	for (;;) {
-		char *out;
-		unsigned int content_cap;
 		/* build continuation prefix */
 		memset (print_data, ' ', prefix_len - 1);
-		out = print_data + prefix_len - 2;
-		allowed = (unsigned int)(max_chars_on_line - (prefix_len - 1));
-		/* capacity for content excludes the '+' itself */
-		content_cap = (allowed > 0) ? (allowed - 1) : 0;
-
-		rlen = strlen (remaining);
+		/* print entire remaining content if it fits within the allowed window */
 		if (rlen <= content_cap) {
 			(void)snprintf (out, max_chars_on_line, "%c%s", '+', remaining);
 			pd_off = (int)strlen (print_data);
 			print_program_data (print_data);
 			break;
 		}
-
+		/* look for last space strictly within the allowed window */
 		breakpos = (content_cap > 0) ? (content_cap - 1) : 0;
 		while (breakpos > 0 && !isspace ((unsigned char)remaining[breakpos])) {
 			breakpos--;
@@ -7066,6 +7064,7 @@ print_with_overflow (const char *prefix, char *content)
 			/* no space found in window (or only at index 0), force break at capacity */
 			breakpos = content_cap;
 		}
+		/* print continuation line with prefix */
 		(void)snprintf (out, max_chars_on_line, "%c%.*s", '+', (int)breakpos, remaining);
 		pd_off = (int)strlen (print_data);
 		while (pd_off > 0 && isspace ((unsigned char)print_data[pd_off - 1])) {
@@ -7074,6 +7073,7 @@ print_with_overflow (const char *prefix, char *content)
 		print_program_data (print_data);
 		/* advance to next continuation without collapsing leading spaces */
 		remaining += breakpos;
+		rlen -= breakpos;
 	}
 }
 

--- a/tests/testsuite.src/listings.at
+++ b/tests/testsuite.src/listings.at
@@ -1639,8 +1639,8 @@ error: syntax error, unexpected Identifier, expecting DYNAMIC or RANDOM or
 000013             DEPENDING ON
 000014             a-numeric-field-with-a-long-name-defined-in-the-file-section.
 error: RECORD DEPENDING item
-     + 'a-numeric-field-with-a-long-name-defined-in-the-file-section' should
-     + be defined in WORKING-STORAGE, LOCAL-STORAGE or LINKAGE SECTION
+     + 'a-numeric-field-with-a-long-name-defined-in-the-file-section' should be
+     + defined in WORKING-STORAGE, LOCAL-STORAGE or LINKAGE SECTION
 000015         01  TESTFILE-RECORD.
 000016             02
 000017             a-numeric-field-with-a-long-name-defined-in-the-file-section
@@ -2181,7 +2181,9 @@ command line:
 + -fno-tmessages -fsyntax-only -t- -fno-tsymbols -ftcmd prog.cob
 ])
 
-AT_CHECK([$COBC $LISTING_FLAGS -q -std=default -Wall -fno-tmessages -fsyntax-only -t- -fno-tsymbols -ftcmd -fdiagnostics-show-option -fdiagnostics-show-line-numbers -fdiagnostics-absolute-paths -fno-remove-unreachable prog.cob], [0],
+AT_CHECK([$COBC $LISTING_FLAGS -q -std=default -Wall -fno-tmessages -fsyntax-only \
+-fno-tsymbols -fdiagnostics-show-option -t abcde -ftcmd -fdiagnostics-show-line-numbers \
+-fdiagnostics-absolute-paths -t- -fno-remove-unreachable prog.cob], [0],
 [GnuCOBOL V.R.P          prog.cob                                        Page 0001
 
 LINE    PG/LN  A...B............................................................
@@ -2201,9 +2203,9 @@ LINE    PG/LN  A...B............................................................
 
 command line:
   cobc -fttitle=GnuCOBOL_V.R.P -fno-ttimestamp -q -std=default -Wall
-+ -fno-tmessages -fsyntax-only -t- -fno-tsymbols -ftcmd
-+ -fdiagnostics-show-option -fdiagnostics-show-line-numbers
-+ -fdiagnostics-absolute-paths -fno-remove-unreachable prog.cob
++ -fno-tmessages -fsyntax-only -fno-tsymbols -fdiagnostics-show-option -t abcde
++ -ftcmd -fdiagnostics-show-line-numbers -fdiagnostics-absolute-paths -t-
++ -fno-remove-unreachable prog.cob
 ])
 
 AT_CLEANUP

--- a/tests/testsuite.src/listings.at
+++ b/tests/testsuite.src/listings.at
@@ -2098,6 +2098,31 @@ command line:
 + -fno-tmessages -fsyntax-only -t- -fno-tsymbols -ftcmd prog.cob
 ])
 
+AT_CHECK([$COBC $LISTING_FLAGS -q -std=default -Wall -fno-tmessages -fsyntax-only -t- -fno-tsymbols -ftcmd -fdiagnostics-show-option -fdiagnostics-show-line-numbers -fdiagnostics-absolute-paths -fno-remove-unreachable prog.cob], [0],
+[GnuCOBOL V.R.P          prog.cob                                        Page 0001
+
+LINE    PG/LN  A...B............................................................
+
+000001
+000002         IDENTIFICATION   DIVISION.
+000003         FUNCTION-ID.     WITHPAR.
+000004         DATA             DIVISION.
+000005         LINKAGE          SECTION.
+000006         01 PAR-IN        PIC 9.
+000007         01 PAR-OUT       PIC 9.
+000008         PROCEDURE DIVISION USING PAR-IN RETURNING PAR-OUT.
+000009             ADD 1 TO PAR-IN GIVING PAR-OUT END-ADD.
+000010             GOBACK.
+000011         END FUNCTION WITHPAR.
+GnuCOBOL V.R.P          prog.cob                                        Page 0002
+
+command line:
+  cobc -fttitle=GnuCOBOL_V.R.P -fno-ttimestamp -q -std=default -Wall
++ -fno-tmessages -fsyntax-only -t- -fno-tsymbols -ftcmd
++ -fdiagnostics-show-option -fdiagnostics-show-line-numbers
++ -fdiagnostics-absolute-paths -fno-remove-unreachable prog.cob
+])
+
 AT_CLEANUP
 
 

--- a/tests/testsuite.src/listings.at
+++ b/tests/testsuite.src/listings.at
@@ -2121,7 +2121,7 @@ AT_CLEANUP
 
 
 AT_SETUP([command line])
-AT_KEYWORDS([listing])
+AT_KEYWORDS([listing multiline])
 
 AT_CAPTURE_FILE([prog.lst])
 AT_DATA([prog.cob], [
@@ -3355,7 +3355,7 @@ AT_CLEANUP
 
 
 AT_SETUP([Invalid PICTURE strings])
-AT_KEYWORDS([listing])
+AT_KEYWORDS([listing multiline])
 
 AT_CAPTURE_FILE([prog.lst])
 

--- a/tests/testsuite.src/listings.at
+++ b/tests/testsuite.src/listings.at
@@ -1589,6 +1589,89 @@ Too many errors in compilation group: 0 maximum errors
 AT_CLEANUP
 
 
+AT_SETUP([Multiline messages])
+AT_KEYWORDS([listing error warning warnings multiline])
+
+AT_DATA([prog.cob], [       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      prog.
+       ENVIRONMENT      DIVISION.
+       INPUT-OUTPUT     SECTION.
+       FILE-CONTROL.
+           SELECT TESTFILE
+           ASSIGN TO a-very-long-name-which-has-not-been-defined-at-all
+           ACCESS IS an-invalid-name.
+       DATA             DIVISION.
+       FILE             SECTION.
+       FD  TESTFILE
+           RECORD IS VARYING IN SIZE FROM 20 TO 50 CHARACTERS
+           DEPENDING ON
+           a-numeric-field-with-a-long-name-defined-in-the-file-section.
+       01  TESTFILE-RECORD.
+           02
+           a-numeric-field-with-a-long-name-defined-in-the-file-section
+           PIC 9(4) COMP.
+           02 FILLER PIC X(48).
+       WORKING-STORAGE  SECTION.
+       01  BAD-PIC PIC +.
+       PROCEDURE        DIVISION.
+           STOP RUN.
+])
+
+AT_CHECK([$COMPILE_LISTING -Wimplicit-define -t- prog.cob], [1],
+[GnuCOBOL V.R.P          prog.cob                                        Page 0001
+
+LINE    PG/LN  A...B............................................................
+
+000001         IDENTIFICATION   DIVISION.
+000002         PROGRAM-ID.      prog.
+000003         ENVIRONMENT      DIVISION.
+000004         INPUT-OUTPUT     SECTION.
+000005         FILE-CONTROL.
+000006             SELECT TESTFILE
+000007             ASSIGN TO a-very-long-name-which-has-not-been-defined-at-all
+000008             ACCESS IS an-invalid-name.
+error: syntax error, unexpected Identifier, expecting DYNAMIC or RANDOM or
+     + SEQUENTIAL
+000009         DATA             DIVISION.
+000010         FILE             SECTION.
+000011         FD  TESTFILE
+000012             RECORD IS VARYING IN SIZE FROM 20 TO 50 CHARACTERS
+000013             DEPENDING ON
+000014             a-numeric-field-with-a-long-name-defined-in-the-file-section.
+error: RECORD DEPENDING item
+     + 'a-numeric-field-with-a-long-name-defined-in-the-file-section' should
+     + be defined in WORKING-STORAGE, LOCAL-STORAGE or LINKAGE SECTION
+000015         01  TESTFILE-RECORD.
+000016             02
+000017             a-numeric-field-with-a-long-name-defined-in-the-file-section
+000018             PIC 9(4) COMP.
+000019             02 FILLER PIC X(48).
+000020         WORKING-STORAGE  SECTION.
+000021         01  BAD-PIC PIC +.
+error: PICTURE string must contain at least one of the set A, N, U, X, Z, 1, 9
+     + and *; or at least two of the set +, - and the currency symbol
+000022         PROCEDURE        DIVISION.
+warning: variable 'a-very-long-name-which-has-not-been-defined-at-all' will be
+       + implicitly defined
+000023             STOP RUN.
+
+
+GnuCOBOL V.R.P          prog.cob                                        Page 0002
+
+Error/Warning summary:
+
+prog.cob:8: error: syntax error, unexpected Identifier, expecting DYNAMIC or RANDOM or SEQUENTIAL
+prog.cob:14: error: RECORD DEPENDING item 'a-numeric-field-with-a-long-name-defined-in-the-file-section' should be defined in WORKING-STORAGE, LOCAL-STORAGE or LINKAGE SECTION
+prog.cob:21: error: PICTURE string must contain at least one of the set A, N, U, X, Z, 1, 9 and *; or at least two of the set +, - and the currency symbol
+prog.cob:22: warning: variable 'a-very-long-name-which-has-not-been-defined-at-all' will be implicitly defined
+
+1 warning in compilation group
+3 errors in compilation group
+], [ignore])
+
+AT_CLEANUP
+
+
 AT_SETUP([Two source files])
 AT_KEYWORDS([listing])
 


### PR DESCRIPTION
## Print with Overflow Multiline

### Summary
This pull request introduces an enhancement to the **-ftcmd** functionality of cobc. The changes ensure that when the cobc command line exceeds the page width of the compiler listing, it is properly wrapped and split across as many continuation lines as are necessary.

### Changes Included
- Updated **print_with_overflow** routine to support multiline overflow.
- Added new testcase to verify correct handling of multiline overflow.
- Improved code comments related to multiline printing.

### Motivation
The previous implementation printed the cobc command line with a maximum of one continuation line. The rest of the command line was truncated, as in this example:  
```
command line:
  cobc -fttitle=GnuCOBOL_V.R.P -fno-ttimestamp -q -std=default -Wall
+ -fno-tmessages -fsyntax-only -t- -fno-tsymbols -ftcmd -fdiagnostics-show-opti
```

This update addresses that issue, producing output like this:  
```
command line:
  cobc -fttitle=GnuCOBOL_V.R.P -fno-ttimestamp -q -std=default -Wall
+ -fno-tmessages -fsyntax-only -t- -fno-tsymbols -ftcmd
+ -fdiagnostics-show-option -fdiagnostics-show-line-numbers
+ -fdiagnostics-absolute-paths -fno-remove-unreachable prog
```

### Impact
- Users will be able to see all of the compile options in the compiler listing.
- No breaking changes; existing print functionality remains compatible.


### Testing
- New testcase added to **tests/testsuite.src/listings.at** as part of the **[command line]** test.

---

Please review and provide feedback or suggestions.