### PR TITLE
feat (parser): parse empty `CLASS-ID` paragraph with "unimplemented" warning

### DIFF
--- a/cobc/ChangeLog
+++ b/cobc/ChangeLog
@@ -1,3 +1,8 @@
+2026-04-08	Saurabh Kumar <developer.saurabh@outlook.com>
+
+	* scanner.l: add support for scanning class names and "END CLASS" token.
+	* parser.y, reserved.c (class_definition): support parsing an "empty" 
+	  CLASS-ID paragraph with no contained paragraphs and divisions.
 
 2025-12-29  Roger Bowler <rbowler@snipix.net>
 

--- a/cobc/ChangeLog
+++ b/cobc/ChangeLog
@@ -1,3 +1,4 @@
+
 2026-04-08	Saurabh Kumar <developer.saurabh@outlook.com>
 
 	* scanner.l: add support for scanning class names and "END CLASS" token.

--- a/cobc/parser.y
+++ b/cobc/parser.y
@@ -3911,9 +3911,23 @@ class_id_name:
 ;
 
 class_id_paragraph:
-  class_id_header TOK_DOT class_id_name _as_literal TOK_DOT
+  class_id_header TOK_DOT
   {
 	CB_PENDING ("CLASS-ID");
+  }
+  class_id_name _as_literal TOK_DOT
+  {
+	/* 
+	  TODO: The if block below is added for triggering
+	  a class redefinition error. This is not the correct
+	  way to do it since `current_program` is a dummy AST
+	  node here.
+	  Remove it when adding support for AST generation
+	  through `setup_program()`.
+	*/
+	if (CB_REFERENCE_P ($4)) {
+		cb_define ($4, CB_TREE (current_program));
+	}
 	cobc_in_id = 0;
   }
 ;

--- a/cobc/parser.y
+++ b/cobc/parser.y
@@ -2585,6 +2585,7 @@ set_record_size (cb_tree min, cb_tree max)
 %token CHARACTERS
 %token CHECK_BOX		"CHECK-BOX"
 %token CLASS
+%token CLASS_ID		"CLASS-ID"
 %token CLASSIFICATION
 %token CLASS_NAME		"class-name"
 %token CLEAR_SELECTION		"CLEAR-SELECTION"
@@ -2734,6 +2735,7 @@ set_record_size (cb_tree min, cb_tree max)
 %token END_MULTIPLY		"END-MULTIPLY"
 %token END_PERFORM		"END-PERFORM"
 %token END_PROGRAM		"END PROGRAM"
+%token END_CLASS		"END CLASS"
 %token END_READ			"END-READ"
 %token END_RECEIVE		"END-RECEIVE"
 %token END_RETURN		"END-RETURN"
@@ -3623,6 +3625,7 @@ source_element_list:
 
 source_element:
   program_definition
+| class_definition
 | function_definition
 | program_prototype
 | function_prototype
@@ -3649,6 +3652,13 @@ program_definition:
      The _end_program_list above is used for allowing an end marker
      in a program which contains a nested program.
   */
+;
+
+class_definition:
+  _identification_header
+  class_id_paragraph
+  /* TODO: _program_body */
+  end_class
 ;
 
 function_definition:
@@ -3683,6 +3693,21 @@ end_program:
 	first_nested_program = 0;
 	clean_up_program ($3, COB_MODULE_TYPE_PROGRAM);
   }
+;
+
+end_class:
+  END_CLASS
+  {
+	last_source_line = cb_source_line;
+	check_area_a_of ("END CLASS");
+  }
+  end_class_name _dot
+  /*
+	TODO
+  	{
+		clean_up_program ($3, COB_MODULE_TYPE_CLASS);
+  	}
+  */
 ;
 
 end_function:
@@ -3861,6 +3886,46 @@ _default_display_clause:
 	  /* TODO: setup_default_display ($3); */
   }
 ;
+
+/* CLASS */
+
+class_id_header:
+  CLASS_ID
+  {
+	cobc_in_id = 1;
+  }
+;
+
+class_id_name:
+  CLASS_NAME
+  {
+	if (CB_REFERENCE_P ($1) && CB_WORD_COUNT ($1) > 0) {
+		redefinition_error ($1);
+	}
+	$$ = $1;
+  }
+| LITERAL
+  {
+	cb_trim_program_id ($1);
+  }
+;
+
+class_id_paragraph:
+  class_id_header TOK_DOT class_id_name _as_literal TOK_DOT
+  {
+	CB_PENDING ("CLASS-ID");
+	cobc_in_id = 0;
+  }
+;
+
+end_class_name:
+  CLASS_NAME
+| LITERAL
+  {
+	cb_trim_program_id ($1);
+  }
+;
+
 
 /* PROGRAM body */
 

--- a/cobc/reserved.c
+++ b/cobc/reserved.c
@@ -636,7 +636,7 @@ static struct cobc_reserved default_reserved_words[] = {
   { "CLASS",			0, 0, CLASS,			/* 2002 */
 				0, 0
   },
-  { "CLASS-ID",			0, 0, -1,			/* 2002 */
+  { "CLASS-ID",			0, 0, CLASS_ID,			/* 2002 */
 				0, 0
   },
   { "CLASSIFICATION",		0, 1, CLASSIFICATION,		/* 2002 (C/S) */

--- a/cobc/scanner.l
+++ b/cobc/scanner.l
@@ -656,6 +656,11 @@ H#[0-9A-Za-z]+ {
 	RETURN_TOK (END_FUNCTION);
 }
 
+"END"[ ,;\n]+"CLASS"/[ .,;\n] {
+	count_lines (yytext);
+	RETURN_TOK (END_CLASS);
+}
+
 "PICTURE"[ ,;\n]+"SYMBOL"/[ .,;\n] {
 	if (lookup_reserved_word ("SYMBOL")) {
 		count_lines (yytext);
@@ -1044,8 +1049,10 @@ H#[0-9A-Za-z]+ {
 	/* Bail early for (END) PROGRAM-ID when not a literal */
 	if  ((second_last_token == PROGRAM_ID  && last_token == TOK_DOT)
 	  || (second_last_token == FUNCTION_ID && last_token == TOK_DOT)
+	  || (second_last_token == CLASS_ID && last_token == TOK_DOT)
 	  ||  last_token == END_PROGRAM
-	  ||  last_token == END_FUNCTION) {
+	  ||  last_token == END_FUNCTION
+	  ||  last_token == END_CLASS) {
 		/* Force PROGRAM-ID / END PROGRAM */
 		if (cb_fold_call) {
 			yylval = cb_build_reference (yytext);

--- a/cobc/scanner.l
+++ b/cobc/scanner.l
@@ -1049,10 +1049,8 @@ H#[0-9A-Za-z]+ {
 	/* Bail early for (END) PROGRAM-ID when not a literal */
 	if  ((second_last_token == PROGRAM_ID  && last_token == TOK_DOT)
 	  || (second_last_token == FUNCTION_ID && last_token == TOK_DOT)
-	  || (second_last_token == CLASS_ID && last_token == TOK_DOT)
 	  ||  last_token == END_PROGRAM
-	  ||  last_token == END_FUNCTION
-	  ||  last_token == END_CLASS) {
+	  ||  last_token == END_FUNCTION) {
 		/* Force PROGRAM-ID / END PROGRAM */
 		if (cb_fold_call) {
 			yylval = cb_build_reference (yytext);
@@ -1061,6 +1059,10 @@ H#[0-9A-Za-z]+ {
 			yylval = cb_build_alphanumeric_literal (yytext, (size_t)yyleng);
 			RETURN_TOK (LITERAL);
 		}
+	} else if ((second_last_token == CLASS_ID && last_token == TOK_DOT) 
+		     || last_token == END_CLASS) {
+		yylval = cb_build_reference (yytext);
+		RETURN_TOK (CLASS_NAME);
 	}
 
 	/* Check reserved word */

--- a/tests/ChangeLog
+++ b/tests/ChangeLog
@@ -1,4 +1,9 @@
 
+2026-05-06	Saurabh Kumar <developer.saurabh@outlook.com>
+
+	* testsuite.at, Makefile.am, testsuite.src/syn_oo.at: new syntax checks for 
+	  object-orientation constructs 
+
 2025-12-04  Simon Sobisch <simonsobisch@gnu.org>
 
 	* atlocal.in: reordered to correctly use perf/valgrind definitions also

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -38,6 +38,7 @@ testsuite_sources = \
 	testsuite.src/syn_move.at \
 	testsuite.src/syn_multiply.at \
 	testsuite.src/syn_occurs.at \
+	testsuite.src/syn_oo.at \
 	testsuite.src/syn_redefines.at \
 	testsuite.src/syn_refmod.at \
 	testsuite.src/syn_reportwriter.at \

--- a/tests/testsuite.at
+++ b/tests/testsuite.at
@@ -52,6 +52,7 @@ m4_include([syn_screen.at])		# 13.9 SCREEN section
 m4_include([syn_set.at])		# 14.8.35 SET statement
 m4_include([syn_functions.at])		# 15 Intrinsic functions
 m4_include([syn_literals.at])		# syntax checks on literals
+m4_include([syn_oo.at])         # syntax checks for object-orientation constructs
 
 ## Listings tests
 AT_BANNER([Listing tests])

--- a/tests/testsuite.src/syn_definition.at
+++ b/tests/testsuite.src/syn_definition.at
@@ -1276,7 +1276,7 @@ AT_DATA([prog.cob], [
 ])
 
 AT_CHECK([$COMPILE_ONLY prog.cob], [1], [],
-[prog.cob:3: error: syntax error, unexpected IDENTIFICATION, expecting FUNCTION-ID or PROGRAM-ID
+[prog.cob:3: error: syntax error, unexpected IDENTIFICATION, expecting CLASS-ID or FUNCTION-ID or PROGRAM-ID
 ])
 AT_CLEANUP
 

--- a/tests/testsuite.src/syn_oo.at
+++ b/tests/testsuite.src/syn_oo.at
@@ -1,5 +1,5 @@
-## Copyright (C) 2003-2012, 2016-2026 Free Software Foundation, Inc.
-## Written by Keisuke Nishida, Roger While, Edward Hart, Simon Sobisch
+## Copyright (C) 2026 Free Software Foundation, Inc.
+## Written by Saurabh Kumar
 ##
 ## This file is part of GnuCOBOL.
 ##
@@ -26,12 +26,62 @@ AT_KEYWORDS([CLASS-ID])
 
 AT_DATA([prog.cob], [
         IDENTIFICATION DIVISION.
-        
+        CLASS-ID. MyClass.
+        END CLASS MyClass.
+
+        CLASS-ID. MySecondClass AS "MyClass".
+        END CLASS MySecondClass.
+])
+
+AT_CHECK([$COMPILE_ONLY prog.cob], [0], [],
+[prog.cob:3: warning: CLASS-ID is not implemented
+prog.cob:6: warning: CLASS-ID is not implemented
+])
+AT_CLEANUP
+
+AT_SETUP([CLASS-ID Syntax Error Check])
+AT_KEYWORDS([CLASS-ID])
+
+AT_DATA([prog1.cob], [
+        IDENTIFICATION DIVISION.
+        CLASS-ID. MyClass.
+        END CLASS.
+])
+
+AT_CHECK([$COMPILE_ONLY prog1.cob], [1], [],
+[prog1.cob:3: warning: CLASS-ID is not implemented 
+prog1.cob:4: error: syntax error, unexpected ., expecting class-name or Literal
+])
+
+AT_DATA([prog2.cob], [
+        IDENTIFICATION DIVISION.
+        CLASS-ID. MyClass.
+        END PROGRAM MyClass.
+])
+
+AT_CHECK([$COMPILE_ONLY prog2.cob], [1], [],
+[prog2.cob:3: warning: CLASS-ID is not implemented
+prog2.cob:4: error: syntax error, unexpected END PROGRAM, expecting END CLASS
+])
+
+AT_CLEANUP
+
+AT_SETUP([Redefinition of class])
+AT_KEYWORDS([CLASS-ID])
+
+AT_DATA([prog.cob], [
+        IDENTIFICATION DIVISION.
+        CLASS-ID. MyClass.
+        END CLASS MyClass.
+
         CLASS-ID. MyClass.
         END CLASS MyClass.
 ])
 
-AT_CHECK([$COBC -fdiagnostics-plain-output -fsyntax-only prog.cob], [0], [],
-[prog.cob:4: warning: CLASS-ID is not implemented [[-Wpending]]
+AT_CHECK([$COMPILE_ONLY prog.cob], [1], [],
+[prog.cob:3: warning: CLASS-ID is not implemented
+prog.cob:6: warning: CLASS-ID is not implemented
+prog.cob:6: error: redefinition of 'MyClass'
+prog.cob:3: note: 'MyClass' previously defined here
 ])
 AT_CLEANUP

--- a/tests/testsuite.src/syn_oo.at
+++ b/tests/testsuite.src/syn_oo.at
@@ -1,0 +1,37 @@
+## Copyright (C) 2003-2012, 2016-2026 Free Software Foundation, Inc.
+## Written by Keisuke Nishida, Roger While, Edward Hart, Simon Sobisch
+##
+## This file is part of GnuCOBOL.
+##
+## The GnuCOBOL compiler is free software: you can redistribute it
+## and/or modify it under the terms of the GNU General Public License
+## as published by the Free Software Foundation, either version 3 of the
+## License, or (at your option) any later version.
+##
+## GnuCOBOL is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with GnuCOBOL.  If not, see <https://www.gnu.org/licenses/>.
+
+### GnuCOBOL Test Suite
+
+### Syntax tests for object-orientation constructs
+
+
+AT_SETUP([CLASS-ID Syntax Check])
+AT_KEYWORDS([CLASS-ID])
+
+AT_DATA([prog.cob], [
+        IDENTIFICATION DIVISION.
+        
+        CLASS-ID. MyClass.
+        END CLASS MyClass.
+])
+
+AT_CHECK([$COBC -fdiagnostics-plain-output -fsyntax-only prog.cob], [0], [],
+[prog.cob:4: warning: CLASS-ID is not implemented [[-Wpending]]
+])
+AT_CLEANUP


### PR DESCRIPTION
* Add support for parsing an "empty" `CLASS-ID` paragraph with no contained paragraphs and divisions.  
* Emit a "unimplemented" warning and exit.