### PR TITLE
drop bashisms in atlocal.in and pre-inst-env.in

### DIFF
--- a/build_aux/pre-inst-env.in
+++ b/build_aux/pre-inst-env.in
@@ -58,7 +58,7 @@ LD_LIBRARY_PATH="@abs_top_builddir@/libcob/.libs:${LD_LIBRARY_PATH}"     # GNU/L
 DYLD_LIBRARY_PATH="@abs_top_builddir@/libcob/.libs:{$DYLD_LIBRARY_PATH}" # Mac OS
 SHLIB_PATH="@abs_top_builddir@/libcob/.libs:${SHLIB_PATH}"               # HP-UX
 LIBPATH="@abs_top_builddir@/libcob/.libs:${LIBPATH}"                     # AIX
-if test "x${COB_LIBRARY_PATH}" = x; then
+if [ -z "${COB_LIBRARY_PATH}" ]; then
    COB_LIBRARY_PATH="$(_return_path "@abs_top_builddir@/extras")"
 else
    # only in pre-inst case: prepend
@@ -74,9 +74,9 @@ export COB_LIBRARY_PATH
 if test "x${BASH_SOURCE}" != "x" -a "${BASH_SOURCE}" != "$0"; then
 	echo "This script should not be sourced but called instead!"
 else
-	if test "x$1" != "x"; then
-		exec "$@"
-	else
+	if [ -z "$1" ]; then
 		$SHELL
+	else
+		exec "$@"
 	fi
 fi

--- a/tests/atlocal.in
+++ b/tests/atlocal.in
@@ -59,7 +59,6 @@ fi
 diff() {
   command "@DIFF@" @DIFF_FLAGS@ "$@"
 }
-export -f diff
 
 DIFF=diff
 AWK=@AWK@
@@ -103,7 +102,6 @@ perf_record() {
 	# drop --aio / -z if your system does not support that
 	perf record -q --aio -z --call-graph dwarf,4096 --output "${outfile}" "$@"
 }
-export -f perf_record
 
 perf_stat() {
 	local logdir="$1"; shift
@@ -111,7 +109,6 @@ perf_stat() {
 
 	perf stat -e instructions --append --output "${outfile}" "$@"
 }
-export -f perf_stat
 
 # get performance counters for compiler and/or runtime
 if test "x${PERFSUFFIX}" != "x"; then
@@ -243,7 +240,6 @@ _return_path () {
 	path="${path%\"}"
 	echo "$path"
 }
-export -f _return_path
 
 # as we run the testsuite in plain LC_ALL=C the system runs in a plain-as-possible environment;
 # in the case that we need UTF8 encoding within tests, we try to find out if a working UTF-8

--- a/tests/atlocal_win
+++ b/tests/atlocal_win
@@ -24,12 +24,11 @@
 # along with GnuCOBOL.  If not, see <https://www.gnu.org/licenses/>.
 
 
-[ -z "${abs_top_srcdir}" ]  && abs_top_srcdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." > /dev/null && pwd )"
 TEMPLATE="${abs_top_srcdir}/tests/testsuite.src"
 
 COB_SRC_PATH="${abs_top_srcdir}"
 
-[ -z "${COB_WIN_BUILDPATH}" ]  && COB_WIN_BUILDPATH="$COB_SRC_PATH/build_windows/x64/Debug"
+[ -z "${COB_WIN_BUILDPATH}" ] && COB_WIN_BUILDPATH="$COB_SRC_PATH/build_windows/x64/Debug"
 
 COBC="cobc.exe"
 COBCRUN="cobcrun.exe"
@@ -40,9 +39,12 @@ PATH="${COB_WIN_BUILDPATH}:${PATH}"
 export PATH
 
 if ! command -v "${COBC}" >/dev/null 2>&1; then
-	echo missing ${COBC} in ${PATH}
+	echo "missing ${COBC} in ${PATH}"
 	return 1
 fi
+
+ABS_COBC="$(which ${COBC})"
+ABS_COBCRUN="$(which ${COBCRUN})"
 
 DIFF=diff
 AWK=awk
@@ -121,7 +123,6 @@ _return_path () {
 		fi
 	fi
 }
-export -f _return_path
 
 # as we run the testsuite in plain LC_ALL=C the system runs in a plain-as-possible environment;
 # in the case that we need UTF8 encoding within tests, we try to find out if a working UTF-8

--- a/tests/testsuite.src/listings.at
+++ b/tests/testsuite.src/listings.at
@@ -1,4 +1,4 @@
-## Copyright (C) 2015-2024 Free Software Foundation, Inc.
+## Copyright (C) 2015-2025 Free Software Foundation, Inc.
 ## Written by Dave Pitts, Simon Sobisch, Edward Hart
 ##
 ## This file is part of GnuCOBOL.


### PR DESCRIPTION
also fix [r5576]'s change to atlocal_win that resulted in errors about missing definitions