### PR TITLE
Remove strbuff in common.c

### DIFF
--- a/libcob/ChangeLog
+++ b/libcob/ChangeLog
@@ -1,4 +1,10 @@
 
+2025-11-18	Oğuzcan Kırmemiş <oguzcan.kirmemis@gmail.com>
+
+	* common.c: remove strbuff variable and cob_strcat/cob_strjoin utilities
+	which were prone to memory corruption due to strbuff being a global
+	* coblocal.h: remove definitions of cob_strcat and cob_strjoin
+
 2025-11-13  Simon Sobisch <simonsobisch@gnu.org>
 
 	* coblocal.h [__GNUC__]: only use C11's _Thread_local for gcc 5+

--- a/libcob/ChangeLog
+++ b/libcob/ChangeLog
@@ -4,6 +4,8 @@
 	* common.c: remove strbuff variable and cob_strcat/cob_strjoin utilities
 	which were prone to memory corruption due to strbuff being a global
 	* coblocal.h: remove definitions of cob_strcat and cob_strjoin
+	* call.c (add_to_preload): remove usage of cob_strcat and directly 
+	concatenate preload paths instead
 
 2025-11-13  Simon Sobisch <simonsobisch@gnu.org>
 

--- a/libcob/call.c
+++ b/libcob/call.c
@@ -19,7 +19,6 @@
 */
 
 
-#include "common.h"
 #include "config.h"
 
 #ifndef	_GNU_SOURCE
@@ -565,7 +564,7 @@ add_to_preload (const char *path, lt_dlhandle libhandle, struct struct_handle *l
 		cobsetptr->cob_preload_str = cob_strdup(path);
 	} else {
 		/* +1 to len for PATHSEP_CHAR */
-		int len = strlen (path) + strlen (cobsetptr->cob_preload_str) + 2;
+		const size_t len = strlen (path) + strlen (cobsetptr->cob_preload_str) + 2;
 		char *buff = (char *) cob_fast_malloc (len);
 		snprintf (buff, len, "%s%c%s", path, PATHSEP_CHAR,
 			cobsetptr->cob_preload_str);

--- a/libcob/call.c
+++ b/libcob/call.c
@@ -19,6 +19,7 @@
 */
 
 
+#include "common.h"
 #include "config.h"
 
 #ifndef	_GNU_SOURCE
@@ -563,8 +564,13 @@ add_to_preload (const char *path, lt_dlhandle libhandle, struct struct_handle *l
 	if (!cobsetptr->cob_preload_str) {
 		cobsetptr->cob_preload_str = cob_strdup(path);
 	} else {
-		cobsetptr->cob_preload_str = cob_strcat((char*) PATHSEP_STR, cobsetptr->cob_preload_str, 2);
-		cobsetptr->cob_preload_str = cob_strcat((char*) path, cobsetptr->cob_preload_str, 2);
+		/* +1 to len for PATHSEP_CHAR */
+		int len = strlen (path) + strlen (cobsetptr->cob_preload_str) + 2;
+		char *buff = (char *) cob_fast_malloc (len);
+		snprintf (buff, len, "%s%c%s", path, PATHSEP_CHAR,
+			cobsetptr->cob_preload_str);
+		cob_free (cobsetptr->cob_preload_str);
+		cobsetptr->cob_preload_str = buff;
 	}
 }
 

--- a/libcob/coblocal.h
+++ b/libcob/coblocal.h
@@ -583,8 +583,6 @@ COB_HIDDEN FILE			*cob_get_dump_file	(void);
 COB_HIDDEN char		*cob_int_to_string		(int, char*);
 COB_HIDDEN char		*cob_int_to_formatted_bytestring	(int, char*);
 #endif
-COB_HIDDEN char		*cob_strcat		(char*, char*, int);
-COB_HIDDEN char		*cob_strjoin		(char**, int, char*);
 
 COB_HIDDEN int		cob_runtime_warning_ss (const char *, const char *);
 

--- a/libcob/common.c
+++ b/libcob/common.c
@@ -7731,8 +7731,11 @@ var_print (const char *msg, const char *val, const char *default_val,
 		return;
 	} else if (format != 0 && val && default_val &&
 		((format != 2 && val[0] == '0') || strcmp (val, default_val) == 0)) {
-		snprintf (val_buff, COB_NORMAL_BUFF, "%s %s", default_val,
+		int len = snprintf (val_buff, COB_NORMAL_BUFF, "%s %s", default_val,
 			_("(default)"));
+		if (len < 0 || len >= COB_NORMAL_MAX) {
+			memcpy(val_buff + COB_NORMAL_MAX - 3, "...", 3 + 1);
+		}
 		val = val_buff;
 	} else if (!val && default_val) {
 		val = default_val;
@@ -7752,8 +7755,11 @@ var_print (const char *msg, const char *val, const char *default_val,
 		return;
 	} else if (format == 1 && val && default_val &&
 		(val[0] == '0' || strcmp (val, default_val) == 0)) {
-		snprintf (val_buff, COB_NORMAL_BUFF, "%s %s", default_val,
+		int len = snprintf (val_buff, COB_NORMAL_MAX, "%s %s", default_val,
 			_("(default)"));
+		if (len < 0 || len >= COB_NORMAL_MAX) {
+			memcpy(val_buff + COB_NORMAL_MAX - 3, "...", 3 + 1);
+		}
 		val = val_buff;
 	} else if (!val && default_val) {
 		val = default_val;
@@ -7765,8 +7771,11 @@ var_print (const char *msg, const char *val, const char *default_val,
 		return;
 	} else if (format != 0 && val && default_val &&
 		((format != 2 && val[0] == '0') || strcmp (val, default_val) == 0)) {
-		snprintf (val_buff, COB_NORMAL_BUFF, "%s %s", default_val,
+		int len = snprintf (val_buff, COB_NORMAL_BUFF, "%s %s", default_val,
 			_("(default)"));
+		if (len < 0 || len >= COB_NORMAL_MAX) {
+			memcpy(val_buff + COB_NORMAL_MAX - 3, "...", 3 + 1);
+		}
 		val = val_buff;
 	} else if (!val && default_val) {
 		val = default_val;

--- a/libcob/common.c
+++ b/libcob/common.c
@@ -423,8 +423,6 @@ static char			cob_debug_modules[12][4] = {"", "", "", "", "", "", "", "", "", ""
 static char			*cob_debug_file_name = NULL;
 #endif
 
-static char			*strbuff = NULL;
-
 static int		cob_process_id = 0;
 static int		cob_temp_iteration = 0;
 
@@ -7699,71 +7697,12 @@ cob_int_to_formatted_bytestring (int i, char *number)
 }
 #endif
 
-/* concatenate two strings allocating a new one
-   and optionally free one of the strings
-   set str_to_free if the result is assigned to
-   one of the two original strings
-*/
-char *
-cob_strcat (char *str1, char *str2, int str_to_free)
-{
-	size_t		l;
-	char		*temp1, *temp2;
-
-	l = strlen (str1) + strlen (str2) + 1;
-
-	/*
-	 * If one of the parameter is the buffer itself,
-	 * we copy the buffer before continuing.
-	 */
-	if (str1 == strbuff) {
-		temp1 = cob_strdup (str1);
-	} else {
-		temp1 = str1;
-	}
-	if (str2 == strbuff) {
-		temp2 = cob_strdup (str2);
-	} else {
-		temp2 = str2;
-	}
-
-	if (strbuff) {
-		cob_free (strbuff);
-	}
-	strbuff = (char *) cob_fast_malloc (l);
-
-	sprintf (strbuff, "%s%s", temp1, temp2);
-	switch (str_to_free) {
-		case 1: cob_free (temp1);
-		        break;
-		case 2: cob_free (temp2);
-		        break;
-		default: break;
-	}
-	return strbuff;
-}
-
-char *
-cob_strjoin (char **strarray, int size, char *separator)
-{
-	char	*result;
-	int	i;
-
-	if (!strarray || size <= 0 || !separator) return NULL;
-
-	result = cob_strdup (strarray[0]);
-	for (i = 1; i < size; i++) {
-		result = cob_strcat (result, separator, 1);
-		result = cob_strcat (result, strarray[i], 1);
-	}
-
-	return result;
-}
-
 static void
 var_print (const char *msg, const char *val, const char *default_val,
 		const unsigned int format)
 {
+	char *val_buff;
+
 #if 0 /* currently only format 0/1 used */
 	switch (format) {
 	case 0:
@@ -7792,11 +7731,15 @@ var_print (const char *msg, const char *val, const char *default_val,
 		return;
 	} else if (format != 0 && val && default_val &&
 		((format != 2 && val[0] == '0') || strcmp (val, default_val) == 0)) {
-		char dflt[40];
-		snprintf (dflt, 39, " %s", _("(default)"));
-		val = cob_strcat ((char *) default_val, dflt, 0);
+		char *dflt = _("(default)");
+		/* +1 to len for space */
+		int len = strlen (default_val) + strlen (dflt) + 2;
+		val_buff = (char *) cob_fast_malloc (len);
+		snprintf (val_buff, len, "%s %s", default_val, dflt);
 	} else if (!val && default_val) {
-		val = default_val;
+		val_buff = cob_strdup (default_val);
+	} else {
+		val_buff = cob_strdup (val);
 	}
 #else
 	if (format == 0) {
@@ -7813,11 +7756,15 @@ var_print (const char *msg, const char *val, const char *default_val,
 		return;
 	} else if (format == 1 && val && default_val &&
 		(val[0] == '0' || strcmp (val, default_val) == 0)) {
-		char dflt[40];
-		snprintf (dflt, 39, " %s", _("(default)"));
-		val = cob_strcat ((char *) default_val, dflt, 0);
+		char *dflt = _("(default)");
+		/* +1 to len for space */
+		int len = strlen (default_val) + strlen (dflt) + 2;
+		val_buff = (char *) cob_fast_malloc (len);
+		snprintf (val_buff, len, "%s %s", default_val, dflt);
 	} else if (!val && default_val) {
-		val = default_val;
+		val_buff = cob_strdup (default_val);
+	} else {
+		val_buff = cob_strdup (val);
 	}
 #endif
 
@@ -7826,11 +7773,15 @@ var_print (const char *msg, const char *val, const char *default_val,
 		return;
 	} else if (format != 0 && val && default_val &&
 		((format != 2 && val[0] == '0') || strcmp (val, default_val) == 0)) {
-		char dflt[40];
-		snprintf (dflt, 39, " %s", _("(default)"));
-		val = cob_strcat ((char *) default_val, dflt, 0);
+		char *dflt = _("(default)");
+		/* +1 to len for space */
+		int len = strlen (default_val) + strlen (dflt) + 2;
+		char *val_buff = (char *) cob_fast_malloc (len);
+		snprintf (val_buff, len, "%s %s", default_val, dflt);
 	} else if (!val && default_val) {
-		val = default_val;
+		val_buff = cob_strdup (default_val);
+	} else {
+		val_buff = cob_strdup (val);
 	}
 
 	if (val && strlen (val) <= CB_IVAL_SIZE) {
@@ -7846,7 +7797,7 @@ var_print (const char *msg, const char *val, const char *default_val,
 		char	*token;
 		size_t	n;
 
-		p = cob_strdup (val);
+		p = val_buff;
 
 		n = 0;
 		token = strtok (p, " ");
@@ -10393,7 +10344,6 @@ cob_init (const int argc, char **argv)
 	basext = NULL;
 	share_sort_state = NULL;
 	cob_source_file = NULL;
-	strbuff = NULL;
 	exit_hdlrs = NULL;
 	hdlrs = NULL;
 	commlncnt = 0;

--- a/libcob/common.c
+++ b/libcob/common.c
@@ -18,7 +18,6 @@
    along with GnuCOBOL.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include "common.h"
 #include "tarstamp.h"
 #include "config.h"
 

--- a/libcob/common.c
+++ b/libcob/common.c
@@ -10393,6 +10393,7 @@ cob_init (const int argc, char **argv)
 	basext = NULL;
 	share_sort_state = NULL;
 	cob_source_file = NULL;
+	strbuff = NULL;
 	exit_hdlrs = NULL;
 	hdlrs = NULL;
 	commlncnt = 0;

--- a/libcob/common.c
+++ b/libcob/common.c
@@ -18,6 +18,7 @@
    along with GnuCOBOL.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+#include "common.h"
 #include "tarstamp.h"
 #include "config.h"
 
@@ -7701,7 +7702,7 @@ static void
 var_print (const char *msg, const char *val, const char *default_val,
 		const unsigned int format)
 {
-	char *val_buff;
+	char val_buff[COB_NORMAL_BUFF];
 
 #if 0 /* currently only format 0/1 used */
 	switch (format) {
@@ -7731,15 +7732,11 @@ var_print (const char *msg, const char *val, const char *default_val,
 		return;
 	} else if (format != 0 && val && default_val &&
 		((format != 2 && val[0] == '0') || strcmp (val, default_val) == 0)) {
-		char *dflt = _("(default)");
-		/* +1 to len for space */
-		int len = strlen (default_val) + strlen (dflt) + 2;
-		val_buff = (char *) cob_fast_malloc (len);
-		snprintf (val_buff, len, "%s %s", default_val, dflt);
+		snprintf (val_buff, COB_NORMAL_BUFF, "%s %s", default_val,
+			_("(default)"));
+		val = val_buff;
 	} else if (!val && default_val) {
-		val_buff = cob_strdup (default_val);
-	} else {
-		val_buff = cob_strdup (val);
+		val = default_val;
 	}
 #else
 	if (format == 0) {
@@ -7756,15 +7753,11 @@ var_print (const char *msg, const char *val, const char *default_val,
 		return;
 	} else if (format == 1 && val && default_val &&
 		(val[0] == '0' || strcmp (val, default_val) == 0)) {
-		char *dflt = _("(default)");
-		/* +1 to len for space */
-		int len = strlen (default_val) + strlen (dflt) + 2;
-		val_buff = (char *) cob_fast_malloc (len);
-		snprintf (val_buff, len, "%s %s", default_val, dflt);
+		snprintf (val_buff, COB_NORMAL_BUFF, "%s %s", default_val,
+			_("(default)"));
+		val = val_buff;
 	} else if (!val && default_val) {
-		val_buff = cob_strdup (default_val);
-	} else {
-		val_buff = cob_strdup (val);
+		val = default_val;
 	}
 #endif
 
@@ -7773,15 +7766,11 @@ var_print (const char *msg, const char *val, const char *default_val,
 		return;
 	} else if (format != 0 && val && default_val &&
 		((format != 2 && val[0] == '0') || strcmp (val, default_val) == 0)) {
-		char *dflt = _("(default)");
-		/* +1 to len for space */
-		int len = strlen (default_val) + strlen (dflt) + 2;
-		char *val_buff = (char *) cob_fast_malloc (len);
-		snprintf (val_buff, len, "%s %s", default_val, dflt);
+		snprintf (val_buff, COB_NORMAL_BUFF, "%s %s", default_val,
+			_("(default)"));
+		val = val_buff;
 	} else if (!val && default_val) {
-		val_buff = cob_strdup (default_val);
-	} else {
-		val_buff = cob_strdup (val);
+		val = default_val;
 	}
 
 	if (val && strlen (val) <= CB_IVAL_SIZE) {
@@ -7797,7 +7786,7 @@ var_print (const char *msg, const char *val, const char *default_val,
 		char	*token;
 		size_t	n;
 
-		p = val_buff;
+		p = cob_strdup (val);
 
 		n = 0;
 		token = strtok (p, " ");

--- a/libcob/screenio.c
+++ b/libcob/screenio.c
@@ -4715,6 +4715,7 @@ cob_exit_screen (void)
 		}
 	}
 	COB_ACCEPT_STATUS = 0;
+	cobglobptr = NULL;
 }
 
 /* minimal exit from curses screen - without any cleanup */

--- a/tests/testsuite.src/run_misc.at
+++ b/tests/testsuite.src/run_misc.at
@@ -15763,10 +15763,6 @@ AT_DATA([dummy.cob], [
 AT_DATA([caller.c], [[
 #include <libcob.h>
 
-#ifndef NULL
-#define NULL (void*)0
-#endif
-
 int
 main (int argc, char **argv)
 {
@@ -15818,7 +15814,7 @@ AT_CHECK([$COMPILE_MODULE -o libdummy1 dummy.cob], [0], [], [])
 AT_CHECK([$COMPILE_MODULE -o libdummy2 dummy.cob], [0], [], [])
 AT_CHECK([$COMPILE_MODULE -o libdummy3 dummy.cob], [0], [], [])
 AT_CHECK([$COMPILE_MODULE callee.cob], [0], [], [])
-AT_CHECK([COB_PRE_LOAD=libdummy1:libdummy2:libdummy3 $COBCRUN_DIRECT ./caller], [0],
+AT_CHECK([COB_PRE_LOAD="libdummy1"$PATHSEP"libdummy2"$PATHSEP"libdummy3" $COBCRUN_DIRECT ./caller], [0],
 [TEST1
 TEST2
 ], [])

--- a/tests/testsuite.src/run_misc.at
+++ b/tests/testsuite.src/run_misc.at
@@ -4787,6 +4787,83 @@ note: error exit with return code -1 and error "buggy.cob:10: offset of 'VAR' ou
 AT_CLEANUP
 
 
+AT_SETUP([can reinitialize cleaned up runtime in C])
+AT_KEYWORDS([runmisc cobcall cob_init cob_call cob_tidy])
+
+# tests memory corruptions caused by leftover global values from previous
+# initializations being used if cob_init/cob_tidy does not correctly reset the
+# global state of the runtime.
+
+AT_DATA([callee.cob], [
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. callee.
+       DATA DIVISION.
+       LINKAGE SECTION.
+       01 VAR1 PIC X(1) VALUE "X".
+       PROCEDURE DIVISION USING VAR1.
+           DISPLAY "TEST" VAR1.
+           EXIT PROGRAM.
+])
+
+AT_DATA([caller.c], [[
+#include <libcob.h>
+
+int
+main (int argc, char **argv)
+{
+    /* for storing libcob return state */
+    int cob_ret;
+
+    /* for storing COBOL parameters */
+    void *cob_argv[1];
+    char cob_arg;
+
+    /* initialize the COBOL run-time library */
+    cob_init (0, NULL);
+
+    /* call COBOL program first time */
+    cob_arg = '1';
+    cob_argv[0] = &cob_arg;
+    cob_ret = cob_call ("callee", 1, cob_argv);
+
+    /* Clean up and terminate runtime */
+    cob_tidy ();
+
+    /* Check normal exit first time */
+    if (cob_ret != 0) {
+        return 1;
+    }
+
+    /* Reinitialize runtime */
+    cob_init (0, NULL);
+
+    /* call COBOL program second time */
+    cob_arg = '2';
+    cob_argv[0] = &cob_arg;
+    cob_ret = cob_call ("callee", 1, cob_argv);
+
+    /* Clean up and terminate runtime */
+    cob_tidy ();
+
+    /* Check normal exit second time */
+    if (cob_ret != 0) {
+      return 2;
+    }
+
+    return 0;
+}
+]])
+
+AT_CHECK([$COMPILE caller.c], [0], [], [])
+AT_CHECK([$COMPILE_MODULE callee.cob], [0], [], [])
+AT_CHECK([$COBCRUN_DIRECT ./caller], [0],
+[TEST1
+TEST2
+], [])
+
+AT_CLEANUP
+
+
 AT_SETUP([CALL in from C, cob_call_params explicitly set])
 AT_KEYWORDS([runmisc])
 
@@ -15734,94 +15811,6 @@ AT_CHECK([$COBCRUN_DIRECT ./prog], [0],
 000000123
 000000001
 000000009
-], [])
-
-AT_CLEANUP
-
-
-# This specifically tests a use-after-free issue where COB_PRE_LOAD caused 
-# leftover values from previous initializations to be used due to
-# cob_init/cob_tidy not resetting the buffer of cob_strcat, which is used
-# by cob_call when it preloads more than one library. It is also, however,
-# useful as a general test case to check if there is any leak between
-# cob_init/cob_tidy.
-AT_SETUP([Can reinitialize cleaned up runtime with COB_PRE_LOAD])
-AT_KEYWORDS([runmisc cob_init cob_call cob_tidy])
-
-AT_DATA([callee.cob], [
-       IDENTIFICATION DIVISION.
-       PROGRAM-ID. callee.
-       DATA DIVISION.
-       LINKAGE SECTION.
-       01 VAR1 PIC X(1) VALUE "X".
-       PROCEDURE DIVISION USING VAR1.
-           DISPLAY "TEST" VAR1.
-           EXIT PROGRAM.
-])
-
-AT_DATA([dummy.cob], [
-       IDENTIFICATION DIVISION.
-       PROGRAM-ID. dummy.
-       PROCEDURE DIVISION.
-           EXIT PROGRAM.
-])
-
-AT_DATA([caller.c], [[
-#include <libcob.h>
-
-int
-main (int argc, char **argv)
-{
-    /* for storing libcob return state */
-    int cob_ret;
-
-    /* for storing COBOL parameters */
-    void *cob_argv[1];
-    char cob_arg;
-
-    /* initialize the COBOL run-time library */
-    cob_init (0, NULL);
-
-    /* call COBOL program first time */
-    cob_arg = '1';
-    cob_argv[0] = &cob_arg;
-    cob_ret = cob_call ("callee", 1, cob_argv);
-
-    /* Clean up and terminate runtime */
-    cob_tidy ();
-
-    /* Check normal exit first time */
-    if (cob_ret != 0) {
-        return 1;
-    }
-
-    /* Reinitialize runtime */
-    cob_init (0, NULL);
-
-    /* call COBOL program second time */
-    cob_arg = '2';
-    cob_argv[0] = &cob_arg;
-    cob_ret = cob_call ("callee", 1, cob_argv);
-
-    /* Clean up and terminate runtime */
-    cob_tidy ();
-
-    /* Check normal exit second time */
-    if (cob_ret != 0) {
-      return 2;
-    }
-
-    return 0;
-}
-]])
-
-AT_CHECK([$COMPILE caller.c], [0], [], [])
-AT_CHECK([$COMPILE_MODULE -o libdummy1 dummy.cob], [0], [], [])
-AT_CHECK([$COMPILE_MODULE -o libdummy2 dummy.cob], [0], [], [])
-AT_CHECK([$COMPILE_MODULE callee.cob], [0], [], [])
-AT_CHECK([COB_PRE_LOAD="libdummy1"$PATHSEP"libdummy2" $COBCRUN_DIRECT ./caller], [0],
-[TEST1
-TEST2
 ], [])
 
 AT_CLEANUP

--- a/tests/testsuite.src/run_misc.at
+++ b/tests/testsuite.src/run_misc.at
@@ -15739,6 +15739,12 @@ AT_CHECK([$COBCRUN_DIRECT ./prog], [0],
 AT_CLEANUP
 
 
+# This specifically tests a use-after-free issue where COB_PRE_LOAD caused 
+# leftover values from previous initializations to be used due to
+# cob_init/cob_tidy not resetting the buffer of cob_strcat, which is used
+# by cob_call when it preloads more than one library. It is also, however,
+# useful as a general test case to check if there is any leak between
+# cob_init/cob_tidy.
 AT_SETUP([Can reinitialize cleaned up runtime with COB_PRE_LOAD])
 AT_KEYWORDS([runmisc cob_init cob_call cob_tidy])
 
@@ -15812,9 +15818,8 @@ main (int argc, char **argv)
 AT_CHECK([$COMPILE caller.c], [0], [], [])
 AT_CHECK([$COMPILE_MODULE -o libdummy1 dummy.cob], [0], [], [])
 AT_CHECK([$COMPILE_MODULE -o libdummy2 dummy.cob], [0], [], [])
-AT_CHECK([$COMPILE_MODULE -o libdummy3 dummy.cob], [0], [], [])
 AT_CHECK([$COMPILE_MODULE callee.cob], [0], [], [])
-AT_CHECK([COB_PRE_LOAD="libdummy1"$PATHSEP"libdummy2"$PATHSEP"libdummy3" $COBCRUN_DIRECT ./caller], [0],
+AT_CHECK([COB_PRE_LOAD="libdummy1"$PATHSEP"libdummy2" $COBCRUN_DIRECT ./caller], [0],
 [TEST1
 TEST2
 ], [])

--- a/tests/testsuite.src/run_misc.at
+++ b/tests/testsuite.src/run_misc.at
@@ -15737,3 +15737,90 @@ AT_CHECK([$COBCRUN_DIRECT ./prog], [0],
 ], [])
 
 AT_CLEANUP
+
+
+AT_SETUP([Can reinitialize cleaned up runtime with COB_PRE_LOAD])
+AT_KEYWORDS([runmisc cob_init cob_call cob_tidy])
+
+AT_DATA([callee.cob], [
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. callee.
+       DATA DIVISION.
+       LINKAGE SECTION.
+       01 VAR1 PIC X(1) VALUE "X".
+       PROCEDURE DIVISION USING VAR1.
+           DISPLAY "TEST" VAR1.
+           EXIT PROGRAM.
+])
+
+AT_DATA([dummy.cob], [
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. dummy.
+       PROCEDURE DIVISION.
+           EXIT PROGRAM.
+])
+
+AT_DATA([caller.c], [[
+#include <libcob.h>
+
+#ifndef NULL
+#define NULL (void*)0
+#endif
+
+int
+main (int argc, char **argv)
+{
+    /* for storing libcob return state */
+    int cob_ret;
+
+    /* for storing COBOL parameters */
+    void *cob_argv[1];
+    char cob_arg;
+
+    /* initialize the COBOL run-time library */
+    cob_init (0, NULL);
+
+    /* call COBOL program first time */
+    cob_arg = '1';
+    cob_argv[0] = &cob_arg;
+    cob_ret = cob_call ("callee", 1, cob_argv);
+
+    /* Clean up and terminate runtime */
+    cob_tidy ();
+
+    /* Check normal exit first time */
+    if (cob_ret != 0) {
+        return 1;
+    }
+
+    /* Reinitialize runtime */
+    cob_init (0, NULL);
+
+    /* call COBOL program second time */
+    cob_arg = '2';
+    cob_argv[0] = &cob_arg;
+    cob_ret = cob_call ("callee", 1, cob_argv);
+
+    /* Clean up and terminate runtime */
+    cob_tidy ();
+
+    /* Check normal exit second time */
+    if (cob_ret != 0) {
+      return 2;
+    }
+
+    return 0;
+}
+]])
+
+AT_CHECK([$COMPILE caller.c], [0], [], [])
+AT_CHECK([$COMPILE_MODULE -o libdummy1 dummy.cob], [0], [], [])
+AT_CHECK([$COMPILE_MODULE -o libdummy2 dummy.cob], [0], [], [])
+AT_CHECK([$COMPILE_MODULE -o libdummy3 dummy.cob], [0], [], [])
+AT_CHECK([$COMPILE_MODULE callee.cob], [0], [], [])
+AT_CHECK([COB_PRE_LOAD=libdummy1:libdummy2:libdummy3 $COBCRUN_DIRECT ./caller], [0],
+[TEST1
+TEST2
+], [])
+
+AT_CLEANUP


### PR DESCRIPTION
This PR resolves a use-after-free bug in `libcob` that occurs when the runtime is cleaned up and subsequently reinitialized while using the `COB_PRE_LOAD` environment variable. 

# Issue Description 

`strbuff` is a global cache/variable defined in common.c, which is used by the `cob_strcat` function. After the runtime is initialized via `cob_init`, this variable is expected to be set to null. Normally, `cob_strcat` manages the memory used by `strbuff` internally. However, if the runtime is cleaned up, even though the memory pointed to by `strbuff` is correctly freed, the value of `strbuff` is not set back to null. If the runtime is initialized a second time afterward, `cob_strcat` assumes that `strbuff` already exists and attempts to free it again, causing a double-free situation. This is highly likely to result in a use-after-free during the second usage of the runtime or a segmentation fault during `cob_tidy`, if glibc's heap protection mechanisms detect the issue. 

# Steps to Reproduce 

The easiest way to reproduce the issue is to initialize the runtime and execute a COBOL program while the `COB_PRE_LOAD` environment variable includes one or more libraries. This is because `cob_strcat` is only used in `cob_call` when the `COB_PRE_LOAD `variable is set. After calling `cob_tidy` to clean up the runtime, the `strbuff` variable retains a leftover value, which will be incorrectly used during the second runtime initialization. An example program flow that reproduces the issue is as follows: 

1. `cob_init`
2. `cob_call`
3. `cob_tidy`
4. `cob_init`
5. `cob_call`
6. `cob_tidy`


I have also added this example as a test case to the PR.

# Solution

Since `strbuff` is a global variable and `cob_strcat` is used in also other places. removing it is probably the best solution to also prevent potential future memory corruptions. This naturally implies the removal of `cob_strcat`, followed by `cob_strjoin`, which uses `cob_strcat` itself. Calls to `cob_strcat` is replaced with a simple `strlen`/`malloc`/`snprintf` or fixed-size-buffer/`snprintf` routine.