### PR TITLE
allow ORG INDEXED without db if callfh is specified

### DIFF
--- a/cobc/ChangeLog
+++ b/cobc/ChangeLog
@@ -1,4 +1,9 @@
 
+2025-12-29  Roger Bowler <rbowler@snipix.net>
+
+	* tree.c (finalize_file): allow ORGANIZATION INDEXED if -fcallfh
+	  is specified, even when compiler is configured --without-db
+
 2025-12-04  Roger Bowler <rbowler@snipix.net>
 
 	* parser.y (entry): check that ENTRY statement begins in area B not area A

--- a/cobc/tree.c
+++ b/cobc/tree.c
@@ -5033,7 +5033,7 @@ finalize_file (struct cb_file *f, struct cb_field *records)
 #if	!defined (WITH_INDEX_EXTFH) && \
 	!defined (WITH_DB) && \
 	!defined (WITH_CISAM) && !defined(WITH_DISAM) && !defined(WITH_VBISAM)
-	if (f->organization == COB_ORG_INDEXED) {
+	if (f->organization == COB_ORG_INDEXED && !f->extfh) {
 		char msg[80];
 		snprintf (msg, sizeof (msg), "ORGANIZATION INDEXED; FD %s", f->name);
 		cb_warning_x (cb_warn_unsupported, f->description_entry,

--- a/tests/testsuite.src/run_file.at
+++ b/tests/testsuite.src/run_file.at
@@ -13578,6 +13578,12 @@ AT_CHECK([$COBCRUN_DIRECT ./prog], [0],
 00: 0005XXXXXXXXXXXX0005
 ], [])
 
+# If there is no database and -fcallfh is not specified then
+# the compile should still fail with an error
+AT_CHECK([$COMPILE prog.cob], [1], [],
+[prog.cob:18: error: runtime is not configured to support ORGANIZATION INDEXED; FD TSTFILE
+])
+
 AT_CLEANUP
 
 

--- a/tests/testsuite.src/run_file.at
+++ b/tests/testsuite.src/run_file.at
@@ -13481,17 +13481,12 @@ AT_CHECK([$DIFF reference prog.out], [0], [], [])
 AT_CLEANUP
 
 
-# When the compiler is configured without a database package,
-# but an external file handler is specified at compile time,
-# programs with INDEXED files should NOT fail with the message
-# "runtime is not configured to support ORGANIZATION INDEXED"
-
 AT_SETUP([INDEXED file using EXTFH without database])
-AT_KEYWORDS([runfile EXTFH indexed without-db])
+AT_KEYWORDS([runfile no-isam])
 
-# This test is only applicable if the compiler has been built
-# with the --without-db configuration option
-AT_SKIP_IF([test "$COB_HAS_ISAM" != "no"])
+# Verifies that an INDEXED file can be processed via an
+# external file handler, even if the compiler has been
+# built with the --without-db configuration option
 
 AT_DATA([prog.cob], [
        IDENTIFICATION DIVISION.
@@ -13577,12 +13572,6 @@ AT_CHECK([$COBCRUN_DIRECT ./prog], [0],
 00: 0004XXXXXXXXXXXX0004
 00: 0005XXXXXXXXXXXX0005
 ], [])
-
-# If there is no database and -fcallfh is not specified then
-# the compile should still fail with an error
-AT_CHECK([$COMPILE prog.cob], [1], [],
-[prog.cob:18: error: runtime is not configured to support ORGANIZATION INDEXED; FD TSTFILE
-])
 
 AT_CLEANUP
 

--- a/tests/testsuite.src/run_file.at
+++ b/tests/testsuite.src/run_file.at
@@ -13481,6 +13481,106 @@ AT_CHECK([$DIFF reference prog.out], [0], [], [])
 AT_CLEANUP
 
 
+# When the compiler is configured without a database package,
+# but an external file handler is specified at compile time,
+# programs with INDEXED files should NOT fail with the message
+# "runtime is not configured to support ORGANIZATION INDEXED"
+
+AT_SETUP([INDEXED file using EXTFH without database])
+AT_KEYWORDS([runfile EXTFH indexed without-db])
+
+# This test is only applicable if the compiler has been built
+# with the --without-db configuration option
+AT_SKIP_IF([test "$COB_HAS_ISAM" != "no"])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. prog.
+
+       ENVIRONMENT DIVISION.
+       CONFIGURATION SECTION.
+
+       INPUT-OUTPUT SECTION.
+       FILE-CONTROL.
+           SELECT TSTFILE
+           ASSIGN TO "testisam"
+           ORGANIZATION INDEXED ACCESS SEQUENTIAL
+           RECORD KEY IS TS-KEY
+           FILE STATUS IS CUST-STAT .
+
+       DATA  DIVISION.
+       FILE SECTION.
+       FD  TSTFILE
+           BLOCK CONTAINS 5 RECORDS.
+
+       01  TSTFL-RECORD.
+           10  TS-KEY                          PICTURE 9(4).
+           10  TS-DATA                         PICTURE X(12).
+           10  TS-SEQ                          PICTURE 9(4).
+
+       WORKING-STORAGE SECTION.
+
+       01  CUST-STAT                           PICTURE XX.
+       01  I                                   PICTURE 9(4) BINARY.
+
+       PROCEDURE DIVISION.
+
+       MAINFILE.
+           OPEN OUTPUT TSTFILE
+           PERFORM VARYING I FROM 1 BY 1 UNTIL I > 5
+               MOVE I TO TS-KEY TS-SEQ
+               MOVE ALL 'X' TO TS-DATA
+               WRITE TSTFL-RECORD
+           END-PERFORM
+           CLOSE TSTFILE.
+
+       READFILE.
+           OPEN INPUT TSTFILE
+           PERFORM VARYING I FROM 1 BY 1 UNTIL I > 5
+               READ TSTFILE
+               DISPLAY CUST-STAT ': ' TSTFL-RECORD
+           END-PERFORM
+           CLOSE TSTFILE.
+           STOP RUN.
+])
+
+AT_DATA([cmod.c], [[
+#include <stdio.h>
+#include <libcob.h>
+
+static char *txtOpCode(int opCode);
+
+/*********************************************************
+ *  TSTFH - External File Handler entry point.
+ *  Simulates INDEXED read/write by LINE SEQUENTIAL
+*********************************************************/
+
+COB_EXT_EXPORT int
+TSTFH (unsigned char *opCodep, FCD3 *fcd)
+{
+   int rc;
+   unsigned char origOrg = fcd->fileOrg;
+   if (origOrg == ORG_INDEXED) fcd->fileOrg = ORG_LINE_SEQ;
+   rc = EXTFH(opCodep, fcd);
+   fcd->fileOrg = origOrg;
+   return rc;
+}
+]])
+
+AT_CHECK([$COMPILE -fcallfh=TSTFH prog.cob cmod.c], [0], [], [])
+
+AT_CHECK([$COBCRUN_DIRECT ./prog], [0],
+
+[00: 0001XXXXXXXXXXXX0001
+00: 0002XXXXXXXXXXXX0002
+00: 0003XXXXXXXXXXXX0003
+00: 0004XXXXXXXXXXXX0004
+00: 0005XXXXXXXXXXXX0005
+], [])
+
+AT_CLEANUP
+
+
 # This is, so far, only supported by the BDB backend
 AT_SETUP([INDEXED file under ASCII/EBCDIC collation])
 AT_KEYWORDS([runfile WRITE DELETE READ EBCDIC])

--- a/tests/testsuite.src/syn_file.at
+++ b/tests/testsuite.src/syn_file.at
@@ -1765,6 +1765,57 @@ prog.cob:15: error: PASSWORD 'PASS2' for EXTERNAL file 'file2' must have EXTERNA
 AT_CLEANUP
 
 
+AT_SETUP([INDEXED file without database])
+AT_KEYWORDS([EXTFH no-isam])
+
+# This test will be run only if the compiler was built
+# with the --without-db configuration option
+AT_SKIP_IF([test "$COB_HAS_ISAM" != "no"])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. prog.
+
+       ENVIRONMENT DIVISION.
+       INPUT-OUTPUT SECTION.
+       FILE-CONTROL.
+           SELECT TSTFILE
+           ASSIGN TO "testisam"
+           ORGANIZATION INDEXED
+           ACCESS SEQUENTIAL
+           RECORD KEY IS TS-KEY
+           FILE STATUS IS CUST-STAT.
+
+       DATA DIVISION.
+       FILE SECTION.
+       FD  TSTFILE.
+       01  TSTFL-RECORD.
+           10  TS-KEY                          PICTURE 9(4).
+           10  TS-DATA                         PICTURE X(12).
+
+       WORKING-STORAGE SECTION.
+       01  CUST-STAT                           PICTURE XX.
+
+       PROCEDURE DIVISION.
+       MAINFILE.
+           OPEN OUTPUT TSTFILE
+           MOVE 1 TO TS-KEY
+           MOVE ALL 'X' TO TS-DATA
+           WRITE TSTFL-RECORD
+           CLOSE TSTFILE.
+           STOP RUN.
+])
+
+AT_CHECK([$COMPILE_ONLY -Wunsupported -Werror prog.cob], [1], [],
+[prog.cob:17: error: runtime is not configured to support ORGANIZATION INDEXED; FD TSTFILE
+])
+
+# No error message is expected when INDEXED is used with an external file handler
+AT_CHECK([$COMPILE_ONLY -Wunsupported -Werror -fcallfh=TESTFH prog.cob], [0], [], [])
+
+AT_CLEANUP
+
+
 AT_SETUP([RECORD clause equal limits])
 AT_KEYWORDS([file])
 


### PR DESCRIPTION
## Summary
This change allows declaring files with ORG INDEXED even when no DB backend is present, provided a file-handler is supplied via callfh.

## Background
When the compiler has been configured using the `--without-db` configuration option, then compilation of a program that uses INDEXED files will produce the message `runtime is not configured to support ORGANIZATION INDEXED [-Werror=unsupported]`, and the compilation will fail if the `-Werror` option is in effect. However, if the compilation option `-fcallfh` is present, then a database backend is not needed because the indexed file will be handled by the specified external file handler, so the condition should not be flagged as an error or warning.

## Motivation
This change enables use-cases where an application or runtime provides the file handler (for example: wrapped file I/O, custom file-systems) and wants indexed access semantics without a DB layer.

## Compatibility
This change is backwards compatible for existing programs that rely on DB-backed indexed files; those still work unchanged.

## Tests & CI
New regression tests in `tests/testsuite.src/run_file.at` will:
- open an ORG INDEXED file using callfh with no DB available and exercise minimal read+write operations with the external file handler writing to and reading from an line-sequential file by changing the type and then using the EXTFH callback.
- test for the prior failure mode by attempting ORG INDEXED without DB and without callfh. The compile should still fail with an error.

A full run of the test suite / CI will confirm no regressions for DB-backed indexed files.