### PR TITLE
comp-5-uses-binary-byteorder dialect configuration option

### DIFF
--- a/cobc/ChangeLog
+++ b/cobc/ChangeLog
@@ -1,4 +1,9 @@
 
+2025-10-21  Roger Bowler <rbowler@snipix.net>
+
+	* field.c (setup_parameters): set flag_binary_swap for COMP-5 fields
+	  when comp-5-uses-binary-byteorder dialect option is set
+
 2025-07-30  Simon Sobisch <simonsobisch@gnu.org>
 
 	* scanner.l, parser.y, reserved.c: use yyless to push part of scanned

--- a/cobc/config.def
+++ b/cobc/config.def
@@ -111,6 +111,9 @@ CB_CONFIG_BOOLEAN (cb_pretty_display, "pretty-display",
 CB_CONFIG_BOOLEAN (cb_binary_truncate, "binary-truncate",
 	_("numeric truncation according to ANSI"))
 
+CB_CONFIG_BOOLEAN (cb_comp_5_uses_binary_byteorder, "comp-5-uses-binary-byteorder",
+	_("COMP-5 uses the same byte order as BINARY"))
+
 CB_CONFIG_BOOLEAN (cb_complex_odo, "complex-odo",
 	_("allow non-standard OCCURS DEPENDING ON syntax"))
 

--- a/cobc/field.c
+++ b/cobc/field.c
@@ -2530,6 +2530,11 @@ setup_parameters (struct cb_field *f)
 			}
 		}
 #ifndef WORDS_BIGENDIAN
+		if (f->usage == CB_USAGE_COMP_5 &&
+			cb_comp_5_uses_binary_byteorder &&
+			cb_binary_byteorder == CB_BYTEORDER_BIG_ENDIAN) {
+			f->flag_binary_swap = 1;
+		}
 		if (f->usage == CB_USAGE_COMP_X &&
 			cb_binary_byteorder == CB_BYTEORDER_BIG_ENDIAN) {
 			f->flag_binary_swap = 1;

--- a/config/ChangeLog
+++ b/config/ChangeLog
@@ -1,4 +1,8 @@
 
+2025-10-21  Roger Bowler <rbowler@snipix.net>
+
+	* general: add option comp-5-uses-binary-byteorder
+
 2025-04-22  Chuck Haatvedt  <chuck.haatvedt+cobol@gmail.com>
 
 	* runtime.cfg: add runtime configuration COB_HEAP_MEMORY and

--- a/config/acu-strict.conf
+++ b/config/acu-strict.conf
@@ -97,6 +97,9 @@ binary-truncate:		yes
 # Value: 'native', 'big-endian'
 binary-byteorder:		big-endian
 
+# COMP-5 uses binary byte order instead of native byte order
+comp-5-uses-binary-byteorder:	no
+
 # Allow larger REDEFINES items other than 01 non-external
 larger-redefines:		ok	# not verified yet
 

--- a/config/bs2000-strict.conf
+++ b/config/bs2000-strict.conf
@@ -99,6 +99,9 @@ binary-truncate:		yes	# TO-DO: For BINARY, *not* for COMP or COMP-5!
 # Value: 'native', 'big-endian'
 binary-byteorder:		big-endian
 
+# COMP-5 uses binary byte order instead of native byte order
+comp-5-uses-binary-byteorder:	no
+
 # Allow larger REDEFINES items other than 01 non-external
 larger-redefines:		error
 

--- a/config/cobol2002.conf
+++ b/config/cobol2002.conf
@@ -98,6 +98,9 @@ binary-truncate:		yes
 # Value: 'native', 'big-endian'
 binary-byteorder:		big-endian
 
+# COMP-5 uses binary byte order instead of native byte order
+comp-5-uses-binary-byteorder:	no
+
 # Allow larger REDEFINES items other than 01 non-external
 larger-redefines:		error
 

--- a/config/cobol2014.conf
+++ b/config/cobol2014.conf
@@ -98,6 +98,9 @@ binary-truncate:		yes
 # Value: 'native', 'big-endian'
 binary-byteorder:		big-endian
 
+# COMP-5 uses binary byte order instead of native byte order
+comp-5-uses-binary-byteorder:	no
+
 # Allow larger REDEFINES items other than 01 non-external
 larger-redefines:		error
 

--- a/config/cobol85.conf
+++ b/config/cobol85.conf
@@ -98,6 +98,9 @@ binary-truncate:		yes
 # Value: 'native', 'big-endian'
 binary-byteorder:		big-endian
 
+# COMP-5 uses binary byte order instead of native byte order
+comp-5-uses-binary-byteorder:	no
+
 # Allow larger REDEFINES items other than 01 non-external
 larger-redefines:		error
 

--- a/config/default.conf
+++ b/config/default.conf
@@ -118,6 +118,9 @@ binary-truncate:		yes
 # Value: 'native', 'big-endian'
 binary-byteorder:		big-endian
 
+# COMP-5 uses binary byte order instead of native byte order
+comp-5-uses-binary-byteorder:	no
+
 # Allow larger REDEFINES items other than 01 non-external
 larger-redefines:		error
 

--- a/config/gcos-strict.conf
+++ b/config/gcos-strict.conf
@@ -97,6 +97,9 @@ binary-truncate:		yes
 # Value: 'native', 'big-endian'
 binary-byteorder:		big-endian
 
+# COMP-5 uses binary byte order instead of native byte order
+comp-5-uses-binary-byteorder:	no
+
 # Allow larger REDEFINES items
 larger-redefines:		error
 

--- a/config/ibm-strict.conf
+++ b/config/ibm-strict.conf
@@ -97,6 +97,9 @@ binary-truncate:		no
 # Value: 'native', 'big-endian'
 binary-byteorder:		big-endian
 
+# COMP-5 uses binary byte order instead of native byte order
+comp-5-uses-binary-byteorder:	no
+
 # Allow larger REDEFINES items other than 01 non-external
 larger-redefines:		error
 

--- a/config/mf-strict.conf
+++ b/config/mf-strict.conf
@@ -100,6 +100,9 @@ binary-truncate:		no
 # Value: 'native', 'big-endian'
 binary-byteorder:		big-endian
 
+# COMP-5 uses binary byte order instead of native byte order
+comp-5-uses-binary-byteorder:	no
+
 # Allow larger REDEFINES items other than 01 non-external
 larger-redefines:		ok
 

--- a/config/mvs-strict.conf
+++ b/config/mvs-strict.conf
@@ -97,6 +97,9 @@ binary-truncate:		no
 # Value: 'native', 'big-endian'
 binary-byteorder:		big-endian
 
+# COMP-5 uses binary byte order instead of native byte order
+comp-5-uses-binary-byteorder:	no
+
 # Allow larger REDEFINES items other than 01 non-external
 larger-redefines:		error
 

--- a/config/realia-strict.conf
+++ b/config/realia-strict.conf
@@ -97,6 +97,9 @@ binary-truncate:		no	# to check
 # Value: 'native', 'big-endian'
 binary-byteorder:		big-endian	# to check
 
+# COMP-5 uses binary byte order instead of native byte order
+comp-5-uses-binary-byteorder:	no
+
 # Allow larger REDEFINES items other than 01 non-external
 larger-redefines:		error	# not verified yet
 

--- a/config/rm-strict.conf
+++ b/config/rm-strict.conf
@@ -103,6 +103,9 @@ binary-truncate:		yes
 # Value: 'native', 'big-endian'
 binary-byteorder:		big-endian
 
+# COMP-5 uses binary byte order instead of native byte order
+comp-5-uses-binary-byteorder:	no
+
 # Allow larger REDEFINES items other than 01 non-external
 larger-redefines:		ok	# (see p. 134)
 

--- a/config/xopen.conf
+++ b/config/xopen.conf
@@ -111,6 +111,9 @@ binary-truncate:		yes
 # Value: 'native', 'big-endian'
 binary-byteorder:		big-endian
 
+# COMP-5 uses binary byte order instead of native byte order
+comp-5-uses-binary-byteorder:	no
+
 # Allow larger REDEFINES items other than 01 non-external
 larger-redefines:		error
 

--- a/tests/testsuite.src/configuration.at
+++ b/tests/testsuite.src/configuration.at
@@ -431,6 +431,7 @@ test.conf: missing definitions:
 	no definition of 'filename-mapping'
 	no definition of 'pretty-display'
 	no definition of 'binary-truncate'
+	no definition of 'comp-5-uses-binary-byteorder'
 	no definition of 'complex-odo'
 	no definition of 'odoslide'
 	no definition of 'init-justify'

--- a/tests/testsuite.src/data_binary.at
+++ b/tests/testsuite.src/data_binary.at
@@ -1406,6 +1406,96 @@ DISPLAY: 85 !=  BINARY : 217
 AT_CLEANUP
 
 
+# comp-5 byteorder
+
+AT_SETUP([COMP-5 byteorder])
+AT_KEYWORDS([binary comp-5 byteorder])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      prog.
+       DATA             DIVISION.
+       WORKING-STORAGE  SECTION.
+       01  X-P2   BINARY-SHORT UNSIGNED  VALUE 23456.
+       01  X-P3   BINARY-LONG UNSIGNED   VALUE 2345678901.
+       01  X-P4   BINARY-DOUBLE UNSIGNED VALUE 2345678901234567891.
+       01  X-P6   PIC 9(4) COMP-5        VALUE 23456.
+       01  X-P7   PIC 9(8) COMP-5        VALUE 2345678901.
+       01  X-P8   PIC 9(18) COMP-5       VALUE 2345678901234567891.
+       01  X-N2   BINARY-SHORT           VALUE -12345.
+       01  X-N3   BINARY-LONG            VALUE -1234567890.
+       01  X-N4   BINARY-DOUBLE          VALUE -1234567890123456789.
+       01  X-N6   PIC S9(4) COMP-5       VALUE -12345.
+       01  X-N7   PIC S9(8) COMP-5       VALUE -1234567890.
+       01  X-N8   PIC S9(18) COMP-5      VALUE -1234567890123456789.
+       PROCEDURE        DIVISION.
+           DISPLAY 'BINARY-SHORT UNSIGNED  ' FUNCTION HEX-OF(X-P2)
+           DISPLAY 'BINARY-LONG UNSIGNED   ' FUNCTION HEX-OF(X-P3)
+           DISPLAY 'BINARY-DOUBLE UNSIGNED ' FUNCTION HEX-OF(X-P4)
+           DISPLAY 'PIC 9(4) COMP-5        ' FUNCTION HEX-OF(X-P6)
+           DISPLAY 'PIC 9(8) COMP-5        ' FUNCTION HEX-OF(X-P7)
+           DISPLAY 'PIC 9(18) COMP-5       ' FUNCTION HEX-OF(X-P8)
+           DISPLAY 'BINARY-SHORT           ' FUNCTION HEX-OF(X-N2)
+           DISPLAY 'BINARY-LONG            ' FUNCTION HEX-OF(X-N3)
+           DISPLAY 'BINARY-DOUBLE          ' FUNCTION HEX-OF(X-N4)
+           DISPLAY 'PIC S9(4) COMP-5       ' FUNCTION HEX-OF(X-N6)
+           DISPLAY 'PIC S9(8) COMP-5       ' FUNCTION HEX-OF(X-N7)
+           DISPLAY 'PIC S9(18) COMP-5      ' FUNCTION HEX-OF(X-N8)
+           STOP RUN.
+])
+
+if test "x$COB_BIGENDIAN" = "xyes"; then
+AT_CHECK([true])
+else
+
+# COMP-5 BINARY-SHORT BINARY-LONG and BINARY-DOUBLE
+# are stored in native (little-endian) format,
+# even when binary-byteorder=big-endian is specified,
+# unless comp-5-uses-binary-byteorder is also specified
+AT_CHECK([$COMPILE -fbinary-size=2-4-8 \
+                   -fbinary-byteorder=big-endian \
+                   prog.cob -o prog3], [0], [], [])
+AT_CHECK([$COBCRUN_DIRECT ./prog3], [0],
+[BINARY-SHORT UNSIGNED  A05B
+BINARY-LONG UNSIGNED   3538D08B
+BINARY-DOUBLE UNSIGNED D30A376188868D20
+PIC 9(4) COMP-5        A05B
+PIC 9(8) COMP-5        3538D08B
+PIC 9(18) COMP-5       D30A376188868D20
+BINARY-SHORT           C7CF
+BINARY-LONG            2EFD69B6
+BINARY-DOUBLE          EB7E16820BEFDDEE
+PIC S9(4) COMP-5       C7CF
+PIC S9(8) COMP-5       2EFD69B6
+PIC S9(18) COMP-5      EB7E16820BEFDDEE
+])
+fi
+
+# COMP-5 BINARY-SHORT BINARY-LONG and BINARY-DOUBLE
+# are stored in big-endian format only when specifying both
+# binary-byteorder=big-endian and comp-5-uses-binary-byteorder
+AT_CHECK([$COMPILE -fbinary-size=2-4-8 \
+                   -fbinary-byteorder=big-endian \
+                   -fcomp-5-uses-binary-byteorder \
+                   prog.cob -o prog4], [0], [], [])
+AT_CHECK([$COBCRUN_DIRECT ./prog4], [0],
+[BINARY-SHORT UNSIGNED  5BA0
+BINARY-LONG UNSIGNED   8BD03835
+BINARY-DOUBLE UNSIGNED 208D868861370AD3
+PIC 9(4) COMP-5        5BA0
+PIC 9(8) COMP-5        8BD03835
+PIC 9(18) COMP-5       208D868861370AD3
+BINARY-SHORT           CFC7
+BINARY-LONG            B669FD2E
+BINARY-DOUBLE          EEDDEF0B82167EEB
+PIC S9(4) COMP-5       CFC7
+PIC S9(8) COMP-5       B669FD2E
+PIC S9(18) COMP-5      EEDDEF0B82167EEB
+])
+
+AT_CLEANUP
+
+
 AT_SETUP([MOVE DISPLAY to BINARY])
 AT_KEYWORDS([fundamental PPP])
 


### PR DESCRIPTION
## Pull Request: comp-5-uses-binary-byteorder dialect configuration option

### Summary
This branch adds a new dialect configuration option which allows COMP-5 fields to be processed using the same byte order as BINARY fields.

### Motivation
Previously GnuCOBOL always stored COMP-5 fields using native endianness, as opposed to BINARY or COMP fields which are held in either big-endian or native format depending on the **binary-byteorder** configuration option. However, COBOL programs ported from the mainframe expect COMP-5 fields to be stored in big-endian format like BINARY fields, the difference between COMP-5 and BINARY being that COMP-5 fields are always treated as no-trunc regardless of the setting of the binary-truncate option. The new configuration option allows the user to request that COMP-5 fields should be stored using the same endianness as BINARY fields.

### Changes
- Added configuration option `comp-5-uses-binary-byteorder` to **config.def**
- Updated all dialect config files to include the statement `comp-5-uses-binary-byteorder: no`
- Modified **field.c** to set the the **flag_binary_swap** flag for COMP-5 fields when:
  -- the comp-5-uses-binary-byteorder option is activated
  -- binary-byteorder=big-endian is specified
  -- the host architecture is little-endian
- Updated test case **configuration.at** to check that all dialect config files contain the new option
- Added a new test case **COMP-5 byteorder** in **data_binary.at** to verify correct behavior both with and without the new configuration option when binary-byteorder=big-endian is specified on little-endian systems.

### Impact
- This change also affects BINARY-SHORT, BINARY-LONG, and BINARY-DOUBLE which GnuCOBOL treats internally as COMP-5.
- Existing programs compiled with `comp-5-uses-binary-byteorder: no` will continue to operate unchanged.

### Testing
- All existing test suites have been run on x86 (little-endian) architecture.
- The new test case produces expected results on x86.

### Related Issues / Discussion
- It may be considered desirable to update **ibm-strict.config** to set `comp-5-uses-binary-byteorder: yes` if that can be done without impacting existing programs.
- This change is compatible with https://github.com/OCamlPro/gnucobol/pull/197

---

Please review and provide feedback or suggestions.