### PR TITLE
feat (parser): add parsing support for all class attributes with "unimplemented" warning

### DIFF
--- a/cobc/ChangeLog
+++ b/cobc/ChangeLog
@@ -1,4 +1,13 @@
 
+2026-06-11	Saurabh Kumar <developer.saurabh@outlook.com>
+
+	* parser.y, reserved.c: add support for parsing class attributes - AS literal,
+	  IS FINAL, INHERITS FROM {class-name ...}, USING {param-name ...}
+	  with unimplemented warning; also support MF extensions IS STATIC, IS ABSTRACT,
+	  IS PARTIAL, IS PUBLIC, IS INTERNAL
+	* tree.h, common.h: add COB_MODULE_TYPE_CLASS and bit masks for all 
+	  object-oriented class attributes
+
 2026-06-08  Nicolas Berthier <nicolas.berthier@ocamlpro.com>
 
 	* tree.h, parser.y: change type of cobc_cs_check flags to permit

--- a/cobc/parser.y
+++ b/cobc/parser.y
@@ -123,6 +123,7 @@
 #define	EVAL_DEPTH		32
 #define	PROG_DEPTH		16
 
+
 /* Global variables */
 
 struct cb_program		*current_program = NULL;    /* program in parse/syntax check/codegen */
@@ -1287,10 +1288,17 @@ begin_scope_of_program_name (struct cb_program *program)
 				    elt_name);
 			return;
 		} else if (strcmp (prog_id, elt_id) == 0) {
-			cb_error_x (CB_TREE(program),
-				    _("redefinition of program ID '%s'"),
-				    elt_id);
-			return;
+			if (program->prog_type == COB_MODULE_TYPE_PROGRAM) {
+				cb_error_x (CB_TREE(program),
+						_("redefinition of program ID '%s'"),
+						elt_id);
+				return;
+			} else if (program->prog_type == COB_MODULE_TYPE_CLASS) {
+				cb_error_x (CB_TREE(program),
+						_("redefinition of class ID '%s'"),
+						elt_id);
+				return;
+			}
 		}
 	}
 
@@ -1471,7 +1479,7 @@ setup_program (cb_tree id, cb_tree as_literal, const enum cob_module_type type, 
 			main_flag_set = 1;
 			current_program->flag_main = !!cobc_flag_main;
 		}
-	} else { /* COB_MODULE_TYPE_FUNCTION */
+	} else if (type == COB_MODULE_TYPE_FUNCTION) {
 		current_program->flag_recursive = 1;
 	}
 
@@ -1515,8 +1523,13 @@ decrement_depth (const char *name, const unsigned char type)
 	}
 
 	if (depth != d) {
-		cb_error (_("END PROGRAM '%s' is different from PROGRAM-ID '%s'"),
-			  name, stack_progid[depth]);
+		if (type == COB_MODULE_TYPE_PROGRAM) {
+			cb_error (_("END PROGRAM '%s' is different from PROGRAM-ID '%s'"),
+				  name, stack_progid[depth]);
+		} else if (type == COB_MODULE_TYPE_CLASS) {
+			cb_error (_("END CLASS '%s' is different from CLASS-ID '%s'"),
+				  name, stack_progid[depth]);
+		}
 	}
 }
 
@@ -2548,12 +2561,24 @@ set_record_size (cb_tree min, cb_tree max)
 	}
 }
 
+/* Object-oriented class */
+
+static COB_INLINE void
+set_oo_class_attr(enum cb_oo_class_attribute attr, const char* attr_name)
+{
+	if (current_program->oo_class_attributes & attr) {							
+		emit_duplicate_clause_message (attr_name);						
+	}	
+	current_program->oo_class_attributes |= attr;
+}
+
 %}
 
 %token TOKEN_EOF 0 "end of file"
 
 %token THREEDIMENSIONAL	"3D"
 %token ABSENT
+%token ABSTRACT
 %token ACCEPT
 %token ACCESS
 %token ACTIVEX			"ACTIVE-X"
@@ -2970,6 +2995,7 @@ set_record_size (cb_tree min, cb_tree max)
 %token INDEX
 %token INDEXED
 %token INDICATE
+%token INHERITS
 %token INITIALIZE
 %token INITIALIZED
 %token INITIATE
@@ -2981,6 +3007,7 @@ set_record_size (cb_tree min, cb_tree max)
 %token INSPECT
 %token INSTALLATION		/* remark: not used here */
 %token INTERMEDIATE
+%token INTERNAL
 %token INTO
 %token INTRINSIC
 %token INVALID			/* remark: not used here */
@@ -3167,6 +3194,7 @@ set_record_size (cb_tree min, cb_tree max)
 %token PARAGRAPH
 %token PARENT
 %token PARSE
+%token PARTIAL
 %token PASSWORD
 %token PERFORM
 %token PERMANENT
@@ -3209,6 +3237,7 @@ set_record_size (cb_tree min, cb_tree max)
 %token PROPERTY
 %token PROTECTED
 %token PROTOTYPE
+%token PUBLIC
 %token PURGE
 %token PUSH_BUTTON		"PUSH-BUTTON"
 %token QUERY_INDEX		"QUERY-INDEX"
@@ -3793,12 +3822,10 @@ end_class:
 	check_area_a_of ("END CLASS");
   }
   end_class_name _dot
-  /*
-	TODO
-  	{
-		clean_up_program ($3, COB_MODULE_TYPE_CLASS);
-  	}
-  */
+  {
+	clean_up_program ($3, COB_MODULE_TYPE_CLASS);
+  }
+
 ;
 
 end_function:
@@ -3985,38 +4012,94 @@ class_id_header:
 ;
 
 class_id_name:
-  CLASS_NAME
-  {
-	if (CB_REFERENCE_P ($1) && CB_WORD_COUNT ($1) > 0) {
-		redefinition_error ($1);
-	}
-	$$ = $1;
-  }
+  CLASS_NAME	{ $$ = $1; }
 | LITERAL
   {
 	cb_trim_program_id ($1);
   }
 ;
 
-class_id_paragraph:
-  class_id_header TOK_DOT
+parent_class_name: 
+  WORD
   {
-	CB_PENDING ("CLASS-ID");
+  	current_program->class_inheritance_list = 
+		cb_list_add(current_program->class_inheritance_list, $1);
   }
-  class_id_name _as_literal TOK_DOT
+;
+
+parent_class_name_list:
+  parent_class_name
+| parent_class_name_list parent_class_name
+;
+
+/* Parameterized classes not supported for now. */
+class_param_list:
+  WORD
+| class_param_list WORD
+;
+
+_inherits_phrase:
+  /* empty */
+| INHERITS _from parent_class_name_list
+;
+
+_using_phrase:
+  /* empty */
+| USING class_param_list
+;
+
+class_attribute:
+  _is STATIC		{ set_oo_class_attr(CB_OO_CLASS_ATTR_STATIC, "STATIC"); }
+| _is PARTIAL		{ set_oo_class_attr(CB_OO_CLASS_ATTR_PARTIAL, "PARTIAL"); }
+| _is FINAL			{ set_oo_class_attr(CB_OO_CLASS_ATTR_FINAL, "FINAL"); }
+| _is ABSTRACT		{ set_oo_class_attr(CB_OO_CLASS_ATTR_ABSTRACT, "ABSTRACT"); }
+| _is PUBLIC		{ set_oo_class_attr(CB_OO_CLASS_ATTR_PUBLIC, "PUBLIC"); }
+| _is INTERNAL		{ set_oo_class_attr(CB_OO_CLASS_ATTR_INTERNAL, "INTERNAL"); }
+;
+
+_class_attributes:
+  /* empty */		{ current_program->oo_class_attributes = CB_OO_CLASS_ATTR_NONE; }
+| _class_attributes class_attribute
+;
+
+/*
+ * CLASS-ID paragraph syntax is:
+ *
+ * CLASS-ID. object-class-name-1 [ AS literal-1 ] [ IS STATIC ]
+ * [ IS { PARTIAL, FINAL, ABSTRACT } ... ] [ IS { PUBLIC, INTERNAL } ]
+ * [ INHERITS FROM { object-class-name-2 } ... ]
+ * [ USING { parameter-name-1 } ... ] .
+ * 
+*/
+
+class_id_paragraph:
+  class_id_header TOK_DOT class_id_name _as_literal
   {
-	/* 
-	  TODO: The if block below is added for triggering
-	  a class redefinition error. This is not the correct
-	  way to do it since `current_program` is a dummy AST
-	  node here.
-	  Remove it when adding support for AST generation
-	  through `setup_program()`.
-	*/
-	if (CB_REFERENCE_P ($4)) {
-		cb_define ($4, CB_TREE (current_program));
+	if (setup_program ($3, $4, COB_MODULE_TYPE_CLASS, 1)) {
+		YYABORT;
 	}
+
+	__CS_CLEAR_ALL();
 	cobc_in_id = 0;
+
+	CB_UNSUPPORTED ("object-oriented COBOL");
+  }
+  _inherits_phrase
+  _class_attributes
+  _using_phrase
+  TOK_DOT
+  {
+	/* check consistency of current attribues */
+	if (current_program->oo_class_attributes & CB_OO_CLASS_ATTR_FINAL
+	 && current_program->oo_class_attributes & CB_OO_CLASS_ATTR_ABSTRACT) {
+		emit_conflicting_clause_message ("FINAL", "ABSTRACT");
+		current_program->oo_class_attributes &= ~CB_OO_CLASS_ATTR_FINAL;
+	}
+	if (current_program->oo_class_attributes & CB_OO_CLASS_ATTR_INTERNAL
+	 && current_program->oo_class_attributes & CB_OO_CLASS_ATTR_PUBLIC) {
+		emit_conflicting_clause_message ("INTERNAL", "PUBLIC");
+		current_program->oo_class_attributes &= ~CB_OO_CLASS_ATTR_INTERNAL;
+	}
   }
 ;
 

--- a/cobc/reserved.c
+++ b/cobc/reserved.c
@@ -253,6 +253,9 @@ static struct cobc_reserved default_reserved_words[] = {
   { "ABSENT",			0, 0, ABSENT,			/* IBM RW */
 				0, 0
   },
+  { "ABSTRACT",			0, 0, ABSTRACT,			/* MF extension */
+				0, 0
+  },
   { "ACCEPT",			1, 0, ACCEPT,			/* 2002 */
 				CB_CS_ACCEPT, 0
   },
@@ -1578,7 +1581,7 @@ static struct cobc_reserved default_reserved_words[] = {
   { "INDICATE",			0, 0, INDICATE,			/* 2002 */
 				0, 0
   },
-  { "INHERITS",			0, 0, -1,			/* 2002 */
+  { "INHERITS",			0, 0, INHERITS,			/* 2002 */
 				0, 0
   },
   { "INITIAL",			0, 0, TOK_INITIAL,		/* 2002 */
@@ -1622,6 +1625,9 @@ static struct cobc_reserved default_reserved_words[] = {
   },
   { "INTERMEDIATE",		0, 1, INTERMEDIATE,		/* 2014 (C/S) */
 				0, CB_CS_OPTIONS
+  },
+  { "INTERNAL",		0, 0, INTERNAL,		/* MF extension */
+				0, 0
   },
   { "INTO",			0, 0, INTO,			/* 2002 */
 				0, 0
@@ -2155,6 +2161,9 @@ static struct cobc_reserved default_reserved_words[] = {
   { "PARSE",			0, 1, PARSE,			/* IBM extension */
    				0, 0
   },
+  { "PARTIAL",			0, 0, PARTIAL,			/* MF extension */
+				0, 0
+  },
   { "PASCAL",			0, 1, PASCAL,			/* Extension: implicit defined CALL-CONVENTION */
 				0, CB_CS_CALL_CONVENTION | CB_CS_OPTIONS
   },
@@ -2285,6 +2294,9 @@ static struct cobc_reserved default_reserved_words[] = {
 				0, CB_CS_ACCEPT
   },
   { "PROTOTYPE",		0, 0, PROTOTYPE,			/* 2002 */
+				0, 0
+  },
+  { "PUBLIC",			0, 0, PUBLIC,			/* MF extension */
 				0, 0
   },
   { "PURGE",			0, 0, PURGE,			/* Communication Section */

--- a/cobc/tree.h
+++ b/cobc/tree.h
@@ -514,6 +514,18 @@ enum cb_index_type {
 	CB_STATIC_INT_VARYING
 };
 
+/* Object-oriented class attributes */
+enum cb_oo_class_attribute {
+	CB_OO_CLASS_ATTR_NONE			= 0x00, 	/* No attribute specified */
+	CB_OO_CLASS_ATTR_FINAL			= 0x01,		/* Cannot be subclassed */
+	CB_OO_CLASS_ATTR_ABSTRACT		= 0x02,		/* Can be subclassed, but not instantiated */
+	CB_OO_CLASS_ATTR_PARTIAL		= 0x04,
+	CB_OO_CLASS_ATTR_STATIC			= 0x08,		/* All methods must be marked STATIC */
+	CB_OO_CLASS_ATTR_PUBLIC			= 0x10,
+	CB_OO_CLASS_ATTR_INTERNAL		= 0x20
+};
+
+
 /* Reserved word list structure */
 struct cobc_reserved {
 	const char	*name;		/* Word */
@@ -1863,6 +1875,7 @@ struct cb_program {
 	cb_tree			user_spec_list;		/* User FUNCTION spec */
 	cb_tree			program_spec_list;	/* PROGRAM spec */
 	cb_tree			property_spec_list;	/* PROPERTY spec */
+	cb_tree			class_inheritance_list;	/* List of Inherited Classes (OOP) */
 	struct cb_alter_id	*alter_gotos;		/* ALTER ids */
 	struct cb_field		*working_storage;	/* WORKING-STORAGE */
 	struct cb_field		*local_storage;		/* LOCAL-STORAGE */
@@ -1913,7 +1926,8 @@ struct cb_program {
 	cob_u8_t	high_value;			/* High-value for this program */
 	cob_u16_t	low_value_n;			/* National Low-value */
 	cob_u16_t	high_value_n;			/* National High-value  */
-	enum cob_module_type	prog_type;			/* Program type (program = 0, function = 1) */
+	enum cob_module_type	prog_type;			/* Program type (program = 0, function = 1, OO class = 2) */
+	cob_u8_t 	oo_class_attributes;			/* OO class attributes */
 	cb_tree			entry_convention;	/* ENTRY convention / PROCEDURE convention */
 	struct literal_list	*decimal_constants;
 

--- a/libcob/common.h
+++ b/libcob/common.h
@@ -1251,7 +1251,8 @@ typedef struct __cob_screen {
 /* Module structure */
 enum cob_module_type {
 	COB_MODULE_TYPE_PROGRAM		= 0,
-	COB_MODULE_TYPE_FUNCTION	= 1
+	COB_MODULE_TYPE_FUNCTION	= 1,
+	COB_MODULE_TYPE_CLASS		= 2
 };
 
 /*

--- a/tests/testsuite.src/run_misc.at
+++ b/tests/testsuite.src/run_misc.at
@@ -7334,10 +7334,10 @@ AT_DATA([callee2.cob], [
                                  .
            EXIT PROGRAM.
 ])
-
-AT_CHECK([$COMPILE_MODULE -fnot-reserved=double,float,new,volatile,xor callee.cob], [0], [], [])
-AT_CHECK([$COMPILE_MODULE -fnot-reserved=double,float,new,volatile,xor callee2.cob], [0], [], [])
-AT_CHECK([$COMPILE -fnot-reserved=double,float,new,volatile,xor -o prog caller.cob], [0], [], [])
+ 
+AT_CHECK([$COMPILE_MODULE -fnot-reserved=double,float,new,volatile,xor,public callee.cob], [0], [], [])
+AT_CHECK([$COMPILE_MODULE -fnot-reserved=double,float,new,volatile,xor,public callee2.cob], [0], [], [])
+AT_CHECK([$COMPILE -fnot-reserved=double,float,new,volatile,xor,public -o prog caller.cob], [0], [], [])
 AT_CHECK([$COBCRUN_DIRECT ./prog], [0], [], [])
 
 AT_CLEANUP

--- a/tests/testsuite.src/syn_oo.at
+++ b/tests/testsuite.src/syn_oo.at
@@ -22,34 +22,35 @@
 
 
 AT_SETUP([CLASS-ID Syntax Check])
-AT_KEYWORDS([CLASS-ID])
+AT_KEYWORDS([OOP])
 
 AT_DATA([prog.cob], [
         IDENTIFICATION DIVISION.
         CLASS-ID. MyClass.
         END CLASS MyClass.
 
-        CLASS-ID. MySecondClass AS "MyClass".
+        CLASS-ID. MySecondClass AS "MySecondClass".
         END CLASS MySecondClass.
 ])
 
-AT_CHECK([$COMPILE_ONLY prog.cob], [0], [],
-[prog.cob:3: warning: CLASS-ID is not implemented
-prog.cob:6: warning: CLASS-ID is not implemented
+AT_CHECK([$COMPILE_ONLY prog.cob], [1], [],
+[prog.cob:3: error: object-oriented COBOL is not supported
+prog.cob:6: error: object-oriented COBOL is not supported
 ])
 AT_CLEANUP
 
+
 AT_SETUP([CLASS-ID Syntax Error Check])
-AT_KEYWORDS([CLASS-ID])
+AT_KEYWORDS([OOP])
 
 AT_DATA([prog1.cob], [
         IDENTIFICATION DIVISION.
-        CLASS-ID. MyClass.
+        CLASS-ID. MyFirstClass.
         END CLASS.
 ])
 
 AT_CHECK([$COMPILE_ONLY prog1.cob], [1], [],
-[prog1.cob:3: warning: CLASS-ID is not implemented 
+[prog1.cob:3: error: object-oriented COBOL is not supported 
 prog1.cob:4: error: syntax error, unexpected ., expecting class-name or Literal
 ])
 
@@ -60,14 +61,26 @@ AT_DATA([prog2.cob], [
 ])
 
 AT_CHECK([$COMPILE_ONLY prog2.cob], [1], [],
-[prog2.cob:3: warning: CLASS-ID is not implemented
+[prog2.cob:3: error: object-oriented COBOL is not supported
 prog2.cob:4: error: syntax error, unexpected END PROGRAM, expecting END CLASS
+])
+
+AT_DATA([prog3.cob], [
+        IDENTIFICATION DIVISION.
+        CLASS-ID. MyFirstClass.
+        END CLASS MyClass.
+])
+
+AT_CHECK([$COMPILE_ONLY prog3.cob], [1], [],
+[prog3.cob:3: error: object-oriented COBOL is not supported
+prog3.cob:4: error: END CLASS 'MyClass' is different from CLASS-ID 'MyFirstClass'
 ])
 
 AT_CLEANUP
 
-AT_SETUP([Redefinition of class])
-AT_KEYWORDS([CLASS-ID])
+
+AT_SETUP([Redefinition of CLASS-ID])
+AT_KEYWORDS([OOP])
 
 AT_DATA([prog.cob], [
         IDENTIFICATION DIVISION.
@@ -79,9 +92,161 @@ AT_DATA([prog.cob], [
 ])
 
 AT_CHECK([$COMPILE_ONLY prog.cob], [1], [],
-[prog.cob:3: warning: CLASS-ID is not implemented
-prog.cob:6: warning: CLASS-ID is not implemented
-prog.cob:6: error: redefinition of 'MyClass'
-prog.cob:3: note: 'MyClass' previously defined here
+[prog.cob:3: error: object-oriented COBOL is not supported
+prog.cob:6: error: redefinition of class ID 'MyClass'
+prog.cob:6: error: object-oriented COBOL is not supported
+])
+AT_CLEANUP
+
+
+AT_SETUP([CLASS-ID Attribute Check - INHERITS FROM and USING])
+AT_KEYWORDS([OOP])
+
+AT_DATA([prog.cob], [
+        IDENTIFICATION DIVISION.
+        CLASS-ID. Account.
+        END CLASS Account.
+
+        CLASS-ID. DematAccount.
+        END CLASS DematAccount.
+        
+        CLASS-ID. SavingsAccount INHERITS FROM Account.
+        END CLASS SavingsAccount.
+
+        *> Skips optional FROM keyword for INHERITS attribute
+        CLASS-ID. MinorSavingsAccount INHERITS SavingsAccount.
+        END CLASS MinorSavingsAccount.
+
+        CLASS-ID. MultiPurposeAccount INHERITS
+                  FROM Account DematAccount.
+        END CLASS MultiPurposeAccount.
+
+        CLASS-ID. MyAccount USING startingBalance.
+        END CLASS MyAccount.
+])
+
+AT_CHECK([$COMPILE_ONLY prog.cob], [1], [],
+[prog.cob:3: error: object-oriented COBOL is not supported
+prog.cob:6: error: object-oriented COBOL is not supported
+prog.cob:9: error: object-oriented COBOL is not supported
+prog.cob:13: error: object-oriented COBOL is not supported
+prog.cob:16: error: object-oriented COBOL is not supported
+prog.cob:20: error: object-oriented COBOL is not supported
+])
+AT_CLEANUP
+
+
+AT_SETUP([CLASS-ID Attribute Check - Multiple attributes together])
+AT_KEYWORDS([OOP])
+
+AT_DATA([prog.cob], [
+        IDENTIFICATION DIVISION.
+        CLASS-ID. MySuperClass.
+        END CLASS MySuperClass.
+        
+        CLASS-ID. MyFirstClass INHERITS 
+                  FROM MySuperClass IS FINAL.
+        END CLASS MyFirstClass.
+
+        CLASS-ID. MySecondClass AS "MySecondClass" 
+                  IS FINAL.
+        END CLASS MySecondClass.
+
+        CLASS-ID. MyThirdClass 
+                  INHERITS FROM MySuperClass
+                  USING param-name.
+        END CLASS MyThirdClass.
+
+        *> Skips optional IS keyword for FINAL attribute
+        CLASS-ID. MyFourthClass AS "MyFourthClass"
+                  FINAL USING param-name.
+        END CLASS MyFourthClass.
+])
+
+AT_CHECK([$COMPILE_ONLY prog.cob], [1], [],
+[prog.cob:3: error: object-oriented COBOL is not supported
+prog.cob:6: error: object-oriented COBOL is not supported
+prog.cob:10: error: object-oriented COBOL is not supported
+prog.cob:15: error: object-oriented COBOL is not supported
+prog.cob:20: error: object-oriented COBOL is not supported
+])
+AT_CLEANUP
+
+
+AT_SETUP([CLASS-ID Attribute Check - FINAL, ABSTRACT, PARTIAL, PUBLIC, INTERNAL])
+AT_KEYWORDS([OOP])
+
+AT_DATA([prog.cob], [
+        IDENTIFICATION DIVISION.
+        CLASS-ID. Account IS ABSTRACT.
+        END CLASS Account.
+
+        CLASS-ID. DematAccount INHERITS Account
+                  ABSTRACT
+                  IS PUBLIC.
+        END CLASS DematAccount.
+        
+        CLASS-ID. SavingsAccount 
+                  INHERITS FROM Account
+                  FINAL.
+        END CLASS SavingsAccount.
+
+        CLASS-ID. MinorSavingsAccount
+                  INHERITS SavingsAccount
+                  IS INTERNAL.
+        END CLASS MinorSavingsAccount.
+
+        CLASS-ID. MultiPurposeAccount 
+                  INHERITS Account DematAccount
+                  PARTIAL.
+        END CLASS MultiPurposeAccount.
+])
+
+AT_CHECK([$COMPILE_ONLY prog.cob], [1], [],
+[prog.cob:3: error: object-oriented COBOL is not supported
+prog.cob:6: error: object-oriented COBOL is not supported
+prog.cob:12: error: object-oriented COBOL is not supported
+prog.cob:17: error: object-oriented COBOL is not supported
+prog.cob:22: error: object-oriented COBOL is not supported
+])
+AT_CLEANUP
+
+AT_SETUP([CLASS-ID Attribute Error Check])
+AT_KEYWORDS([OOP])
+
+AT_DATA([prog.cob], [
+        IDENTIFICATION DIVISION.
+        CLASS-ID. Account IS FINAL
+                  FINAL.
+        END CLASS Account.
+
+        CLASS-ID. DematAccount INHERITS Account
+                  ABSTRACT
+                  IS PUBLIC
+                  INTERNAL.
+        END CLASS DematAccount.
+        
+        CLASS-ID. SavingsAccount 
+                  INHERITS FROM Account
+                  FINAL
+                  IS ABSTRACT.
+        END CLASS SavingsAccount.
+
+        CLASS-ID. MultiPurposeAccount 
+                  INHERITS Account DematAccount
+                  PARTIAL
+                  IS PARTIAL.
+        END CLASS MultiPurposeAccount.
+])
+
+AT_CHECK([$COMPILE_ONLY prog.cob], [1], [],
+[prog.cob:3: error: object-oriented COBOL is not supported
+prog.cob:4: error: duplicate FINAL clause
+prog.cob:7: error: object-oriented COBOL is not supported
+prog.cob:10: error: cannot specify both INTERNAL and PUBLIC
+prog.cob:14: error: object-oriented COBOL is not supported
+prog.cob:16: error: cannot specify both FINAL and ABSTRACT
+prog.cob:20: error: object-oriented COBOL is not supported
+prog.cob:22: error: duplicate PARTIAL clause
 ])
 AT_CLEANUP


### PR DESCRIPTION
Adds support for the following class attributes:

* AS literal
* IS FINAL
* INHERITS FROM {class-name ...}
* USING {param-name ...}

Also support MF extensions IS STATIC, IS ABSTRACT, IS PARTIAL,
IS PUBLIC, IS INTERNAL.

MF docs: https://docs.rocketsoftware.com/de-DE/bundle/visualcoboldevhub_ug_110/page/pho1742953034730.html