### PR TITLE
Config option tab-width can receive a list of comma-separated widths

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -107,6 +107,10 @@ NEWS - user visible changes				-*- outline -*-
 ** New option --gentable to build EBCDIC/ASCII translation tables,
    for use with -febcdic-table
 
+** Option -ftab-width can now receive a list of comma-separated widths,
+   such as "6,1,4", indicating the width of each tabulation, the last one
+   being reused for all the next ones
+
 * Listing changes
 
 ** the listing header shows the processed file's basename to prevent

--- a/cobc/ChangeLog
+++ b/cobc/ChangeLog
@@ -1,4 +1,16 @@
 
+2026-05-24  Fabrice Le Fessant <fabrice.le_fessant@ocamlpro.com>
+
+	* config.def: "tab-width" option is changed to a comma-separated
+	  list of tab widths, for example "6,1,4", the last one being reused.
+	  This new meaning is backward compatible.
+	  Implements FR #498 " Adjust tab-width to optionally be a list of
+	  tab-stop positions"
+	* config.c: initialize cb_tab_width as a string,
+	  each position indicating the number of spaces to insert for a tab
+	  at that position
+	* pplex.c,cobc.c: use the new type of cb_tab_width
+
 2025-12-29  Roger Bowler <rbowler@snipix.net>
 
 	* tree.c (finalize_file): if file is EXTFH enabled then don't warn for

--- a/cobc/cobc.c
+++ b/cobc/cobc.c
@@ -6784,9 +6784,11 @@ get_next_listing_line (FILE *fd, char **pline, int fixed)
 
 	for (in_char = in_line; i != CB_LINE_LENGTH && *in_char; in_char++) {
 		if (*in_char == '\t') {
-			out_line[i++] = ' ';
-			while (i % cb_tab_width != 0) {
+			/* See comment on tab-width in config.c */
+			int tab_width = cb_tab_width[i];
+			while (tab_width > 0){
 				out_line[i++] = ' ';
+				tab_width--;
 				if (i == CB_LINE_LENGTH) {
 					break;
 				}

--- a/cobc/config.c
+++ b/cobc/config.c
@@ -732,6 +732,57 @@ cb_config_entry (char *buff, const char *fname, const int line)
 			}
 			break;
 
+		} else if (strcmp (name, "tab-width") == 0) {
+			/* The original implementation tab-width used
+			 * to rely on a unique tab width and
+			 * computation by modulos. Instead, this new
+			 * implementation relies on cb_tab_width being
+			 * an array of offsets, each position in the
+			 * array corresponding to the offset from that
+			 * position to the next tabstop. The array is
+			 * initialized here from the tab-width
+			 * option. */
+
+			/* This option is always initialized, so let's
+			   allocate a static buffer. COB_SMALL_BUFF is
+			   much larger than the maximal line length,
+			   but there is currently no other constant
+			   available for that. */
+			static char cb_tab_width_static[COB_SMALL_BUFF];
+
+			char *token = strtok(val, ",");
+			int pos = 0;
+			unsigned int last_tab_width = 8;
+			if (cb_tab_width == NULL)
+				cb_tab_width = cb_tab_width_static;
+			/* Initialize the beginning of the array
+			 * corresponding to the tabulations set in the
+			 * tab-width option, storing the last one in
+			 * last_tab_width. */
+			while (token != NULL) {
+				unsigned int tab_width = atoi(token);
+
+				if (tab_width < 1 || tab_width > 12){
+					invalid_value (fname, line, name,
+						       token, "1-12", 0, 0);
+					return -1;
+				}
+				last_tab_width = tab_width;
+				while (tab_width > 0 && pos < COB_SMALL_BUFF){
+					cb_tab_width[pos++] = tab_width--;
+				}
+				token = strtok(NULL, ",");
+			}
+			/* Initialize the end of the array, using the
+			 * last tabulation found. */
+			while (pos < COB_SMALL_BUFF){
+				unsigned int tab_width = last_tab_width;
+				while (tab_width > 0 && pos < COB_SMALL_BUFF){
+					cb_tab_width[pos++] = tab_width--;
+				}
+			}
+			break;
+
 		} else if (strcmp (name, "binary-byteorder") == 0) {
 			if (strcmp (val, "native") == 0) {
 				cb_binary_byteorder = CB_BYTEORDER_NATIVE;

--- a/cobc/config.def
+++ b/cobc/config.def
@@ -48,8 +48,8 @@ CB_CONFIG_STRING (cb_reserved_words, "reserved-words", _("use of complete/fixed 
 
 /* Integer flags */
 
-CB_CONFIG_INT (cb_tab_width, "tab-width", 1, 12, CB_XRANGE(1,12),
-	_("number of spaces that are assumed for tabs"))
+CB_CONFIG_ANY (char *, cb_tab_width, "tab-width",
+	_("number of spaces that are assumed for tabs (comma separated)"))
 
 CB_CONFIG_INT (cb_config_text_column, "text-column", 72, 255, CB_XRANGE(72,255),
 	_("right margin column number for fixed-form reference-format"))

--- a/cobc/pplex.l
+++ b/cobc/pplex.l
@@ -1426,11 +1426,10 @@ ppopen_get_file (const char *name)
 					line_pos = 0;
 					break;
 				case '\t':
+					/* See comment on tab-width in
+					 * config.c */
+					line_pos+= cb_tab_width[pos];
 					buffer[pos] = ' ';
-					line_pos++;				/* move test from run_extensions.at 1809 to -fformat */
-					while (line_pos % cb_tab_width != 0) {
-						line_pos++;
-					}
 					break;
 				default:
 					line_pos++;
@@ -2383,9 +2382,11 @@ start:
 		}
 		if (unlikely (ipchar == '\t')) {
 			if (likely (line_overflow == 0)) {
-				buff[n++] = ' ';
-				while (n % cb_tab_width != 0) {
+				/* See comment on tab-width in config.c */
+				int tab_width = cb_tab_width[n];
+				while (tab_width > 0){
 					buff[n++] = ' ';
+					tab_width--;
 				}
 				if (unlikely (n > PPLEX_BUFF_LEN)) {
 					n = PPLEX_BUFF_LEN;

--- a/tests/testsuite.src/configuration.at
+++ b/tests/testsuite.src/configuration.at
@@ -1010,3 +1010,57 @@ cobc: error: invalid parameter: -febcdic-table
 ])
 
 AT_CLEANUP
+
+
+AT_SETUP([tabstop tab-width])
+AT_KEYWORDS([tabulation])
+
+AT_DATA([prog.cob], [
+02		IDENTIFICATION   DIVISION.
+03		PROGRAM-ID.      prog.
+04		PROCEDURE        DIVISION.
+05    * In the next line, the star is an indicator after a tab of size 6
+06	*PROCEDURE        DIVISION.
+07    * After 2 tabs, the line is at the beginning of Area A
+08		DISPLAY "hello".
+09		 DISPLAY "hello".
+10		  DISPLAY "hello".
+11		   DISPLAY "hello".
+12		    DISPLAY "hello".
+13    * After 3 tabs, the line is at the beginning of Area B
+14			DISPLAY "hello".
+15			STOP RUN.
+])
+
+AT_CHECK([$COMPILE_ONLY -std=ibm -ftab-width=6,1,4 -ftab-width=6 prog.cob], [0], [],
+[prog.cob:2: warning: IDENTIFICATION DIVISION should start in Area A
+prog.cob:4: warning: PROCEDURE DIVISION should start in Area A
+])
+
+AT_CHECK([$COMPILE_ONLY -std=ibm -ftab-width=4 prog.cob], [1], [],
+[prog.cob:6: error: invalid indicator 'R' at column 7
+prog.cob:8: warning: start of statement in Area A
+prog.cob:9: warning: start of statement in Area A
+prog.cob:10: warning: start of statement in Area A
+])
+
+AT_CHECK([$COMPILE_ONLY -std=ibm -ftab-width=6,1,a prog.cob], [1], [],
+[configuration error:
+-ftab-width=6,1,a: invalid value 'a' for configuration tag 'tab-width';
+	should be one of the following values: 1-12
+])
+
+AT_CHECK([$COMPILE_ONLY -std=ibm -ftab-width=a prog.cob], [1], [],
+[configuration error:
+-ftab-width=a: invalid value 'a' for configuration tag 'tab-width';
+	should be one of the following values: 1-12
+])
+
+AT_CHECK([$COMPILE_ONLY -std=ibm -ftab-width=6,1,4 prog.cob], [0], [],
+[prog.cob:8: warning: start of statement in Area A
+prog.cob:9: warning: start of statement in Area A
+prog.cob:10: warning: start of statement in Area A
+prog.cob:11: warning: start of statement in Area A
+])
+
+AT_CLEANUP


### PR DESCRIPTION
Before this patch, option "tab-width" could only receive a single integer value, indicating the width of all tabulations.
After this patch, option "tab-width" can receive a list of comma-separated widths, each one indicating the width of the corresponding tabulation, the last one being kept for all other tabulations.

For example, `-ftab-width=6,1,4` will give the following behavior:
* a tabulation in colomns < 7 will move the cursor to column 7 (indicator)
* a tabulation in column 7 will move the cursor to column 8
* a tabulation in column < 12 will move the cursor to column 12 (area B)
* any other tabulation will move the cursor to 16,20,24,28, etc.

