### PR TITLE
Change is_test in cob_is_test

### DIFF
--- a/libcob/ChangeLog
+++ b/libcob/ChangeLog
@@ -1,4 +1,9 @@
 
+2026-03-02  Fabrice Le Fessant <fabrice.le_fessant@ocamlpro.com>
+
+	* coblocal.h, common.c, profiling.c: rename is_test to cob_is_test
+	  as it is an external value.
+
 2025-12-04  Simon Sobisch <simonsobisch@gnu.org>
 
 	* fileio.c (indexed_open) [WITH_DB]: if open was successful but checking

--- a/libcob/coblocal.h
+++ b/libcob/coblocal.h
@@ -616,7 +616,7 @@ COB_HIDDEN int		cob_cmps	(const unsigned char *, const unsigned char *,
 COB_HIDDEN FILE *	cob_open_logfile (const char *filename);
 
 /* Whether we are in testsuite mode */
-COB_HIDDEN int is_test;
+COB_HIDDEN int cob_is_test;
 
 #undef	COB_HIDDEN
 

--- a/libcob/common.c
+++ b/libcob/common.c
@@ -398,7 +398,7 @@ COB_TLS struct sort_state	*share_sort_state = NULL;
 COB_TLS const char		*cob_source_file = NULL;
 COB_TLS unsigned int		cob_source_line = 0;
 
-int				is_test = 0;
+int				cob_is_test = 0;
 
 #ifdef	HAVE_DESIGNATED_INITS
 const char	*cob_statement_name[STMT_MAX_ENTRY] = {
@@ -7984,7 +7984,7 @@ cob_expand_env_string (const char *strval)
 			const char *s = NULL;
 		        switch ( strval[k+1] ){
 			case '$': /* Replace $$ with process-id */
-				if (is_test) {
+				if (cob_is_test) {
 					j += sprintf (&env[j], "%d", 123456);
 				} else {
 					j += sprintf (&env[j], "%d", cob_sys_getpid());
@@ -10414,7 +10414,7 @@ cob_init (const int argc, char **argv)
 
 	cob_initialized = 1;
 
-	is_test = !!getenv ("COB_IS_RUNNING_IN_TESTMODE");
+	cob_is_test = !!getenv ("COB_IS_RUNNING_IN_TESTMODE");
 
 #ifdef	HAVE_SETLOCALE
 	/* Prime the locale from user settings */

--- a/libcob/profiling.c
+++ b/libcob/profiling.c
@@ -87,7 +87,7 @@ static cob_ns_time
 get_ns_time (void)
 {
 	static cob_ns_time ns_time = 0;
-	if (is_test) {
+	if (cob_is_test) {
 		ns_time += 1000000;
 		return ns_time;
 	}
@@ -462,7 +462,7 @@ cob_prof_print_line (
 			case 'I':
 			case 'i':
 				if (info){
-					if (is_test){
+					if (cob_is_test){
 						fprintf (file, "%d", 123456);
 					} else {
 						fprintf (file, "%d", cob_sys_getpid());


### PR DESCRIPTION
Very small change to avoid conflicts, since this variable  `is_test` is external, it should be prefixed with `cob_`.