### PR TITLE
ENTRY statement should begin in area B not area A

### DIFF
--- a/cobc/ChangeLog
+++ b/cobc/ChangeLog
@@ -1,4 +1,7 @@
 
+2025-12-04  Roger Bowler <rbowler@snipix.net>
+	* parser.y: check that ENTRY statement begins in area B not area A
+
 2025-07-30  Simon Sobisch <simonsobisch@gnu.org>
 
 	* scanner.l, parser.y, reserved.c: use yyless to push part of scanned

--- a/cobc/parser.y
+++ b/cobc/parser.y
@@ -13944,7 +13944,7 @@ enable_statement:
 
 /* ENTRY statement */
 
-entry: ENTRY {check_area_a_of ("ENTRY"); };
+entry: ENTRY {check_non_area_a_of ("ENTRY"); };
 entry_statement:
   entry
   {

--- a/tests/testsuite.src/syn_misc.at
+++ b/tests/testsuite.src/syn_misc.at
@@ -3487,6 +3487,36 @@ AT_CHECK([$COMPILE_ONLY -std=cobol85 -fformat=fixed prog.cob], [0], [])
 AT_CLEANUP
 
 
+AT_SETUP([ENTRY statements in areas A and B])
+AT_KEYWORDS([misc cobol85 areacheck ENTRY])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION   DIVISION.
+       PROGRAM-ID.      prog.
+       DATA             DIVISION.
+       LINKAGE          SECTION.
+       01 PARM-1        PIC X(256).
+       01 PARM-2        PIC X(256).
+       PROCEDURE        DIVISION.
+           ENTRY 'PRGEP1' USING PARM-1 PARM-2.
+           DISPLAY 'ENTRY POINT 1'.
+           GOBACK.
+         ENTRY 'PRGEP2' USING PARM-1 PARM-2.
+           DISPLAY 'ENTRY POINT 2'.
+           GOBACK.
+])
+
+AT_CHECK([$COMPILE_ONLY prog.cob], [0], [])
+AT_CHECK([$COMPILE_ONLY -std=ibm-strict prog.cob], [1], [],
+[prog.cob:12: error: ENTRY should not start in Area A
+])
+
+AT_CHECK([$COMPILE_ONLY -std=ibm-strict -fno-areacheck prog.cob], [0], [])
+AT_CHECK([$COMPILE_ONLY -std=ibm-strict -fformat=fixed prog.cob], [0], [])
+
+AT_CLEANUP
+
+
 AT_SETUP([pseudotext replacement with text in area A])
 AT_KEYWORDS([misc cobol85 gcos copy missing-periods])
 


### PR DESCRIPTION
When using a dialect configuration which includes `areacheck:yes` (for example, `-std=ibm-strict`), GnuCOBOL rejects an ENTRY statement coded in column 12 with the error message:  
`error: ENTRY should start in Area A`
This is incorrect, as ENTRY statements should begin in Area B (ref: [Enterprise COBOL Language Reference manual](https://www.ibm.com/docs/en/cobol-zos/6.4.0?topic=format-area))

This modification changes `parser.y` so that when `areacheck:yes` is in effect, ENTRY statements must start in Area B not Area A.