### PR TITLE
Add COB_SET_RUNTIME_STDOUT_FILE and COB_SET_RUNTIME_STDERR_FILE runtime options to enable redirection of stdout/stderr output

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -55,10 +55,9 @@ NEWS - user visible changes				-*- outline -*-
 
 ** new runtime configurations: COB_STDIN_FILE, COB_STDOUT_FILE,
    COB_STDERR_FILE. They allow redirection of stdin/stdout/stderr input/output
-   to a file. Alternatively, these configurations are also available as runtime
-   options which can be used to set them programmatically:
-   COB_SET_RUNTIME_STDIN_FILE, COB_SET_RUNTIME_STDOUT_FILE,
-   COB_SET_RUNTIME_STDERR_FILE.
+   to a file. These configurations can be set via configuration file,
+   environment variables or programmatically with COB_SET_RUNTIME_STDIN_FILE,
+   COB_SET_RUNTIME_STDOUT_FILE, COB_SET_RUNTIME_STDERR_FILE.
 
 ** added multiple window functionality with new system function CBL_GC_WINDOW
 

--- a/NEWS
+++ b/NEWS
@@ -53,9 +53,12 @@ NEWS - user visible changes				-*- outline -*-
    already have a registered handler, allowing users to preserve their own
    signal handlers during the initialization of the GnuCOBOL runtime.
 
-** new runtime options COB_SET_RUNTIME_STDOUT_FILE/COB_SET_RUNTIME_STDERR_FILE,
-   allows redirection of stdout/stderr output to a file from a module written
-   in C.
+** new runtime configurations: COB_STDIN_FILE, COB_STDOUT_FILE,
+   COB_STDERR_FILE. They allow redirection of stdin/stdout/stderr input/output
+   to a file. Alternatively, these configurations are also available as runtime
+   options which can be used to set them programmatically:
+   COB_SET_RUNTIME_STDIN_FILE, COB_SET_RUNTIME_STDOUT_FILE,
+   COB_SET_RUNTIME_STDERR_FILE.
 
 ** added multiple window functionality with new system function CBL_GC_WINDOW
 

--- a/NEWS
+++ b/NEWS
@@ -53,6 +53,10 @@ NEWS - user visible changes				-*- outline -*-
    already have a registered handler, allowing users to preserve their own
    signal handlers during the initialization of the GnuCOBOL runtime.
 
+** new runtime options COB_SET_RUNTIME_STDOUT_FILE/COB_SET_RUNTIME_STDERR_FILE,
+   allows redirection of stdout/stderr output to a file from a module written
+   in C.
+
 ** added multiple window functionality with new system function CBL_GC_WINDOW
 
 ** New system functions

--- a/config/ChangeLog
+++ b/config/ChangeLog
@@ -1,4 +1,10 @@
 
+2026-07-07	Oğuzcan Kırmemiş <oguzcan.kirmemis@gmail.com>
+
+	* runtime.cfg: add runtime configurations COB_STDIN_FILE, COB_STDOUT_FILE,
+	  COB_STDERR_FILE to allow redirection of stdin/stdout/stderr input/output
+	  to given files
+
 2025-11-19  Oğuzcan Kırmemiş <oguzcan.kirmemis@gmail.com>
 
 	* runtime.cfg: add runtime configuration COB_SIGNAL_REGIME to allow

--- a/config/ChangeLog
+++ b/config/ChangeLog
@@ -832,7 +832,7 @@
 	* default.inc, Makefile.am: New files.
 
 
-Copyright 2003,2005-2007-2010,2014-2024 Free Software Foundation, Inc.
+Copyright 2003,2005-2007-2010,2014-2026 Free Software Foundation, Inc.
 
 Copying and distribution of this file, with or without modification, are
 permitted provided the copyright notice and this notice are preserved.

--- a/config/runtime.cfg
+++ b/config/runtime.cfg
@@ -118,6 +118,30 @@
 #          Default:  false
 #          Example:  COB_SET_DEBUG  1
 
+# Environment name:  COB_STDIN_FILE
+#   Parameter name:  stdin_file
+#          Purpose:  to define where COBOL stdin input should be read from
+#             Type:  string (file) ; may use $-sequences
+#             Note:  file is opened for read-only
+#          Default:  stdin
+#          Example:  STDIN_FILE  ${HOME}/stdin.$$
+
+# Environment name:  COB_STDOUT_FILE
+#   Parameter name:  stdout_file
+#          Purpose:  to define where COBOL stdout output should go
+#             Type:  string (file) ; may use $-sequences
+#             Note:  file is opened for append if name starts with "+"
+#          Default:  stdout
+#          Example:  STDOUT_FILE  ${HOME}/stdout.$$
+
+# Environment name:  COB_STDERR_FILE
+#   Parameter name:  stderr_file
+#          Purpose:  to define where COBOL stderr output should go
+#             Type:  string (file) ; may use $-sequences
+#             Note:  file is opened for append if name starts with "+"
+#          Default:  stderr
+#          Example:  STDERR_FILE  ${HOME}/stderr.$$
+
 # Environment name:  COB_SET_TRACE
 #   Parameter name:  set_trace
 #          Purpose:  to enable COBOL trace feature

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,4 +1,9 @@
 
+2026-07-07  Oğuzcan Kırmemiş <oguzcan.kirmemis@gmail.com>
+
+	* gnucobol.texi: document the new COB_SET_RUNTIME_STDOUT_FILE and
+	  COB_SET_RUNTIME_STDERR_FILE runtime options.
+
 2025-03-26  David Declerck <david.declerck@ocamlpro.com>
 
 	* gnucobol.texi: document the new --gentable option

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -336,7 +336,7 @@
 	* open-cobol.texi (Customize): Add COB_LDADD, COB_CONFIG_FILE.
 
 
-Copyright 2002,2005,2009-2025 Free Software Foundation, Inc.
+Copyright 2002,2005,2009-2026 Free Software Foundation, Inc.
 
 Copying and distribution of this file, with or without modification, are
 permitted provided the copyright notice and this notice are preserved.

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,8 +1,9 @@
 
 2026-07-07  Oğuzcan Kırmemiş <oguzcan.kirmemis@gmail.com>
 
-	* gnucobol.texi: document the new COB_SET_RUNTIME_STDOUT_FILE and
-	  COB_SET_RUNTIME_STDERR_FILE runtime options.
+	* gnucobol.texi: document the new COB_SET_RUNTIME_STDIN_FILE,
+	  COB_SET_RUNTIME_STDOUT_FILE and COB_SET_RUNTIME_STDERR_FILE runtime
+	  options
 
 2025-03-26  David Declerck <david.declerck@ocamlpro.com>
 

--- a/doc/gnucobol.texi
+++ b/doc/gnucobol.texi
@@ -1657,6 +1657,7 @@ enum cob_runtime_option_switch @{
    COB_SET_RUNTIME_DISPLAY_PRINTER_FILE    /* 'p' is  FILE *  */
    COB_SET_RUNTIME_RESCAN_ENV              /* rescan environment variables */
    COB_SET_RUNTIME_DISPLAY_PUNCH_FILE      /* 'p' is  FILE *  */
+   COB_SET_RUNTIME_STDIN_FILE              /* 'p' is  FILE *  */
    COB_SET_RUNTIME_STDOUT_FILE             /* 'p' is  FILE *  */
    COB_SET_RUNTIME_STDERR_FILE             /* 'p' is  FILE *  */
 @};

--- a/doc/gnucobol.texi
+++ b/doc/gnucobol.texi
@@ -1657,6 +1657,8 @@ enum cob_runtime_option_switch @{
    COB_SET_RUNTIME_DISPLAY_PRINTER_FILE    /* 'p' is  FILE *  */
    COB_SET_RUNTIME_RESCAN_ENV              /* rescan environment variables */
    COB_SET_RUNTIME_DISPLAY_PUNCH_FILE      /* 'p' is  FILE *  */
+   COB_SET_RUNTIME_STDOUT_FILE             /* 'p' is  FILE *  */
+   COB_SET_RUNTIME_STDERR_FILE             /* 'p' is  FILE *  */
 @};
 COB_EXT_IMPORT  void  cob_set_runtime_option   (enum cob_runtime_option_switch opt, void *p);
 @end smallexample
@@ -1676,6 +1678,20 @@ cob_set_runtime_option (COB_SET_RUNTIME_DISPLAY_PRINTER_FILE,
 You could also redirect all @code{DISPLAY UPON SYSPUNCH} output to a file by:
 @example
 cob_set_runtime_option (COB_SET_RUNTIME_DISPLAY_PUNCH_FILE,
+                         (void*)((FILE*)myfd));
+@end example
+
+Likewise, you could also redirect all @code{DISPLAY} output that would be normally
+printed to stdout to a file by:
+@example
+cob_set_runtime_option (COB_SET_RUNTIME_STDOUT_FILE,
+                         (void*)((FILE*)myfd));
+@end example
+
+The same option is also possible for stderr, including error outputs directly
+coming from the runtime:
+@example
+cob_set_runtime_option (COB_SET_RUNTIME_STDERR_FILE,
                          (void*)((FILE*)myfd));
 @end example
 

--- a/doc/gnucobol.texi
+++ b/doc/gnucobol.texi
@@ -1681,16 +1681,19 @@ cob_set_runtime_option (COB_SET_RUNTIME_DISPLAY_PUNCH_FILE,
                          (void*)((FILE*)myfd));
 @end example
 
-Likewise, you could also redirect all @code{DISPLAY} output that would be normally
-printed to stdout to a file by:
+You are also able to redirect @code{ACCEPT} so that instead of stdin, it reads
+from a file, by using:
 @example
-cob_set_runtime_option (COB_SET_RUNTIME_STDOUT_FILE,
+cob_set_runtime_option (COB_SET_RUNTIME_STDIN_FILE,
                          (void*)((FILE*)myfd));
 @end example
 
-The same option is also possible for stderr, including error outputs directly
-coming from the runtime:
+Likewise, you could also redirect all @code{DISPLAY} output that would be
+normally printed to stdout/stderr, including outputs directly coming from the
+runtime, to a file by:
 @example
+cob_set_runtime_option (COB_SET_RUNTIME_STDOUT_FILE,
+                         (void*)((FILE*)myfd));
 cob_set_runtime_option (COB_SET_RUNTIME_STDERR_FILE,
                          (void*)((FILE*)myfd));
 @end example

--- a/libcob/ChangeLog
+++ b/libcob/ChangeLog
@@ -42,11 +42,9 @@
 
 	* common.c: add COB_STDIN_FILE, COB_STDOUT_FILE and COB_STDERR_FILE runtime
 	  configurations for redirection of stdin/stdout/stderr to a file
-	* common.h (cob_runtime_option_switch): add COB_SET_RUNTIME_STDIN_FILE,
-	  COB_SET_RUNTIME_STDOUT_FILE and COB_SET_RUNTIME_STDERR_FILE enums
-	* common.c (cob_set_runtime_option, cob_get_runtime_option): extend for
-	  COB_SET_RUNTIME_STDIN_FILE, COB_SET_RUNTIME_STDOUT_FILE and
-	  COB_SET_RUNTIME_STDERR_FILE options
+	* common.c, common.h: add COB_SET_RUNTIME_STDIN_FILE,
+	  COB_SET_RUNTIME_STDOUT_FILE and COB_SET_RUNTIME_STDERR_FILE runtime
+	  options
 	* coblocal.h (cob_settings): extend the setting to store FILE pointers
 	  for stdin/stdout/stderr
 	* fileio.c: introduce cob_settings_fileio to trigger reset of settings

--- a/libcob/ChangeLog
+++ b/libcob/ChangeLog
@@ -43,9 +43,8 @@
 	* common.c: add COB_STDIN_FILE, COB_STDOUT_FILE and COB_STDERR_FILE runtime
 	  configurations for redirection of stdin/stdout/stderr to a file
 	* common.h (cob_runtime_option_switch): add COB_SET_RUNTIME_STDIN_FILE,
-	  COB_SET_RUNTIME_STDOUT_FILE and COB_SET_RUNTIME_STDERR_FILE runtime
-	  options to enable redirection programmatically
-	* common.c (cob_set_runtime_option, cob_get_runtime_option): add logic for
+	  COB_SET_RUNTIME_STDOUT_FILE and COB_SET_RUNTIME_STDERR_FILE enums
+	* common.c (cob_set_runtime_option, cob_get_runtime_option): extend for
 	  COB_SET_RUNTIME_STDIN_FILE, COB_SET_RUNTIME_STDOUT_FILE and
 	  COB_SET_RUNTIME_STDERR_FILE options
 	* coblocal.h (cob_settings): extend the setting to store FILE pointers

--- a/libcob/ChangeLog
+++ b/libcob/ChangeLog
@@ -38,6 +38,18 @@
 	  events across END-OF-INPUT boundaries. 
 	  This is due to libxml2 internal details.
 
+2026-07-07  Oğuzcan Kırmemiş <oguzcan.kirmemis@gmail.com>
+
+	* common.h (cob_runtime_option_switch): add COB_SET_RUNTIME_STDOUT_FILE and
+	  COB_SET_RUNTIME_STDERR_FILE runtime options to enable redirection of
+	  stdout/stderr output to a file.
+	* common.c (cob_set_runtime_option, cob_get_runtime_option): add logic for
+	  COB_SET_RUNTIME_STDOUT_FILE and COB_SET_RUNTIME_STDERR_FILE options.
+	* coblocal.h (cob_settings): extend the setting to store FILE pointers
+	  for stdout/stderr.
+	* common.c, cobgetopt.c, coblocal.h, fileio.c, profiling.c, screenio.c,
+	  termio.c: use stdout/stderr in cob_settings instead of global.
+
 2026-03-02  Fabrice Le Fessant <fabrice.le_fessant@ocamlpro.com>
 
 	* coblocal.h, common.c, profiling.c: rename is_test to cob_is_test

--- a/libcob/ChangeLog
+++ b/libcob/ChangeLog
@@ -40,15 +40,20 @@
 
 2026-07-07  Oğuzcan Kırmemiş <oguzcan.kirmemis@gmail.com>
 
-	* common.h (cob_runtime_option_switch): add COB_SET_RUNTIME_STDOUT_FILE and
-	  COB_SET_RUNTIME_STDERR_FILE runtime options to enable redirection of
-	  stdout/stderr output to a file.
+	* common.c: add COB_STDIN_FILE, COB_STDOUT_FILE and COB_STDERR_FILE runtime
+	  configurations for redirection of stdin/stdout/stderr to a file
+	* common.h (cob_runtime_option_switch): add COB_SET_RUNTIME_STDIN_FILE,
+	  COB_SET_RUNTIME_STDOUT_FILE and COB_SET_RUNTIME_STDERR_FILE runtime
+	  options to enable redirection programmatically
 	* common.c (cob_set_runtime_option, cob_get_runtime_option): add logic for
-	  COB_SET_RUNTIME_STDOUT_FILE and COB_SET_RUNTIME_STDERR_FILE options.
+	  COB_SET_RUNTIME_STDIN_FILE, COB_SET_RUNTIME_STDOUT_FILE and
+	  COB_SET_RUNTIME_STDERR_FILE options
 	* coblocal.h (cob_settings): extend the setting to store FILE pointers
-	  for stdout/stderr.
+	  for stdin/stdout/stderr
+	* fileio.c: introduce cob_settings_fileio to trigger reset of settings
+	  related configurations
 	* common.c, cobgetopt.c, coblocal.h, fileio.c, profiling.c, screenio.c,
-	  termio.c: use stdout/stderr in cob_settings instead of global.
+	  termio.c: use stdin/stdout/stderr in cob_settings instead of global
 
 2026-03-02  Fabrice Le Fessant <fabrice.le_fessant@ocamlpro.com>
 

--- a/libcob/cobgetopt.c
+++ b/libcob/cobgetopt.c
@@ -249,6 +249,8 @@ process_long_option (const int argc, char * const *argv, const char *optstring,
 		     const int long_only,
 		     int print_errors, const char *prefix)
 {
+  FILE *stderr_f = cob_get_runtime_option (COB_SET_RUNTIME_STDERR_FILE) ?
+	cob_get_runtime_option (COB_SET_RUNTIME_STDERR_FILE) : stderr;
   char *nameend;
   size_t namelen;
   const struct option *p;
@@ -326,26 +328,24 @@ process_long_option (const int argc, char * const *argv, const char *optstring,
 	    {
 	      if (ambig_fallback)
 		  {
-		  /* TODO: Decide how to do stdout/stderr redirection here
-		  (and in examples below), or not at all */
-		  fprintf (stderr, _("%s: option '%s%s' is ambiguous"),
+		  fprintf (stderr_f, _("%s: option '%s%s' is ambiguous"),
 			 argv[0], prefix, nextchar);
-		  fputc ('\n', stderr);
+		  fputc ('\n', stderr_f);
 		}
 	      else
 		{
-		  flockfile (stderr);
-		  fprintf (stderr,
+		  flockfile (stderr_f);
+		  fprintf (stderr_f,
 			   _("%s: option '%s%s' is ambiguous; possibilities:"),
 			   argv[0], prefix, nextchar);
 
 		  for (option_index = 0; option_index < n_options; option_index++)
 		    if (ambig_set[option_index])
-		      fprintf (stderr, " '%s%s'",
+		      fprintf (stderr_f, " '%s%s'",
 			       prefix, longopts[option_index].name);
 
-		  fputc ('\n', stderr);
-		  funlockfile (stderr);
+		  fputc ('\n', stderr_f);
+		  funlockfile (stderr_f);
 		}
 	    }
 	  if (ambig_malloced)
@@ -369,9 +369,9 @@ process_long_option (const int argc, char * const *argv, const char *optstring,
 	{
 	  if (print_errors)
 	  {
-		  fprintf (stderr, _("%s: unrecognized option '%s%s'"),
+		  fprintf (stderr_f, _("%s: unrecognized option '%s%s'"),
 		     argv[0], prefix, nextchar);
-		  fputc ('\n', stderr);
+		  fputc ('\n', stderr_f);
 	  }
 
 	  nextchar = NULL;
@@ -397,10 +397,10 @@ process_long_option (const int argc, char * const *argv, const char *optstring,
 	{
 	  if (print_errors)
 		  {
-		  fprintf (stderr,
+		  fprintf (stderr_f,
 		     _("%s: option '%s%s' doesn't allow an argument"),
 		     argv[0], prefix, pfound->name);
-		  fputc ('\n', stderr);
+		  fputc ('\n', stderr_f);
 		  }
 
 	  optopt = pfound->val;
@@ -415,10 +415,10 @@ process_long_option (const int argc, char * const *argv, const char *optstring,
 	{
 	  if (print_errors)
 		  {
-		    fprintf (stderr,
+		    fprintf (stderr_f,
 		     _("%s: option '%s%s' requires an argument"),
 		     argv[0], prefix, pfound->name);
-		  fputc ('\n', stderr);
+		  fputc ('\n', stderr_f);
 		  }
 
 	  optopt = pfound->val;
@@ -539,6 +539,8 @@ cob_getopt_long_long (const int argc, char *const *argv, const char *optstring,
 		      const struct option *longopts, int *longind,
 		      const int long_only)
 {
+  FILE *stderr_f = cob_get_runtime_option (COB_SET_RUNTIME_STDERR_FILE) ?
+	cob_get_runtime_option (COB_SET_RUNTIME_STDERR_FILE) : stderr;
   int print_errors = opterr;
 
   if (argc < 1)
@@ -687,8 +689,8 @@ cob_getopt_long_long (const int argc, char *const *argv, const char *optstring,
       {
 	if (print_errors)
 	  {
-		fprintf (stderr, _("%s: invalid option -- '%c'"), argv[0], c);
-		fputc ('\n', stderr);
+		fprintf (stderr_f, _("%s: invalid option -- '%c'"), argv[0], c);
+		fputc ('\n', stderr_f);
 	  }
 	optopt = c;
 	return '?';
@@ -704,10 +706,10 @@ cob_getopt_long_long (const int argc, char *const *argv, const char *optstring,
 	  {
 	    if (print_errors)
 	      {
-	      fprintf (stderr,
+	      fprintf (stderr_f,
 		       _("%s: option requires an argument -- '%c'"),
 		       argv[0], c);
-	      fputc ('\n', stderr);
+	      fputc ('\n', stderr_f);
 	      }
 	    optopt = c;
 	    if (optstring[0] == ':')
@@ -752,9 +754,9 @@ cob_getopt_long_long (const int argc, char *const *argv, const char *optstring,
 	      {
 		if (print_errors)
 		  {
-		    fprintf (stderr, _("%s: option requires an argument -- '%c'"),
+		    fprintf (stderr_f, _("%s: option requires an argument -- '%c'"),
 			     argv[0], c);
-		     fputc ('\n', stderr);
+		     fputc ('\n', stderr_f);
 		  }
 		optopt = c;
 		if (optstring[0] == ':')

--- a/libcob/cobgetopt.c
+++ b/libcob/cobgetopt.c
@@ -326,7 +326,7 @@ process_long_option (const int argc, char * const *argv, const char *optstring,
 	    {
 	      if (ambig_fallback)
 		  {
-		  /* TODO: Decide how to do stdout/stderr redirection here 
+		  /* TODO: Decide how to do stdout/stderr redirection here
 		  (and in examples below), or not at all */
 		  fprintf (stderr, _("%s: option '%s%s' is ambiguous"),
 			 argv[0], prefix, nextchar);

--- a/libcob/cobgetopt.c
+++ b/libcob/cobgetopt.c
@@ -326,6 +326,8 @@ process_long_option (const int argc, char * const *argv, const char *optstring,
 	    {
 	      if (ambig_fallback)
 		  {
+		  /* TODO: Decide how to do stdout/stderr redirection here 
+		  (and in examples below), or not at all */
 		  fprintf (stderr, _("%s: option '%s%s' is ambiguous"),
 			 argv[0], prefix, nextchar);
 		  fputc ('\n', stderr);

--- a/libcob/coblocal.h
+++ b/libcob/coblocal.h
@@ -386,12 +386,15 @@ typedef struct __cob_settings {
 											   / creation of coredumps on runtime errors */
 	char		*cob_core_filename;	/* filename for coredump creation */
 
-	char 		*cob_stdin_filename;	/* Filename to redirect reads to stdin */
-	char		*cob_stdout_filename;	/* Filename to redirect writes to stdout */
-	char		*cob_stderr_filename;	/* Filename to redirect writes to stderr */
-	FILE		*cob_stdin;				/* FILE* to redirect reads to stdin */
-	FILE        *cob_stdout; 			/* FILE* to redirect writes to stdout */
-	FILE        *cob_stderr; 			/* FILE* to redirect writes to stderr */
+	char 		*cob_stdin_filename;		/* Filename to redirect reads to stdin */
+	char		*cob_stdout_filename;		/* Filename to redirect writes to stdout */
+	char		*cob_stderr_filename;		/* Filename to redirect writes to stderr */
+	char		*cob_stdin_filename_set;	/* Current filename which is replacing stdin */
+	char 		*cob_stdout_filename_set;	/* Current filename which is replacing stdout */
+	char 		*cob_stderr_filename_set;	/* Current filename which is replacing stderr */
+	FILE		*cob_stdin;					/* FILE* to redirect reads to stdin */
+	FILE		*cob_stdout; 				/* FILE* to redirect writes to stdout */
+	FILE		*cob_stderr; 				/* FILE* to redirect writes to stderr */
 } cob_settings;
 
 
@@ -477,6 +480,7 @@ COB_HIDDEN void		cob_init_cconv		(cob_global *);
 COB_HIDDEN void		cob_init_termio		(cob_global *, cob_settings *);
 COB_HIDDEN void		cob_init_fileio		(cob_global *, cob_settings *);
 COB_HIDDEN void		cob_settings_fileio (void);
+COB_HIDDEN void		cob_settings_termio (void);
 COB_HIDDEN char		*cob_get_filename_print	(cob_file *, const int);
 COB_HIDDEN char		*cob_setup_filename		(const cob_field *);
 COB_HIDDEN void		cob_init_reportio	(cob_global *, cob_settings *);

--- a/libcob/coblocal.h
+++ b/libcob/coblocal.h
@@ -386,9 +386,12 @@ typedef struct __cob_settings {
 											   / creation of coredumps on runtime errors */
 	char		*cob_core_filename;	/* filename for coredump creation */
 
-	FILE		*cob_stdin;		/* FILE* to redirect reads to stdin */
-	FILE        *cob_stdout; 	/* FILE* to redirect writes to stdout */
-	FILE        *cob_stderr; 	/* FILE* to redirect writes to stderr */
+	char 		*cob_stdin_filename;	/* Filename to redirect reads to stdin */
+	char		*cob_stdout_filename;	/* Filename to redirect writes to stdout */
+	char		*cob_stderr_filename;	/* Filename to redirect writes to stderr */
+	FILE		*cob_stdin;				/* FILE* to redirect reads to stdin */
+	FILE        *cob_stdout; 			/* FILE* to redirect writes to stdout */
+	FILE        *cob_stderr; 			/* FILE* to redirect writes to stderr */
 } cob_settings;
 
 

--- a/libcob/coblocal.h
+++ b/libcob/coblocal.h
@@ -386,8 +386,9 @@ typedef struct __cob_settings {
 											   / creation of coredumps on runtime errors */
 	char		*cob_core_filename;	/* filename for coredump creation */
 
-	FILE        *cob_stdout; /* FILE* to redirect writes to stdout */
-	FILE        *cob_stderr; /* FILE* to redirect writes to stderr */
+	FILE		*cob_stdin;		/* FILE* to redirect reads to stdin */
+	FILE        *cob_stdout; 	/* FILE* to redirect writes to stdout */
+	FILE        *cob_stderr; 	/* FILE* to redirect writes to stderr */
 } cob_settings;
 
 
@@ -472,6 +473,7 @@ COB_HIDDEN void		cob_init_numeric	(cob_global *);
 COB_HIDDEN void		cob_init_cconv		(cob_global *);
 COB_HIDDEN void		cob_init_termio		(cob_global *, cob_settings *);
 COB_HIDDEN void		cob_init_fileio		(cob_global *, cob_settings *);
+COB_HIDDEN void		cob_settings_fileio (void);
 COB_HIDDEN char		*cob_get_filename_print	(cob_file *, const int);
 COB_HIDDEN char		*cob_setup_filename		(const cob_field *);
 COB_HIDDEN void		cob_init_reportio	(cob_global *, cob_settings *);

--- a/libcob/coblocal.h
+++ b/libcob/coblocal.h
@@ -385,6 +385,9 @@ typedef struct __cob_settings {
 	unsigned int	cob_core_on_error;		/* signal handling and possible raise of SIGABRT
 											   / creation of coredumps on runtime errors */
 	char		*cob_core_filename;	/* filename for coredump creation */
+
+	FILE        *cob_stdout; /* FILE* to redirect writes to stdout */
+	FILE        *cob_stderr; /* FILE* to redirect writes to stderr */
 } cob_settings;
 
 

--- a/libcob/coblocal.h
+++ b/libcob/coblocal.h
@@ -263,9 +263,14 @@ Note: also defined together with __clang__ in both frontends:
 #define	COB_INSERT_MODE		cobsetptr->cob_insert_mode
 #define	COB_HIDE_CURSOR		cobsetptr->cob_hide_cursor
 #define	COB_EXTENDED_STATUS	cobsetptr->cob_extended_status
-#define	COB_MOUSE_FLAGS	cobsetptr->cob_mouse_flags
+#define	COB_MOUSE_FLAGS		cobsetptr->cob_mouse_flags
 #define	COB_MOUSE_INTERVAL	cobsetptr->cob_mouse_interval
 #define	COB_USE_ESC		cobsetptr->cob_use_esc
+#define	COB_STDIN		cobsetptr->cob_stdin
+#define	COB_STDOUT		cobsetptr->cob_stdout
+#define	COB_STDERR		cobsetptr->cob_stderr
+#define	COB_STDERR_OR_DEFAULT	cobsetptr && cobsetptr->cob_stderr ? \
+	cobsetptr->cob_stderr : stderr
 
 #if defined(COB_TLS)
     /* already defined, for example as static to explicit disable TLS */

--- a/libcob/common.c
+++ b/libcob/common.c
@@ -9183,6 +9183,13 @@ cob_fatal_error (const enum cob_fatal_error fatal_error)
 	int		status;
 #ifdef	_WIN32
 	char		*p;
+
+	FILE 		*stdin_f = cobsetptr && cobsetptr->cob_stdin
+		? cobsetptr->cob_stdin : stdin;
+	FILE 		*stdout_f = cobsetptr && cobsetptr->cob_stdout
+		? cobsetptr->cob_stdout : stdout;
+	FILE 		*stderr_f = cobsetptr && cobsetptr->cob_stderr
+		? cobsetptr->cob_stderr : stderr;
 #endif
 
 	switch (fatal_error) {
@@ -9203,9 +9210,9 @@ cob_fatal_error (const enum cob_fatal_error fatal_error)
 		if (p && (*p == 'Y' || *p == 'y' ||
 			*p == 'T' || *p == 't' ||
 			*p == '1')) {
-			(void)_setmode (_fileno (cobsetptr->cob_stdin), _O_BINARY);
-			(void)_setmode (_fileno (cobsetptr->cob_stdout), _O_BINARY);
-			(void)_setmode (_fileno (cobsetptr->cob_stderr), _O_BINARY);
+			(void)_setmode (_fileno (stdin_f), _O_BINARY);
+			(void)_setmode (_fileno (stdout_f), _O_BINARY);
+			(void)_setmode (_fileno (stderr_f), _O_BINARY);
 		}
 #endif
 		/* note: same message in call.c */
@@ -10239,6 +10246,14 @@ cob_common_init (void *setptr)
 		int use_unix_lf = 0;
 		char *s = getenv ("COB_UNIX_LF");
 
+		FILE *stdin_f = cobsetptr && cobsetptr->cob_stdin
+			? cobsetptr->cob_stdin : stdin;
+		FILE *stdout_f = cobsetptr && cobsetptr->cob_stdout
+			? cobsetptr->cob_stdout : stdout;
+		FILE *stderr_f = cobsetptr && cobsetptr->cob_stderr
+			? cobsetptr->cob_stderr : stderr;
+
+
 		if (s != NULL) {
 			if (setptr) {
 				set_config_val_by_name (s, "unix_lf", NULL);
@@ -10252,9 +10267,9 @@ cob_common_init (void *setptr)
 			}
 		}
 		if (use_unix_lf) {
-			(void)_setmode (_fileno (cobsetptr->cob_stdin), _O_BINARY);
-			(void)_setmode (_fileno (cobsetptr->cob_stdout), _O_BINARY);
-			(void)_setmode (_fileno (cobsetptr->cob_stderr), _O_BINARY);
+			(void)_setmode (_fileno (stdin_f), _O_BINARY);
+			(void)_setmode (_fileno (stdout_f), _O_BINARY);
+			(void)_setmode (_fileno (stderr_f), _O_BINARY);
 		}
 	}
 #endif

--- a/libcob/common.c
+++ b/libcob/common.c
@@ -10561,6 +10561,11 @@ cob_init (const int argc, char **argv)
 void
 cob_set_runtime_option (enum cob_runtime_option_switch opt, void *p)
 {
+	if (!cobsetptr) {
+		cob_fatal_error (COB_FERROR_INITIALIZED);
+		return;
+	}
+
 	switch (opt) {
 	case COB_SET_RUNTIME_TRACE_FILE:
 		cobsetptr->cob_trace_file = (FILE *)p;
@@ -10671,6 +10676,7 @@ cob_get_runtime_option (enum cob_runtime_option_switch opt)
 	if (!cobsetptr) {
 		return NULL;
 	}
+
 	switch (opt) {
 	case COB_SET_RUNTIME_TRACE_FILE:
 		return (void*)cobsetptr->cob_trace_file;

--- a/libcob/common.c
+++ b/libcob/common.c
@@ -10545,7 +10545,7 @@ cob_init (const int argc, char **argv)
 
 /*
  * Set special runtime options:
- * Currently this is only FILE * for trace and printer output
+ * Currently this is only FILE * for trace, printer and stdout/stderr output
  * or to reload the runtime configuration after changing environment
  */
 void
@@ -10587,9 +10587,6 @@ cob_set_runtime_option (enum cob_runtime_option_switch opt, void *p)
 			cobsetptr->cob_dump_filename = cob_strdup ("NONE");
 		}
 		break;
-	case COB_SET_RUNTIME_RESCAN_ENV:
-		cob_rescan_env_vals ();
-		break;
 	case COB_SET_RUNTIME_STDOUT_FILE:
 		if (p) {
 			cobsetptr->cob_stdout = (FILE *)p;
@@ -10599,6 +10596,9 @@ cob_set_runtime_option (enum cob_runtime_option_switch opt, void *p)
 		if (p) {
 			cobsetptr->cob_stderr = (FILE *)p;
 		}
+		break;
+	case COB_SET_RUNTIME_RESCAN_ENV:
+		cob_rescan_env_vals ();
 		break;
 	default:
 		cob_runtime_warning (_("%s called with unknown option: %d"),

--- a/libcob/common.c
+++ b/libcob/common.c
@@ -10603,11 +10603,19 @@ cob_set_runtime_option (enum cob_runtime_option_switch opt, void *p)
 	case COB_SET_RUNTIME_STDOUT_FILE:
 		if (p) {
 			cobsetptr->cob_stdout = (FILE *)p;
+		} else {
+			cobsetptr->cob_stdout = stdout;
+			cob_runtime_warning ("COB_SET_RUNTIME_STDOUT_FILE option used "
+				"with null parameter, defaulting back to process stdout");
 		}
 	    break;
 	case COB_SET_RUNTIME_STDERR_FILE:
 		if (p) {
 			cobsetptr->cob_stderr = (FILE *)p;
+		} else {
+			cobsetptr->cob_stderr = stderr;
+			cob_runtime_warning ("COB_SET_RUNTIME_STDERR_FILE option used "
+				"with null parameter, defaulting back to process stderr");
 		}
 		break;
 	case COB_SET_RUNTIME_RESCAN_ENV:

--- a/libcob/common.c
+++ b/libcob/common.c
@@ -10435,7 +10435,6 @@ cob_init (const int argc, char **argv)
 	/* Get settings structure */
 	cobsetptr = cob_malloc (sizeof (cob_settings));
 
-	/* TODO: Find a better a place set stdout/stderr initial values */
 	cobsetptr->cob_stdin = stdin;
 	cobsetptr->cob_stdout = stdout;
 	cobsetptr->cob_stderr = stderr;

--- a/libcob/common.c
+++ b/libcob/common.c
@@ -8992,30 +8992,34 @@ void
 cob_runtime_warning (const char *fmt, ...)
 {
 	va_list args;
+	FILE	*stderr_f = stderr;
 
 	if (cobsetptr && !cobsetptr->cob_display_warn) {
 		return;
 	}
 
+	if (cobsetptr && cobsetptr->cob_stderr) {
+		stderr_f = cobsetptr->cob_stderr;
+	}
 
 	/* Prefix */
-	fprintf (cobsetptr->cob_stderr, "libcob: ");
+	fprintf (stderr_f, "libcob: ");
 	{
 		char buff[COB_MINI_BUFF];
 		cob_get_source_line ();
 		get_source_location (buff);
-		fprintf (cobsetptr->cob_stderr, "%s", buff);
+		fprintf (stderr_f, "%s", buff);
 	}
-	fprintf (cobsetptr->cob_stderr, _("warning: "));
+	fprintf (stderr_f, _("warning: "));
 
 	/* Body */
 	va_start (args, fmt);
-	vfprintf (cobsetptr->cob_stderr, fmt, args);
+	vfprintf (stderr_f, fmt, args);
 	va_end (args);
 
 	/* Postfix */
-	putc ('\n', cobsetptr->cob_stderr);
-	fflush (cobsetptr->cob_stderr);
+	putc ('\n', stderr_f);
+	fflush (stderr_f);
 }
 
 void

--- a/libcob/common.c
+++ b/libcob/common.c
@@ -9026,18 +9026,23 @@ void
 cob_runtime_hint (const char *fmt, ...)
 {
 	va_list args;
+	FILE    *stderr_f = stderr;
+
+	if (cobsetptr && cobsetptr->cob_stderr) {
+		stderr_f = cobsetptr->cob_stderr;
+	}
 
 	/* Prefix */
-	fprintf (cobsetptr->cob_stderr, "%s", _("note: "));
+	fprintf (stderr_f, "%s", _("note: "));
 
 	/* Body */
 	va_start (args, fmt);
-	vfprintf (cobsetptr->cob_stderr, fmt, args);
+	vfprintf (stderr_f, fmt, args);
 	va_end (args);
 
 	/* Postfix */
-	putc ('\n', cobsetptr->cob_stderr);
-	fflush (cobsetptr->cob_stderr);
+	putc ('\n', stderr_f);
+	fflush (stderr_f);
 }
 
 /* extra function for direct interaction with the debugger
@@ -9067,7 +9072,12 @@ void
 cob_runtime_error (const char *fmt, ...)
 {
 	struct handlerlist	*h;
-	va_list			ap;
+	va_list				ap;
+	FILE            	*stderr_f = stderr;
+
+	if (cobsetptr && cobsetptr->cob_stderr) {
+		stderr_f = cobsetptr->cob_stderr;
+	}
 
 	int	more_error_procedures = 1;
 	cob_get_source_line ();
@@ -9142,31 +9152,31 @@ cob_runtime_error (const char *fmt, ...)
 		const char		*source_file;
 		unsigned int	 source_line;
 		set_source_location (&source_file, &source_line);
-		fputs ("libcob: ", cobsetptr->cob_stderr);
+		fputs ("libcob: ", stderr_f);
 		if (source_file) {
-			fprintf (cobsetptr->cob_stderr, "%s:", source_file);
+			fprintf (stderr_f, "%s:", source_file);
 			if (source_line) {
-				fprintf (cobsetptr->cob_stderr, "%u:", source_line);
+				fprintf (stderr_f, "%u:", source_line);
 			}
-			fputc (' ', cobsetptr->cob_stderr);
+			fputc (' ', stderr_f);
 		}
-		fprintf (cobsetptr->cob_stderr, "%s: ", _("error"));
+		fprintf (stderr_f, "%s: ", _("error"));
 
 		/* Body */
 		va_start (ap, fmt);
-		vfprintf (cobsetptr->cob_stderr, fmt, ap);
+		vfprintf (stderr_f, fmt, ap);
 		va_end (ap);
 
 		/* Postfix */
-		fputc ('\n', cobsetptr->cob_stderr);
-		fflush (cobsetptr->cob_stderr);
+		fputc ('\n', stderr_f);
+		fflush (stderr_f);
 	}
 
 	/* setup reason for optional module dump */
 	if (cob_initialized && abort_reason[0] == 0) {
 #if 0	/* Is there a use in this message ?*/
-		fputc ('\n', cobsetptr->cob_stderr);
-		fprintf (cobsetptr->cob_stderr, _("abnormal termination - file contents may be incorrect"));
+		fputc ('\n', stderr_f);
+		fprintf (stderr_f, _("abnormal termination - file contents may be incorrect"));
 #endif
 		va_start (ap, fmt);
 		vsnprintf (abort_reason, COB_MINI_BUFF, fmt, ap);

--- a/libcob/common.c
+++ b/libcob/common.c
@@ -10254,14 +10254,6 @@ cob_common_init (void *setptr)
 		int use_unix_lf = 0;
 		char *s = getenv ("COB_UNIX_LF");
 
-		FILE *stdin_f = cobsetptr && cobsetptr->cob_stdin
-			? cobsetptr->cob_stdin : stdin;
-		FILE *stdout_f = cobsetptr && cobsetptr->cob_stdout
-			? cobsetptr->cob_stdout : stdout;
-		FILE *stderr_f = cobsetptr && cobsetptr->cob_stderr
-			? cobsetptr->cob_stderr : stderr;
-
-
 		if (s != NULL) {
 			if (setptr) {
 				set_config_val_by_name (s, "unix_lf", NULL);
@@ -10275,6 +10267,13 @@ cob_common_init (void *setptr)
 			}
 		}
 		if (use_unix_lf) {
+			FILE *stdin_f = cobsetptr && cobsetptr->cob_stdin
+				? cobsetptr->cob_stdin : stdin;
+			FILE *stdout_f = cobsetptr && cobsetptr->cob_stdout
+				? cobsetptr->cob_stdout : stdout;
+			FILE *stderr_f = cobsetptr && cobsetptr->cob_stderr
+				? cobsetptr->cob_stderr : stderr;
+
 			(void)_setmode (_fileno (stdin_f), _O_BINARY);
 			(void)_setmode (_fileno (stdout_f), _O_BINARY);
 			(void)_setmode (_fileno (stderr_f), _O_BINARY);

--- a/libcob/common.c
+++ b/libcob/common.c
@@ -8314,9 +8314,9 @@ set_config_val (char *value, int pos)
 			cob_new_trace_file ();
 		}
 
-		if (data == (char *)cobsetptr->cob_stdin_filename
-			|| data == (char *)cobsetptr->cob_stdout_filename
-			|| data == (char *)cobsetptr->cob_stderr_filename) {
+		if (data_loc == offsetof (cob_settings, cob_stdin_filename)
+			|| data_loc == offsetof (cob_settings, cob_stdout_filename)
+			|| data_loc == offsetof (cob_settings, cob_stderr_filename)) {
 			cob_settings_termio ();
 		}
 	} else if (data_type & ENV_STR) {	/* String (environment expanded) */

--- a/libcob/common.c
+++ b/libcob/common.c
@@ -10621,6 +10621,7 @@ cob_set_runtime_option (enum cob_runtime_option_switch opt, void *p)
 			cob_runtime_warning ("COB_SET_RUNTIME_STDIN_FILE option used "
 				"with null parameter, defaulting back to process stdin");
 		}
+		break;
 	case COB_SET_RUNTIME_STDOUT_FILE:
 		if (p) {
 			cobsetptr->cob_stdout = (FILE *)p;

--- a/libcob/common.c
+++ b/libcob/common.c
@@ -18,7 +18,6 @@
    along with GnuCOBOL.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include "common.h"
 #include "tarstamp.h"
 #include "config.h"
 

--- a/libcob/common.c
+++ b/libcob/common.c
@@ -6628,7 +6628,7 @@ cob_sys_hosted (void *p, const void *var)
 			return 0;
 		}
 		if ((i == 5) && !memcmp (name, "stdin", 5)) {
-			*((FILE **)data) = stdin;
+			*((FILE **)data) = cobsetptr->cob_stdin;
 			return 0;
 		}
 		if ((i == 6) && !memcmp (name, "stdout", 6)) {
@@ -8991,14 +8991,11 @@ void
 cob_runtime_warning (const char *fmt, ...)
 {
 	va_list args;
-	FILE	*stderr_f = stderr;
+	FILE	*stderr_f = cobsetptr && cobsetptr->cob_stderr
+		? cobsetptr->cob_stderr : stderr;
 
 	if (cobsetptr && !cobsetptr->cob_display_warn) {
 		return;
-	}
-
-	if (cobsetptr && cobsetptr->cob_stderr) {
-		stderr_f = cobsetptr->cob_stderr;
 	}
 
 	/* Prefix */
@@ -9025,11 +9022,8 @@ void
 cob_runtime_hint (const char *fmt, ...)
 {
 	va_list args;
-	FILE    *stderr_f = stderr;
-
-	if (cobsetptr && cobsetptr->cob_stderr) {
-		stderr_f = cobsetptr->cob_stderr;
-	}
+	FILE    *stderr_f = cobsetptr && cobsetptr->cob_stderr
+		? cobsetptr->cob_stderr : stderr;
 
 	/* Prefix */
 	fprintf (stderr_f, "%s", _("note: "));
@@ -9072,11 +9066,8 @@ cob_runtime_error (const char *fmt, ...)
 {
 	struct handlerlist	*h;
 	va_list				ap;
-	FILE            	*stderr_f = stderr;
-
-	if (cobsetptr && cobsetptr->cob_stderr) {
-		stderr_f = cobsetptr->cob_stderr;
-	}
+	FILE            	*stderr_f = cobsetptr && cobsetptr->cob_stderr 
+		? cobsetptr->cob_stderr : stderr;
 
 	int	more_error_procedures = 1;
 	cob_get_source_line ();
@@ -9212,7 +9203,7 @@ cob_fatal_error (const enum cob_fatal_error fatal_error)
 		if (p && (*p == 'Y' || *p == 'y' ||
 			*p == 'T' || *p == 't' ||
 			*p == '1')) {
-			(void)_setmode (_fileno (stdin), _O_BINARY);
+			(void)_setmode (_fileno (cobsetptr->cob_stdin), _O_BINARY);
 			(void)_setmode (_fileno (cobsetptr->cob_stdout), _O_BINARY);
 			(void)_setmode (_fileno (cobsetptr->cob_stderr), _O_BINARY);
 		}
@@ -10261,7 +10252,7 @@ cob_common_init (void *setptr)
 			}
 		}
 		if (use_unix_lf) {
-			(void)_setmode (_fileno (stdin), _O_BINARY);
+			(void)_setmode (_fileno (cobsetptr->cob_stdin), _O_BINARY);
 			(void)_setmode (_fileno (cobsetptr->cob_stdout), _O_BINARY);
 			(void)_setmode (_fileno (cobsetptr->cob_stderr), _O_BINARY);
 		}
@@ -10427,6 +10418,7 @@ cob_init (const int argc, char **argv)
 	cobsetptr = cob_malloc (sizeof (cob_settings));
 
 	/* TODO: Find a better a place set stdout/stderr initial values */
+	cobsetptr->cob_stdin = stdin;
 	cobsetptr->cob_stdout = stdout;
 	cobsetptr->cob_stderr = stderr;
 
@@ -10600,6 +10592,14 @@ cob_set_runtime_option (enum cob_runtime_option_switch opt, void *p)
 			cobsetptr->cob_dump_filename = cob_strdup ("NONE");
 		}
 		break;
+	case COB_SET_RUNTIME_STDIN_FILE:
+		if (p) {
+			cobsetptr->cob_stdin = (FILE *)p;
+		} else {
+			cobsetptr->cob_stdin = stdin;
+			cob_runtime_warning ("COB_SET_RUNTIME_STDIN_FILE option used "
+				"with null parameter, defaulting back to process stdin");
+		}
 	case COB_SET_RUNTIME_STDOUT_FILE:
 		if (p) {
 			cobsetptr->cob_stdout = (FILE *)p;
@@ -10617,6 +10617,7 @@ cob_set_runtime_option (enum cob_runtime_option_switch opt, void *p)
 			cob_runtime_warning ("COB_SET_RUNTIME_STDERR_FILE option used "
 				"with null parameter, defaulting back to process stderr");
 		}
+		cob_settings_fileio ();
 		break;
 	case COB_SET_RUNTIME_RESCAN_ENV:
 		cob_rescan_env_vals ();
@@ -10647,6 +10648,8 @@ cob_get_runtime_option (enum cob_runtime_option_switch opt)
 		return (void*)cobsetptr->cob_display_punch_file;
 	case COB_SET_RUNTIME_DUMP_FILE:
 		return (void*)cobsetptr->cob_dump_file;
+	case COB_SET_RUNTIME_STDIN_FILE:
+		return (void*)cobsetptr->cob_stdin;
 	case COB_SET_RUNTIME_STDOUT_FILE:
 		return (void*)cobsetptr->cob_stdout;
 	case COB_SET_RUNTIME_STDERR_FILE:

--- a/libcob/common.c
+++ b/libcob/common.c
@@ -9186,13 +9186,6 @@ cob_fatal_error (const enum cob_fatal_error fatal_error)
 	int		status;
 #ifdef	_WIN32
 	char		*p;
-
-	FILE 		*stdin_f = cobsetptr && cobsetptr->cob_stdin
-		? cobsetptr->cob_stdin : stdin;
-	FILE 		*stdout_f = cobsetptr && cobsetptr->cob_stdout
-		? cobsetptr->cob_stdout : stdout;
-	FILE 		*stderr_f = cobsetptr && cobsetptr->cob_stderr
-		? cobsetptr->cob_stderr : stderr;
 #endif
 
 	switch (fatal_error) {
@@ -9213,6 +9206,13 @@ cob_fatal_error (const enum cob_fatal_error fatal_error)
 		if (p && (*p == 'Y' || *p == 'y' ||
 			*p == 'T' || *p == 't' ||
 			*p == '1')) {
+			FILE *stdin_f = cobsetptr && cobsetptr->cob_stdin
+				? cobsetptr->cob_stdin : stdin;
+			FILE *stdout_f = cobsetptr && cobsetptr->cob_stdout
+				? cobsetptr->cob_stdout : stdout;
+			FILE *stderr_f = cobsetptr && cobsetptr->cob_stderr
+				? cobsetptr->cob_stderr : stderr;
+
 			(void)_setmode (_fileno (stdin_f), _O_BINARY);
 			(void)_setmode (_fileno (stdout_f), _O_BINARY);
 			(void)_setmode (_fileno (stderr_f), _O_BINARY);

--- a/libcob/common.c
+++ b/libcob/common.c
@@ -10571,7 +10571,7 @@ cob_init (const int argc, char **argv)
 
 /*
  * Set special runtime options:
- * Currently this is only FILE * for trace, printer and stdout/stderr output
+ * Currently this is only FILE * for trace, printer and stdin/stdout/stderr
  * or to reload the runtime configuration after changing environment
  */
 void

--- a/libcob/common.c
+++ b/libcob/common.c
@@ -872,7 +872,7 @@ ss_terminate_routines (void)
 			if (!(dump_trace_started & (DUMP_TRACE_DONE_TRACE | DUMP_TRACE_ACTIVE_TRACE))) {
 				dump_trace_started |= DUMP_TRACE_DONE_TRACE;
 				dump_trace_started |= DUMP_TRACE_ACTIVE_TRACE;
-				cob_stack_trace_internal (cobsetptr->cob_stderr, 1, 0);
+				cob_stack_trace_internal (COB_STDERR, 1, 0);
 				dump_trace_started ^= DUMP_TRACE_ACTIVE_TRACE;
 			}
 		}
@@ -887,7 +887,7 @@ cob_terminate_routines (void)
 	if (!cob_initialized || !cobglobptr) {
 		return;
 	}
-	fflush (cobsetptr->cob_stderr);
+	fflush (COB_STDERR);
 
 	cob_prof_end ();
 	cob_exit_fileio_msg_only ();
@@ -897,7 +897,7 @@ cob_terminate_routines (void)
 			if (!(dump_trace_started & (DUMP_TRACE_DONE_TRACE | DUMP_TRACE_ACTIVE_TRACE))) {
 				dump_trace_started |= DUMP_TRACE_DONE_TRACE;
 				dump_trace_started |= DUMP_TRACE_ACTIVE_TRACE;
-				cob_stack_trace_internal (cobsetptr->cob_stderr, 1, 0);
+				cob_stack_trace_internal (COB_STDERR, 1, 0);
 				dump_trace_started ^= DUMP_TRACE_ACTIVE_TRACE;
 			}
 		}
@@ -908,7 +908,7 @@ cob_terminate_routines (void)
 	}
 
 	if (cobsetptr->cob_dump_file == cobsetptr->cob_trace_file
-	 || cobsetptr->cob_dump_file == cobsetptr->cob_stderr) {
+	 || cobsetptr->cob_dump_file == COB_STDERR) {
 		cobsetptr->cob_dump_file = NULL;
 	}
 
@@ -920,7 +920,7 @@ cob_terminate_routines (void)
 #ifdef COB_DEBUG_LOG
 	/* close debug log (delete file if empty) */
 	if (cob_debug_file
-	 && cob_debug_file != cobsetptr->cob_stderr) {
+	 && cob_debug_file != COB_STDERR) {
 		/* note: cob_debug_file can only be identical to cob_trace_file
 		         if same file name was used, not with external_trace_file */
 		if (cob_debug_file == cobsetptr->cob_trace_file) {
@@ -942,7 +942,7 @@ cob_terminate_routines (void)
 #endif
 
 	if (cobsetptr->cob_trace_file
-	 && cobsetptr->cob_trace_file != cobsetptr->cob_stderr
+	 && cobsetptr->cob_trace_file != COB_STDERR
 	 && !cobsetptr->external_trace_file	/* note: may include stdout */) {
 		fclose (cobsetptr->cob_trace_file);
 	}
@@ -1170,9 +1170,9 @@ create_dumpfile (void)
 
 	ret = system (cmd);
 	if (ret) {
-		fprintf (cobsetptr->cob_stderr, "\nlibcob: ");
-		fprintf (cobsetptr->cob_stderr, _("requested coredump creation failed with status %d"), ret);
-		fprintf (cobsetptr->cob_stderr, "\n\t%s\t%s\n", _("executing:"), (char *)cmd);
+		fprintf (COB_STDERR, "\nlibcob: ");
+		fprintf (COB_STDERR, _("requested coredump creation failed with status %d"), ret);
+		fprintf (COB_STDERR, "\n\t%s\t%s\n", _("executing:"), (char *)cmd);
 	}
 	return ret;
 }
@@ -1240,8 +1240,8 @@ cob_sig_handler (int sig)
 #ifdef	SIGHUP
 	case SIGHUP:
 #endif
-		fflush (cobsetptr->cob_stderr);
-		fflush (cobsetptr->cob_stdout);
+		fflush (COB_STDERR);
+		fflush (COB_STDOUT);
 		break;
 	default:
 		break;
@@ -2322,10 +2322,10 @@ cob_check_trace_file (void)
 			/* could not open the file
 			   unset the filename for not referencing it later */
 			cobsetptr->cob_trace_filename = NULL;
-			cobsetptr->cob_trace_file = cobsetptr->cob_stderr;
+			cobsetptr->cob_trace_file = COB_STDERR;
 		}
 	} else {
-		cobsetptr->cob_trace_file = cobsetptr->cob_stderr;
+		cobsetptr->cob_trace_file = COB_STDERR;
 	}
 }
 
@@ -2337,7 +2337,7 @@ cob_new_trace_file (void)
 
 	if (!cobsetptr->cob_trace_file
 	 || cobsetptr->external_trace_file
-	 || cobsetptr->cob_trace_file == cobsetptr->cob_stderr) {
+	 || cobsetptr->cob_trace_file == COB_STDERR) {
 		cobsetptr->cob_trace_file = NULL;
 		cob_check_trace_file ();
 		return;
@@ -3310,12 +3310,12 @@ cob_hard_failure_internal (const char *prefix)
 {
 	unsigned int core_on_error;
 	if (prefix) {
-		fprintf (cobsetptr->cob_stderr, "\n%s: ", prefix);
+		fprintf (COB_STDERR, "\n%s: ", prefix);
 	} else {
-		fprintf (cobsetptr->cob_stderr, "\n");
+		fprintf (COB_STDERR, "\n");
 	}
-	fprintf (cobsetptr->cob_stderr, _("Please report this!"));
-	fprintf (cobsetptr->cob_stderr, "\n");
+	fprintf (COB_STDERR, _("Please report this!"));
+	fprintf (COB_STDERR, "\n");
 	core_on_error = handle_core_on_error ();
 	if (core_on_error != 4) {
 		if (core_on_error == 2 && cob_initialized) {
@@ -6631,15 +6631,15 @@ cob_sys_hosted (void *p, const void *var)
 			return 0;
 		}
 		if ((i == 5) && !memcmp (name, "stdin", 5)) {
-			*((FILE **)data) = cobsetptr->cob_stdin;
+			*((FILE **)data) = COB_STDIN;
 			return 0;
 		}
 		if ((i == 6) && !memcmp (name, "stdout", 6)) {
-			*((FILE **)data) = cobsetptr->cob_stdout;
+			*((FILE **)data) = COB_STDOUT;
 			return 0;
 		}
 		if ((i == 6) && !memcmp (name, "stderr", 6)) {
-			*((FILE **)data) = cobsetptr->cob_stderr;
+			*((FILE **)data) = COB_STDERR;
 			return 0;
 		}
 		if ((i == 5) && !memcmp (name, "errno", 5)) {
@@ -8144,19 +8144,19 @@ set_config_val (char *value, int pos)
 		 && gc_conf[pos].enums[i].match == NULL
 		 && (!(data_type & ENV_BOOL))) {
 			conf_runtime_error_value (ptr, pos);
-			fprintf (cobsetptr->cob_stderr, _("should be one of the following values: %s"), "");
+			fprintf (COB_STDERR, _("should be one of the following values: %s"), "");
 			for (i = 0; gc_conf[pos].enums[i].match != NULL; i++) {
 				if (i != 0) {
-					putc (',', cobsetptr->cob_stderr);
-					putc (' ', cobsetptr->cob_stderr);
+					putc (',', COB_STDERR);
+					putc (' ', COB_STDERR);
 				}
-				fprintf (cobsetptr->cob_stderr, "%s", (char *)gc_conf[pos].enums[i].match);
+				fprintf (COB_STDERR, "%s", (char *)gc_conf[pos].enums[i].match);
 				if (data_type & ENV_ENUMVAL) {
-					fprintf (cobsetptr->cob_stderr, "(%s)", (char *)gc_conf[pos].enums[i].value);
+					fprintf (COB_STDERR, "(%s)", (char *)gc_conf[pos].enums[i].value);
 				}
 			}
-			putc ('\n', cobsetptr->cob_stderr);
-			fflush (cobsetptr->cob_stderr);
+			putc ('\n', COB_STDERR);
+			fflush (COB_STDERR);
 			return 1;
 		}
 	}
@@ -8315,8 +8315,8 @@ set_config_val (char *value, int pos)
 		}
 
 		if (data_loc == offsetof (cob_settings, cob_stdin_filename)
-			|| data_loc == offsetof (cob_settings, cob_stdout_filename)
-			|| data_loc == offsetof (cob_settings, cob_stderr_filename)) {
+		    || data_loc == offsetof (cob_settings, cob_stdout_filename)
+		    || data_loc == offsetof (cob_settings, cob_stderr_filename)) {
 			cob_settings_termio ();
 		}
 	} else if (data_type & ENV_STR) {	/* String (environment expanded) */
@@ -8943,26 +8943,26 @@ cob_runtime_warning_external (const char *caller_name, const int cob_reference, 
 	}
 
 	/* Prefix */
-	fprintf (cobsetptr->cob_stderr, "libcob: ");
+	fprintf (COB_STDERR, "libcob: ");
 	if (cob_reference) {
 		char buff[COB_MINI_BUFF];
 		cob_get_source_line ();
 		get_source_location (buff);
-		fprintf (cobsetptr->cob_stderr, "%s", buff);
+		fprintf (COB_STDERR, "%s", buff);
 	}
-	fprintf (cobsetptr->cob_stderr, _("warning: "));
+	fprintf (COB_STDERR, _("warning: "));
 
 	if (!(caller_name && *caller_name)) caller_name = "unknown caller";
-	fprintf (cobsetptr->cob_stderr, "%s: ", caller_name);
+	fprintf (COB_STDERR, "%s: ", caller_name);
 
 	/* Body */
 	va_start (args, fmt);
-	vfprintf (cobsetptr->cob_stderr, fmt, args);
+	vfprintf (COB_STDERR, fmt, args);
 	va_end (args);
 
 	/* Postfix */
-	putc ('\n', cobsetptr->cob_stderr);
-	fflush (cobsetptr->cob_stderr);
+	putc ('\n', COB_STDERR);
+	fflush (COB_STDERR);
 }
 
 /* output non-buffered (signal-async-safe) runtime warning,
@@ -8999,51 +8999,47 @@ void
 cob_runtime_warning (const char *fmt, ...)
 {
 	va_list args;
-	FILE	*stderr_f = cobsetptr && cobsetptr->cob_stderr
-		? cobsetptr->cob_stderr : stderr;
 
 	if (cobsetptr && !cobsetptr->cob_display_warn) {
 		return;
 	}
 
 	/* Prefix */
-	fprintf (stderr_f, "libcob: ");
+	fprintf (COB_STDERR_OR_DEFAULT, "libcob: ");
 	{
 		char buff[COB_MINI_BUFF];
 		cob_get_source_line ();
 		get_source_location (buff);
-		fprintf (stderr_f, "%s", buff);
+		fprintf (COB_STDERR_OR_DEFAULT, "%s", buff);
 	}
-	fprintf (stderr_f, _("warning: "));
+	fprintf (COB_STDERR_OR_DEFAULT, _("warning: "));
 
 	/* Body */
 	va_start (args, fmt);
-	vfprintf (stderr_f, fmt, args);
+	vfprintf (COB_STDERR_OR_DEFAULT, fmt, args);
 	va_end (args);
 
 	/* Postfix */
-	putc ('\n', stderr_f);
-	fflush (stderr_f);
+	putc ('\n', COB_STDERR_OR_DEFAULT);
+	fflush (COB_STDERR_OR_DEFAULT);
 }
 
 void
 cob_runtime_hint (const char *fmt, ...)
 {
 	va_list args;
-	FILE    *stderr_f = cobsetptr && cobsetptr->cob_stderr
-		? cobsetptr->cob_stderr : stderr;
 
 	/* Prefix */
-	fprintf (stderr_f, "%s", _("note: "));
+	fprintf (COB_STDERR_OR_DEFAULT, "%s", _("note: "));
 
 	/* Body */
 	va_start (args, fmt);
-	vfprintf (stderr_f, fmt, args);
+	vfprintf (COB_STDERR_OR_DEFAULT, fmt, args);
 	va_end (args);
 
 	/* Postfix */
-	putc ('\n', stderr_f);
-	fflush (stderr_f);
+	putc ('\n', COB_STDERR_OR_DEFAULT);
+	fflush (COB_STDERR_OR_DEFAULT);
 }
 
 /* extra function for direct interaction with the debugger
@@ -9074,8 +9070,6 @@ cob_runtime_error (const char *fmt, ...)
 {
 	struct handlerlist	*h;
 	va_list				ap;
-	FILE            	*stderr_f = cobsetptr && cobsetptr->cob_stderr 
-		? cobsetptr->cob_stderr : stderr;
 
 	int	more_error_procedures = 1;
 	cob_get_source_line ();
@@ -9150,31 +9144,31 @@ cob_runtime_error (const char *fmt, ...)
 		const char		*source_file;
 		unsigned int	 source_line;
 		set_source_location (&source_file, &source_line);
-		fputs ("libcob: ", stderr_f);
+		fputs ("libcob: ", COB_STDERR_OR_DEFAULT);
 		if (source_file) {
-			fprintf (stderr_f, "%s:", source_file);
+			fprintf (COB_STDERR_OR_DEFAULT, "%s:", source_file);
 			if (source_line) {
-				fprintf (stderr_f, "%u:", source_line);
+				fprintf (COB_STDERR_OR_DEFAULT, "%u:", source_line);
 			}
-			fputc (' ', stderr_f);
+			fputc (' ', COB_STDERR_OR_DEFAULT);
 		}
-		fprintf (stderr_f, "%s: ", _("error"));
+		fprintf (COB_STDERR_OR_DEFAULT, "%s: ", _("error"));
 
 		/* Body */
 		va_start (ap, fmt);
-		vfprintf (stderr_f, fmt, ap);
+		vfprintf (COB_STDERR_OR_DEFAULT, fmt, ap);
 		va_end (ap);
 
 		/* Postfix */
-		fputc ('\n', stderr_f);
-		fflush (stderr_f);
+		fputc ('\n', COB_STDERR_OR_DEFAULT);
+		fflush (COB_STDERR_OR_DEFAULT);
 	}
 
 	/* setup reason for optional module dump */
 	if (cob_initialized && abort_reason[0] == 0) {
 #if 0	/* Is there a use in this message ?*/
-		fputc ('\n', stderr_f);
-		fprintf (stderr_f, _("abnormal termination - file contents may be incorrect"));
+		fputc ('\n', COB_STDERR_OR_DEFAULT);
+		fprintf (COB_STDERR_OR_DEFAULT, _("abnormal termination - file contents may be incorrect"));
 #endif
 		va_start (ap, fmt);
 		vsnprintf (abort_reason, COB_MINI_BUFF, fmt, ap);
@@ -9211,16 +9205,11 @@ cob_fatal_error (const enum cob_fatal_error fatal_error)
 		if (p && (*p == 'Y' || *p == 'y' ||
 			*p == 'T' || *p == 't' ||
 			*p == '1')) {
-			FILE *stdin_f = cobsetptr && cobsetptr->cob_stdin
-				? cobsetptr->cob_stdin : stdin;
-			FILE *stdout_f = cobsetptr && cobsetptr->cob_stdout
-				? cobsetptr->cob_stdout : stdout;
-			FILE *stderr_f = cobsetptr && cobsetptr->cob_stderr
-				? cobsetptr->cob_stderr : stderr;
-
-			(void)_setmode (_fileno (stdin_f), _O_BINARY);
-			(void)_setmode (_fileno (stdout_f), _O_BINARY);
-			(void)_setmode (_fileno (stderr_f), _O_BINARY);
+			/* using the process stdin/stdout/stderr instead of the ones in
+			settings here, as settings is not initialized at this point */
+			(void)_setmode (_fileno (stdin), _O_BINARY);
+			(void)_setmode (_fileno (stdout), _O_BINARY);
+			(void)_setmode (_fileno (stderr), _O_BINARY);
 		}
 #endif
 		/* note: same message in call.c */
@@ -9405,8 +9394,8 @@ conf_runtime_error (const int finish_error, const char *fmt, ...)
 
 	if (!conf_runtime_error_displayed) {
 		conf_runtime_error_displayed = 1;
-		fputs (_("configuration error:"), cobsetptr->cob_stderr);
-		putc ('\n', cobsetptr->cob_stderr);
+		fputs (_("configuration error:"), COB_STDERR);
+		putc ('\n', COB_STDERR);
 	}
 
 	/* Prefix; note: no need to strcmp as we check against
@@ -9416,30 +9405,30 @@ conf_runtime_error (const int finish_error, const char *fmt, ...)
 		last_runtime_error_file = cob_source_file;
 		last_runtime_error_line = cob_source_line;
 		if (cob_source_file) {
-			fprintf (cobsetptr->cob_stderr, "%s", cob_source_file);
+			fprintf (COB_STDERR, "%s", cob_source_file);
 			if (cob_source_line) {
-				fprintf (cobsetptr->cob_stderr, ":%u", cob_source_line);
+				fprintf (COB_STDERR, ":%u", cob_source_line);
 			}
 		} else {
-			fprintf (cobsetptr->cob_stderr, "%s", _("environment variables"));
+			fprintf (COB_STDERR, "%s", _("environment variables"));
 		}
-		fputc(':', cobsetptr->cob_stderr);
-		fputc(' ', cobsetptr->cob_stderr);
+		fputc(':', COB_STDERR);
+		fputc(' ', COB_STDERR);
 	}
 
 	/* Body */
 	va_start (args, fmt);
-	vfprintf (cobsetptr->cob_stderr, fmt, args);
+	vfprintf (COB_STDERR, fmt, args);
 	va_end (args);
 
 	/* Postfix */
 	if (!finish_error) {
-		putc (';', cobsetptr->cob_stderr);
-		putc ('\n', cobsetptr->cob_stderr);
-		putc ('\t', cobsetptr->cob_stderr);
+		putc (';', COB_STDERR);
+		putc ('\n', COB_STDERR);
+		putc ('\t', COB_STDERR);
 	} else {
-		putc ('\n', cobsetptr->cob_stderr);
-		fflush (cobsetptr->cob_stderr);
+		putc ('\n', COB_STDERR);
+		fflush (COB_STDERR);
 	}
 }
 
@@ -10251,32 +10240,27 @@ cob_common_init (void *setptr)
 #ifdef	_WIN32
 	/* Allows running tests under Win */
 	{
+		if (setptr) {
+			/* termio initialization does this when settings is initialized */
+			return;
+		}
+
 		int use_unix_lf = 0;
 		char *s = getenv ("COB_UNIX_LF");
 
-		if (s != NULL) {
-			if (setptr) {
-				set_config_val_by_name (s, "unix_lf", NULL);
-				use_unix_lf = cobsetptr->cob_unix_lf;
-			} else
-			if (*s == 'Y' || *s == 'y' ||
-			    *s == 'O' || *s == 'o' ||
-			    *s == 'T' || *s == 't' ||
-			    *s == '1') {
-				use_unix_lf = 1;
-			}
+		if (s == NULL) {
+			return;
 		}
-		if (use_unix_lf) {
-			FILE *stdin_f = cobsetptr && cobsetptr->cob_stdin
-				? cobsetptr->cob_stdin : stdin;
-			FILE *stdout_f = cobsetptr && cobsetptr->cob_stdout
-				? cobsetptr->cob_stdout : stdout;
-			FILE *stderr_f = cobsetptr && cobsetptr->cob_stderr
-				? cobsetptr->cob_stderr : stderr;
 
-			(void)_setmode (_fileno (stdin_f), _O_BINARY);
-			(void)_setmode (_fileno (stdout_f), _O_BINARY);
-			(void)_setmode (_fileno (stderr_f), _O_BINARY);
+		if (*s == 'Y' || *s == 'y' || *s == 'O' ||
+			*s == 'o' || *s == 'T' || *s == 't' || *s == '1') {
+			use_unix_lf = 1;
+		}
+
+		if (use_unix_lf) {
+			(void)_setmode (_fileno (stdin), _O_BINARY);
+			(void)_setmode (_fileno (stdout), _O_BINARY);
+			(void)_setmode (_fileno (stderr), _O_BINARY);
 		}
 	}
 #endif
@@ -10439,9 +10423,9 @@ cob_init (const int argc, char **argv)
 	/* Get settings structure */
 	cobsetptr = cob_malloc (sizeof (cob_settings));
 
-	cobsetptr->cob_stdin = stdin;
-	cobsetptr->cob_stdout = stdout;
-	cobsetptr->cob_stderr = stderr;
+	COB_STDIN = stdin;
+	COB_STDOUT = stdout;
+	COB_STDERR = stderr;
 
 	cob_initialized = 1;
 
@@ -10614,31 +10598,58 @@ cob_set_runtime_option (enum cob_runtime_option_switch opt, void *p)
 		}
 		break;
 	case COB_SET_RUNTIME_STDIN_FILE:
-		if (p) {
-			cobsetptr->cob_stdin = (FILE *)p;
-		} else {
-			cobsetptr->cob_stdin = stdin;
+		if (!p) {
 			cob_runtime_warning ("COB_SET_RUNTIME_STDIN_FILE option used "
-				"with null parameter, defaulting back to process stdin");
+				"with null parameter, ignoring");
+			break;
 		}
+		/* Closing/cleaning previous if owned by libcob */
+		if (cobsetptr->cob_stdin_filename) {
+			cob_free (cobsetptr->cob_stdin_filename);
+			cobsetptr->cob_stdin_filename = NULL;
+		}
+		if (cobsetptr->cob_stdin_filename_set) {
+			cob_free (cobsetptr->cob_stdin_filename_set);
+			cobsetptr->cob_stdin_filename_set = NULL;
+			fclose (COB_STDIN);
+		}
+		COB_STDIN = (FILE *)p;
 		break;
 	case COB_SET_RUNTIME_STDOUT_FILE:
-		if (p) {
-			cobsetptr->cob_stdout = (FILE *)p;
-		} else {
-			cobsetptr->cob_stdout = stdout;
+		if (!p) {
 			cob_runtime_warning ("COB_SET_RUNTIME_STDOUT_FILE option used "
-				"with null parameter, defaulting back to process stdout");
+				"with null parameter, ignoring");
+			break;
 		}
+		/* Closing/cleaning previous if owned by libcob */
+		if (cobsetptr->cob_stdout_filename) {
+			cob_free (cobsetptr->cob_stdout_filename);
+			cobsetptr->cob_stdout_filename = NULL;
+		}
+		if (cobsetptr->cob_stdout_filename_set) {
+			cob_free (cobsetptr->cob_stdout_filename_set);
+			cobsetptr->cob_stdout_filename_set = NULL;
+			fclose (COB_STDOUT);
+		}
+		COB_STDOUT = (FILE *)p;
 	    break;
 	case COB_SET_RUNTIME_STDERR_FILE:
-		if (p) {
-			cobsetptr->cob_stderr = (FILE *)p;
-		} else {
-			cobsetptr->cob_stderr = stderr;
+		if (!p) {
 			cob_runtime_warning ("COB_SET_RUNTIME_STDERR_FILE option used "
 				"with null parameter, defaulting back to process stderr");
+			break;
 		}
+		/* Closing/cleaning previous if owned by libcob */
+		if (cobsetptr->cob_stderr_filename) {
+			cob_free (cobsetptr->cob_stderr_filename);
+			cobsetptr->cob_stderr_filename = NULL;
+		}
+		if (cobsetptr->cob_stderr_filename_set) {
+			cob_free (cobsetptr->cob_stderr_filename_set);
+			cobsetptr->cob_stderr_filename_set = NULL;
+			fclose (COB_STDERR);
+		}
+		COB_STDERR = (FILE *)p;
 		cob_settings_fileio ();
 		break;
 	case COB_SET_RUNTIME_RESCAN_ENV:
@@ -10671,11 +10682,11 @@ cob_get_runtime_option (enum cob_runtime_option_switch opt)
 	case COB_SET_RUNTIME_DUMP_FILE:
 		return (void*)cobsetptr->cob_dump_file;
 	case COB_SET_RUNTIME_STDIN_FILE:
-		return (void*)cobsetptr->cob_stdin;
+		return cobsetptr ? (void*)COB_STDIN : NULL;
 	case COB_SET_RUNTIME_STDOUT_FILE:
-		return (void*)cobsetptr->cob_stdout;
+		return cobsetptr ? (void*)COB_STDOUT : NULL;
 	case COB_SET_RUNTIME_STDERR_FILE:
-		return (void*)cobsetptr->cob_stderr;
+		return cobsetptr ? (void*)COB_STDERR : NULL;
 	default:
 		cob_runtime_error (_("%s called with unknown option: %d"),
 			"cob_get_runtime_option", opt);
@@ -10700,10 +10711,10 @@ cob_stack_trace (void *target)
 static void
 flush_target (FILE* target)
 {
-	if (target == cobsetptr->cob_stderr
-	 || target == cobsetptr->cob_stdout) {
-		fflush (cobsetptr->cob_stdout);
-		fflush (cobsetptr->cob_stderr);
+	if (target == COB_STDERR
+	 || target == COB_STDOUT) {
+		fflush (COB_STDOUT);
+		fflush (COB_STDERR);
 	} else {
 		fflush (target);
 	}
@@ -10785,7 +10796,7 @@ cob_stack_trace_internal (FILE *target, int verbose, int count)
 		return;
 	}
 
-	if (target == cobsetptr->cob_stderr) {
+	if (target == COB_STDERR) {
 		file_no = STDERR_FILENO;
 	} else {
 		flush_target (target);
@@ -10999,7 +11010,7 @@ cob_get_dump_file (void)
 	if (cobsetptr->cob_trace_file != NULL) {	/* If TRACE active, use that */
 		return cobsetptr->cob_trace_file;
 	} else {
-		return cobsetptr->cob_stderr;
+		return COB_STDERR;
 	}
 #else /* currently only COB_DUMP_TO_FILE used */
 	FILE    *fp;
@@ -11014,10 +11025,10 @@ cob_get_dump_file (void)
 				}
 				fp = fopen(cobsetptr->cob_dump_filename, "a");
 				if(fp == NULL)
-					fp = cobsetptr->cob_stderr;
+					fp = COB_STDERR;
 				cobsetptr->cob_dump_file = fp;
 			} else {
-				fp = cobsetptr->cob_stderr;
+				fp = COB_STDERR;
 			}
 		}
 	} else if (where == COB_DUMP_TO_PRINT) {
@@ -11026,11 +11037,11 @@ cob_get_dump_file (void)
 			if(cobsetptr->cob_trace_file != NULL) {	/* If TRACE active, use that */
 				fp = cobsetptr->cob_trace_file;
 			} else {
-				fp = cobsetptr->cob_stdout;
+				fp = COB_STDOUT;
 			}
 		}
 	} else {
-		fp = cobsetptr->cob_stderr;
+		fp = COB_STDERR;
 	}
 	return fp;
 #endif
@@ -11051,12 +11062,12 @@ cob_dump_module (char *reason)
 		}
 		if (mod->next == mod) {
 			/* not translated as highly unexpected */
-			fputs ("FIXME: recursive mod (module dump)\n", cobsetptr->cob_stderr);
+			fputs ("FIXME: recursive mod (module dump)\n", COB_STDERR);
 			break;
 		}
 		if (k++ == MAX_MODULE_ITERS) {
 			/* not translated as highly unexpected */
-			fputs ("max module iterations exceeded, possible broken chain\n", cobsetptr->cob_stderr);
+			fputs ("max module iterations exceeded, possible broken chain\n", COB_STDERR);
 			break;
 		}
 		if (mod->flag_dump_ready) {
@@ -11076,7 +11087,7 @@ cob_dump_module (char *reason)
 		if (fp == NULL) {
 			return;
 		}
-		if (fp != cobsetptr->cob_stderr) {
+		if (fp != COB_STDERR) {
 			if (reason) {
 				if (reason[0] == 0) {
 					reason = (char *)_ ("unknown");
@@ -11086,7 +11097,7 @@ cob_dump_module (char *reason)
 				fputc ('\n', fp);
 				fflush (fp);
 			}
-			if (fp != cobsetptr->cob_stdout) {
+			if (fp != COB_STDOUT) {
 				/* was already sent to stderr before this function was called,
 				   so skip here for stdout/stderr ... */
 				if (!(dump_trace_started & DUMP_TRACE_ACTIVE_TRACE)) {
@@ -11096,7 +11107,7 @@ cob_dump_module (char *reason)
 				}
 			}
 		} else {
-			fflush (cobsetptr->cob_stderr);
+			fflush (COB_STDERR);
 		}
 
 		fputc ('\n', fp);
@@ -11124,7 +11135,7 @@ cob_dump_module (char *reason)
 		if (previous_locale) {
 			setlocale (LC_CTYPE, previous_locale);
 		}
-		if (fp != cobsetptr->cob_stdout && fp != cobsetptr->cob_stderr) {
+		if (fp != COB_STDOUT && fp != COB_STDERR) {
 			char * fname = NULL;
 			if (cobsetptr->cob_dump_filename) {
 				fname = cobsetptr->cob_dump_filename;
@@ -11135,10 +11146,10 @@ cob_dump_module (char *reason)
 				fname = cobsetptr->cob_trace_filename;
 			}
 			if (fname != NULL) {
-				fputc ('\n', cobsetptr->cob_stderr);
-				fprintf (cobsetptr->cob_stderr, _("dump written to %s"), fname);
-				fputc ('\n', cobsetptr->cob_stderr);
-				fflush (cobsetptr->cob_stderr);
+				fputc ('\n', COB_STDERR);
+				fprintf (COB_STDERR, _("dump written to %s"), fname);
+				fputc ('\n', COB_STDERR);
+				fflush (COB_STDERR);
 			}
 		}
 	}

--- a/libcob/common.c
+++ b/libcob/common.c
@@ -581,6 +581,9 @@ static struct config_tbl gc_conf[] = {
 	{"COB_PROF_FILE", "prof_file",		"cob-prof-$b-$$-$d-$t.csv",	NULL, GRP_MISC, ENV_FILE, SETPOS (cob_prof_filename)},
 	{"COB_PROF_FORMAT", "prof_format",	"%m,%s,%p,%e,%w,%k,%t,%h,%n", NULL, GRP_MISC, ENV_STR, SETPOS (cob_prof_format)},
 	{"COB_PROF_MAX_DEPTH", "prof_max_depth",        "8192",	NULL, GRP_MISC, ENV_UINT, SETPOS (cob_prof_max_depth)},
+	{"COB_STDIN_FILE", "stdin_file", 		NULL, 	NULL, GRP_MISC, ENV_FILE, SETPOS (cob_stdin_filename)},
+	{"COB_STDOUT_FILE", "stdout_file", 		NULL, 	NULL, GRP_MISC, ENV_FILE, SETPOS (cob_stdout_filename)},
+	{"COB_STDERR_FILE", "stderr_file", 		NULL, 	NULL, GRP_MISC, ENV_FILE, SETPOS (cob_stderr_filename)},
 #ifdef  _WIN32
 	/* checked before configuration load if set from environment in cob_common_init() */
 	{"COB_UNIX_LF", "unix_lf", 		"0", 	NULL, GRP_FILE, ENV_BOOL, SETPOS (cob_unix_lf)},
@@ -10490,6 +10493,39 @@ cob_init (const int argc, char **argv)
 	/* Load runtime configuration file */
 	if (unlikely (cob_load_config () < 0)) {
 		cob_hard_failure ();
+	}
+
+
+	if (cobsetptr->cob_stdin_filename) {
+		if (!cobsetptr->cob_unix_lf) {
+			cobsetptr->cob_stdin =
+				fopen (cobsetptr->cob_stdin_filename, "r");
+		} else {
+			cobsetptr->cob_stdin =
+				fopen (cobsetptr->cob_stdin_filename, "rb");
+		}
+		if (!cobsetptr->cob_stdin) {
+			cobsetptr->cob_stdin_filename = NULL;
+			cobsetptr->cob_stdin = stdin;
+		}
+	}
+
+	if (cobsetptr->cob_stdout_filename) {
+		cobsetptr->cob_stdout =
+			cob_open_logfile (cobsetptr->cob_stdout_filename);
+		if (!cobsetptr->cob_stdout) {
+			cobsetptr->cob_stdout_filename = NULL;
+			cobsetptr->cob_stdout = stdout;
+		}
+	}
+
+	if (cobsetptr->cob_stderr_filename) {
+		cobsetptr->cob_stderr =
+			cob_open_logfile (cobsetptr->cob_stderr_filename);
+		if (!cobsetptr->cob_stderr) {
+			cobsetptr->cob_stderr_filename = NULL;
+			cobsetptr->cob_stderr = stderr;
+		}
 	}
 
 	/* Copy COB_PHYSICAL_CANCEL from settings (internal) to global structure */

--- a/libcob/common.c
+++ b/libcob/common.c
@@ -10668,6 +10668,9 @@ cob_set_runtime_option (enum cob_runtime_option_switch opt, void *p)
 void *
 cob_get_runtime_option (enum cob_runtime_option_switch opt)
 {
+	if (!cobsetptr) {
+		return NULL;
+	}
 	switch (opt) {
 	case COB_SET_RUNTIME_TRACE_FILE:
 		return (void*)cobsetptr->cob_trace_file;
@@ -10682,11 +10685,11 @@ cob_get_runtime_option (enum cob_runtime_option_switch opt)
 	case COB_SET_RUNTIME_DUMP_FILE:
 		return (void*)cobsetptr->cob_dump_file;
 	case COB_SET_RUNTIME_STDIN_FILE:
-		return cobsetptr ? (void*)COB_STDIN : NULL;
+		return (void*)COB_STDIN;
 	case COB_SET_RUNTIME_STDOUT_FILE:
-		return cobsetptr ? (void*)COB_STDOUT : NULL;
+		return (void*)COB_STDOUT;
 	case COB_SET_RUNTIME_STDERR_FILE:
-		return cobsetptr ? (void*)COB_STDERR : NULL;
+		return (void*)COB_STDERR;
 	default:
 		cob_runtime_error (_("%s called with unknown option: %d"),
 			"cob_get_runtime_option", opt);

--- a/libcob/common.c
+++ b/libcob/common.c
@@ -8314,6 +8314,11 @@ set_config_val (char *value, int pos)
 			cob_new_trace_file ();
 		}
 
+		if (data == (char *)cobsetptr->cob_stdin_filename
+			|| data == (char *)cobsetptr->cob_stdout_filename
+			|| data == (char *)cobsetptr->cob_stderr_filename) {
+			cob_settings_termio ();
+		}
 	} else if (data_type & ENV_STR) {	/* String (environment expanded) */
 		memcpy (&str, data, sizeof (char *));
 		if (str != NULL) {
@@ -10492,39 +10497,6 @@ cob_init (const int argc, char **argv)
 	/* Load runtime configuration file */
 	if (unlikely (cob_load_config () < 0)) {
 		cob_hard_failure ();
-	}
-
-
-	if (cobsetptr->cob_stdin_filename) {
-		if (!cobsetptr->cob_unix_lf) {
-			cobsetptr->cob_stdin =
-				fopen (cobsetptr->cob_stdin_filename, "r");
-		} else {
-			cobsetptr->cob_stdin =
-				fopen (cobsetptr->cob_stdin_filename, "rb");
-		}
-		if (!cobsetptr->cob_stdin) {
-			cobsetptr->cob_stdin_filename = NULL;
-			cobsetptr->cob_stdin = stdin;
-		}
-	}
-
-	if (cobsetptr->cob_stdout_filename) {
-		cobsetptr->cob_stdout =
-			cob_open_logfile (cobsetptr->cob_stdout_filename);
-		if (!cobsetptr->cob_stdout) {
-			cobsetptr->cob_stdout_filename = NULL;
-			cobsetptr->cob_stdout = stdout;
-		}
-	}
-
-	if (cobsetptr->cob_stderr_filename) {
-		cobsetptr->cob_stderr =
-			cob_open_logfile (cobsetptr->cob_stderr_filename);
-		if (!cobsetptr->cob_stderr) {
-			cobsetptr->cob_stderr_filename = NULL;
-			cobsetptr->cob_stderr = stderr;
-		}
 	}
 
 	/* Copy COB_PHYSICAL_CANCEL from settings (internal) to global structure */

--- a/libcob/common.c
+++ b/libcob/common.c
@@ -18,6 +18,7 @@
    along with GnuCOBOL.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+#include "common.h"
 #include "tarstamp.h"
 #include "config.h"
 
@@ -869,7 +870,7 @@ ss_terminate_routines (void)
 			if (!(dump_trace_started & (DUMP_TRACE_DONE_TRACE | DUMP_TRACE_ACTIVE_TRACE))) {
 				dump_trace_started |= DUMP_TRACE_DONE_TRACE;
 				dump_trace_started |= DUMP_TRACE_ACTIVE_TRACE;
-				cob_stack_trace_internal (stderr, 1, 0);
+				cob_stack_trace_internal (cobsetptr->cob_stderr, 1, 0);
 				dump_trace_started ^= DUMP_TRACE_ACTIVE_TRACE;
 			}
 		}
@@ -884,7 +885,7 @@ cob_terminate_routines (void)
 	if (!cob_initialized || !cobglobptr) {
 		return;
 	}
-	fflush (stderr);
+	fflush (cobsetptr->cob_stderr);
 
 	cob_prof_end ();
 	cob_exit_fileio_msg_only ();
@@ -894,7 +895,7 @@ cob_terminate_routines (void)
 			if (!(dump_trace_started & (DUMP_TRACE_DONE_TRACE | DUMP_TRACE_ACTIVE_TRACE))) {
 				dump_trace_started |= DUMP_TRACE_DONE_TRACE;
 				dump_trace_started |= DUMP_TRACE_ACTIVE_TRACE;
-				cob_stack_trace_internal (stderr, 1, 0);
+				cob_stack_trace_internal (cobsetptr->cob_stderr, 1, 0);
 				dump_trace_started ^= DUMP_TRACE_ACTIVE_TRACE;
 			}
 		}
@@ -905,7 +906,7 @@ cob_terminate_routines (void)
 	}
 
 	if (cobsetptr->cob_dump_file == cobsetptr->cob_trace_file
-	 || cobsetptr->cob_dump_file == stderr) {
+	 || cobsetptr->cob_dump_file == cobsetptr->cob_stderr) {
 		cobsetptr->cob_dump_file = NULL;
 	}
 
@@ -917,7 +918,7 @@ cob_terminate_routines (void)
 #ifdef COB_DEBUG_LOG
 	/* close debug log (delete file if empty) */
 	if (cob_debug_file
-	 && cob_debug_file != stderr) {
+	 && cob_debug_file != cobsetptr->cob_stderr) {
 		/* note: cob_debug_file can only be identical to cob_trace_file
 		         if same file name was used, not with external_trace_file */
 		if (cob_debug_file == cobsetptr->cob_trace_file) {
@@ -939,7 +940,7 @@ cob_terminate_routines (void)
 #endif
 
 	if (cobsetptr->cob_trace_file
-	 && cobsetptr->cob_trace_file != stderr
+	 && cobsetptr->cob_trace_file != cobsetptr->cob_stderr
 	 && !cobsetptr->external_trace_file	/* note: may include stdout */) {
 		fclose (cobsetptr->cob_trace_file);
 	}
@@ -1167,9 +1168,9 @@ create_dumpfile (void)
 
 	ret = system (cmd);
 	if (ret) {
-		fprintf (stderr, "\nlibcob: ");
-		fprintf (stderr, _("requested coredump creation failed with status %d"), ret);
-		fprintf (stderr, "\n\t%s\t%s\n", _("executing:"), (char *)cmd);
+		fprintf (cobsetptr->cob_stderr, "\nlibcob: ");
+		fprintf (cobsetptr->cob_stderr, _("requested coredump creation failed with status %d"), ret);
+		fprintf (cobsetptr->cob_stderr, "\n\t%s\t%s\n", _("executing:"), (char *)cmd);
 	}
 	return ret;
 }
@@ -1237,8 +1238,8 @@ cob_sig_handler (int sig)
 #ifdef	SIGHUP
 	case SIGHUP:
 #endif
-		fflush (stderr);
-		fflush (stdout);
+		fflush (cobsetptr->cob_stderr);
+		fflush (cobsetptr->cob_stdout);
 		break;
 	default:
 		break;
@@ -2319,10 +2320,10 @@ cob_check_trace_file (void)
 			/* could not open the file
 			   unset the filename for not referencing it later */
 			cobsetptr->cob_trace_filename = NULL;
-			cobsetptr->cob_trace_file = stderr;
+			cobsetptr->cob_trace_file = cobsetptr->cob_stderr;
 		}
 	} else {
-		cobsetptr->cob_trace_file = stderr;
+		cobsetptr->cob_trace_file = cobsetptr->cob_stderr;
 	}
 }
 
@@ -2334,7 +2335,7 @@ cob_new_trace_file (void)
 
 	if (!cobsetptr->cob_trace_file
 	 || cobsetptr->external_trace_file
-	 || cobsetptr->cob_trace_file == stderr) {
+	 || cobsetptr->cob_trace_file == cobsetptr->cob_stderr) {
 		cobsetptr->cob_trace_file = NULL;
 		cob_check_trace_file ();
 		return;
@@ -3307,12 +3308,12 @@ cob_hard_failure_internal (const char *prefix)
 {
 	unsigned int core_on_error;
 	if (prefix) {
-		fprintf (stderr, "\n%s: ", prefix);
+		fprintf (cobsetptr->cob_stderr, "\n%s: ", prefix);
 	} else {
-		fprintf (stderr, "\n");
+		fprintf (cobsetptr->cob_stderr, "\n");
 	}
-	fprintf (stderr, _("Please report this!"));
-	fprintf (stderr, "\n");
+	fprintf (cobsetptr->cob_stderr, _("Please report this!"));
+	fprintf (cobsetptr->cob_stderr, "\n");
 	core_on_error = handle_core_on_error ();
 	if (core_on_error != 4) {
 		if (core_on_error == 2 && cob_initialized) {
@@ -6632,11 +6633,11 @@ cob_sys_hosted (void *p, const void *var)
 			return 0;
 		}
 		if ((i == 6) && !memcmp (name, "stdout", 6)) {
-			*((FILE **)data) = stdout;
+			*((FILE **)data) = cobsetptr->cob_stdout;
 			return 0;
 		}
 		if ((i == 6) && !memcmp (name, "stderr", 6)) {
-			*((FILE **)data) = stderr;
+			*((FILE **)data) = cobsetptr->cob_stderr;
 			return 0;
 		}
 		if ((i == 5) && !memcmp (name, "errno", 5)) {
@@ -8141,19 +8142,19 @@ set_config_val (char *value, int pos)
 		 && gc_conf[pos].enums[i].match == NULL
 		 && (!(data_type & ENV_BOOL))) {
 			conf_runtime_error_value (ptr, pos);
-			fprintf (stderr, _("should be one of the following values: %s"), "");
+			fprintf (cobsetptr->cob_stderr, _("should be one of the following values: %s"), "");
 			for (i = 0; gc_conf[pos].enums[i].match != NULL; i++) {
 				if (i != 0) {
-					putc (',', stderr);
-					putc (' ', stderr);
+					putc (',', cobsetptr->cob_stderr);
+					putc (' ', cobsetptr->cob_stderr);
 				}
-				fprintf (stderr, "%s", (char *)gc_conf[pos].enums[i].match);
+				fprintf (cobsetptr->cob_stderr, "%s", (char *)gc_conf[pos].enums[i].match);
 				if (data_type & ENV_ENUMVAL) {
-					fprintf (stderr, "(%s)", (char *)gc_conf[pos].enums[i].value);
+					fprintf (cobsetptr->cob_stderr, "(%s)", (char *)gc_conf[pos].enums[i].value);
 				}
 			}
-			putc ('\n', stderr);
-			fflush (stderr);
+			putc ('\n', cobsetptr->cob_stderr);
+			fflush (cobsetptr->cob_stderr);
 			return 1;
 		}
 	}
@@ -8935,26 +8936,26 @@ cob_runtime_warning_external (const char *caller_name, const int cob_reference, 
 	}
 
 	/* Prefix */
-	fprintf (stderr, "libcob: ");
+	fprintf (cobsetptr->cob_stderr, "libcob: ");
 	if (cob_reference) {
 		char buff[COB_MINI_BUFF];
 		cob_get_source_line ();
 		get_source_location (buff);
-		fprintf (stderr, "%s", buff);
+		fprintf (cobsetptr->cob_stderr, "%s", buff);
 	}
-	fprintf (stderr, _("warning: "));
+	fprintf (cobsetptr->cob_stderr, _("warning: "));
 
 	if (!(caller_name && *caller_name)) caller_name = "unknown caller";
-	fprintf (stderr, "%s: ", caller_name);
+	fprintf (cobsetptr->cob_stderr, "%s: ", caller_name);
 
 	/* Body */
 	va_start (args, fmt);
-	vfprintf (stderr, fmt, args);
+	vfprintf (cobsetptr->cob_stderr, fmt, args);
 	va_end (args);
 
 	/* Postfix */
-	putc ('\n', stderr);
-	fflush (stderr);
+	putc ('\n', cobsetptr->cob_stderr);
+	fflush (cobsetptr->cob_stderr);
 }
 
 /* output non-buffered (signal-async-safe) runtime warning,
@@ -8998,23 +8999,23 @@ cob_runtime_warning (const char *fmt, ...)
 
 
 	/* Prefix */
-	fprintf (stderr, "libcob: ");
+	fprintf (cobsetptr->cob_stderr, "libcob: ");
 	{
 		char buff[COB_MINI_BUFF];
 		cob_get_source_line ();
 		get_source_location (buff);
-		fprintf (stderr, "%s", buff);
+		fprintf (cobsetptr->cob_stderr, "%s", buff);
 	}
-	fprintf (stderr, _("warning: "));
+	fprintf (cobsetptr->cob_stderr, _("warning: "));
 
 	/* Body */
 	va_start (args, fmt);
-	vfprintf (stderr, fmt, args);
+	vfprintf (cobsetptr->cob_stderr, fmt, args);
 	va_end (args);
 
 	/* Postfix */
-	putc ('\n', stderr);
-	fflush (stderr);
+	putc ('\n', cobsetptr->cob_stderr);
+	fflush (cobsetptr->cob_stderr);
 }
 
 void
@@ -9023,16 +9024,16 @@ cob_runtime_hint (const char *fmt, ...)
 	va_list args;
 
 	/* Prefix */
-	fprintf (stderr, "%s", _("note: "));
+	fprintf (cobsetptr->cob_stderr, "%s", _("note: "));
 
 	/* Body */
 	va_start (args, fmt);
-	vfprintf (stderr, fmt, args);
+	vfprintf (cobsetptr->cob_stderr, fmt, args);
 	va_end (args);
 
 	/* Postfix */
-	putc ('\n', stderr);
-	fflush (stderr);
+	putc ('\n', cobsetptr->cob_stderr);
+	fflush (cobsetptr->cob_stderr);
 }
 
 /* extra function for direct interaction with the debugger
@@ -9137,31 +9138,31 @@ cob_runtime_error (const char *fmt, ...)
 		const char		*source_file;
 		unsigned int	 source_line;
 		set_source_location (&source_file, &source_line);
-		fputs ("libcob: ", stderr);
+		fputs ("libcob: ", cobsetptr->cob_stderr);
 		if (source_file) {
-			fprintf (stderr, "%s:", source_file);
+			fprintf (cobsetptr->cob_stderr, "%s:", source_file);
 			if (source_line) {
-				fprintf (stderr, "%u:", source_line);
+				fprintf (cobsetptr->cob_stderr, "%u:", source_line);
 			}
-			fputc (' ', stderr);
+			fputc (' ', cobsetptr->cob_stderr);
 		}
-		fprintf (stderr, "%s: ", _("error"));
+		fprintf (cobsetptr->cob_stderr, "%s: ", _("error"));
 
 		/* Body */
 		va_start (ap, fmt);
-		vfprintf (stderr, fmt, ap);
+		vfprintf (cobsetptr->cob_stderr, fmt, ap);
 		va_end (ap);
 
 		/* Postfix */
-		fputc ('\n', stderr);
-		fflush (stderr);
+		fputc ('\n', cobsetptr->cob_stderr);
+		fflush (cobsetptr->cob_stderr);
 	}
 
 	/* setup reason for optional module dump */
 	if (cob_initialized && abort_reason[0] == 0) {
 #if 0	/* Is there a use in this message ?*/
-		fputc ('\n', stderr);
-		fprintf (stderr, _("abnormal termination - file contents may be incorrect"));
+		fputc ('\n', cobsetptr->cob_stderr);
+		fprintf (cobsetptr->cob_stderr, _("abnormal termination - file contents may be incorrect"));
 #endif
 		va_start (ap, fmt);
 		vsnprintf (abort_reason, COB_MINI_BUFF, fmt, ap);
@@ -9199,8 +9200,8 @@ cob_fatal_error (const enum cob_fatal_error fatal_error)
 			*p == 'T' || *p == 't' ||
 			*p == '1')) {
 			(void)_setmode (_fileno (stdin), _O_BINARY);
-			(void)_setmode (_fileno (stdout), _O_BINARY);
-			(void)_setmode (_fileno (stderr), _O_BINARY);
+			(void)_setmode (_fileno (cobsetptr->cob_stdout), _O_BINARY);
+			(void)_setmode (_fileno (cobsetptr->cob_stderr), _O_BINARY);
 		}
 #endif
 		/* note: same message in call.c */
@@ -9385,8 +9386,8 @@ conf_runtime_error (const int finish_error, const char *fmt, ...)
 
 	if (!conf_runtime_error_displayed) {
 		conf_runtime_error_displayed = 1;
-		fputs (_("configuration error:"), stderr);
-		putc ('\n', stderr);
+		fputs (_("configuration error:"), cobsetptr->cob_stderr);
+		putc ('\n', cobsetptr->cob_stderr);
 	}
 
 	/* Prefix; note: no need to strcmp as we check against
@@ -9396,30 +9397,30 @@ conf_runtime_error (const int finish_error, const char *fmt, ...)
 		last_runtime_error_file = cob_source_file;
 		last_runtime_error_line = cob_source_line;
 		if (cob_source_file) {
-			fprintf (stderr, "%s", cob_source_file);
+			fprintf (cobsetptr->cob_stderr, "%s", cob_source_file);
 			if (cob_source_line) {
-				fprintf (stderr, ":%u", cob_source_line);
+				fprintf (cobsetptr->cob_stderr, ":%u", cob_source_line);
 			}
 		} else {
-			fprintf (stderr, "%s", _("environment variables"));
+			fprintf (cobsetptr->cob_stderr, "%s", _("environment variables"));
 		}
-		fputc(':', stderr);
-		fputc(' ', stderr);
+		fputc(':', cobsetptr->cob_stderr);
+		fputc(' ', cobsetptr->cob_stderr);
 	}
 
 	/* Body */
 	va_start (args, fmt);
-	vfprintf (stderr, fmt, args);
+	vfprintf (cobsetptr->cob_stderr, fmt, args);
 	va_end (args);
 
 	/* Postfix */
 	if (!finish_error) {
-		putc (';', stderr);
-		putc ('\n', stderr);
-		putc ('\t', stderr);
+		putc (';', cobsetptr->cob_stderr);
+		putc ('\n', cobsetptr->cob_stderr);
+		putc ('\t', cobsetptr->cob_stderr);
 	} else {
-		putc ('\n', stderr);
-		fflush (stderr);
+		putc ('\n', cobsetptr->cob_stderr);
+		fflush (cobsetptr->cob_stderr);
 	}
 }
 
@@ -10248,8 +10249,8 @@ cob_common_init (void *setptr)
 		}
 		if (use_unix_lf) {
 			(void)_setmode (_fileno (stdin), _O_BINARY);
-			(void)_setmode (_fileno (stdout), _O_BINARY);
-			(void)_setmode (_fileno (stderr), _O_BINARY);
+			(void)_setmode (_fileno (cobsetptr->cob_stdout), _O_BINARY);
+			(void)_setmode (_fileno (cobsetptr->cob_stderr), _O_BINARY);
 		}
 	}
 #endif
@@ -10411,6 +10412,10 @@ cob_init (const int argc, char **argv)
 
 	/* Get settings structure */
 	cobsetptr = cob_malloc (sizeof (cob_settings));
+
+	/* TODO: Find a better a place set stdout/stderr initial values */
+	cobsetptr->cob_stdout = stdout;
+	cobsetptr->cob_stderr = stderr;
 
 	cob_initialized = 1;
 
@@ -10585,6 +10590,16 @@ cob_set_runtime_option (enum cob_runtime_option_switch opt, void *p)
 	case COB_SET_RUNTIME_RESCAN_ENV:
 		cob_rescan_env_vals ();
 		break;
+	case COB_SET_RUNTIME_STDOUT_FILE:
+		if (p) {
+			cobsetptr->cob_stdout = (FILE *)p;
+		}
+	    break;
+	case COB_SET_RUNTIME_STDERR_FILE:
+		if (p) {
+			cobsetptr->cob_stderr = (FILE *)p;
+		}
+		break;
 	default:
 		cob_runtime_warning (_("%s called with unknown option: %d"),
 			"cob_set_runtime_option", opt);
@@ -10611,6 +10626,10 @@ cob_get_runtime_option (enum cob_runtime_option_switch opt)
 		return (void*)cobsetptr->cob_display_punch_file;
 	case COB_SET_RUNTIME_DUMP_FILE:
 		return (void*)cobsetptr->cob_dump_file;
+	case COB_SET_RUNTIME_STDOUT_FILE:
+		return (void*)cobsetptr->cob_stdout;
+	case COB_SET_RUNTIME_STDERR_FILE:
+		return (void*)cobsetptr->cob_stderr;
 	default:
 		cob_runtime_error (_("%s called with unknown option: %d"),
 			"cob_get_runtime_option", opt);
@@ -10635,10 +10654,10 @@ cob_stack_trace (void *target)
 static void
 flush_target (FILE* target)
 {
-	if (target == stderr
-	 || target == stdout) {
-		fflush (stdout);
-		fflush (stderr);
+	if (target == cobsetptr->cob_stderr
+	 || target == cobsetptr->cob_stdout) {
+		fflush (cobsetptr->cob_stdout);
+		fflush (cobsetptr->cob_stderr);
 	} else {
 		fflush (target);
 	}
@@ -10720,7 +10739,7 @@ cob_stack_trace_internal (FILE *target, int verbose, int count)
 		return;
 	}
 
-	if (target == stderr) {
+	if (target == cobsetptr->cob_stderr) {
 		file_no = STDERR_FILENO;
 	} else {
 		flush_target (target);
@@ -10934,7 +10953,7 @@ cob_get_dump_file (void)
 	if (cobsetptr->cob_trace_file != NULL) {	/* If TRACE active, use that */
 		return cobsetptr->cob_trace_file;
 	} else {
-		return stderr;
+		return cobsetptr->cob_stderr;
 	}
 #else /* currently only COB_DUMP_TO_FILE used */
 	FILE    *fp;
@@ -10949,10 +10968,10 @@ cob_get_dump_file (void)
 				}
 				fp = fopen(cobsetptr->cob_dump_filename, "a");
 				if(fp == NULL)
-					fp = stderr;
+					fp = cobsetptr->cob_stderr;
 				cobsetptr->cob_dump_file = fp;
 			} else {
-				fp = stderr;
+				fp = cobsetptr->cob_stderr;
 			}
 		}
 	} else if (where == COB_DUMP_TO_PRINT) {
@@ -10961,11 +10980,11 @@ cob_get_dump_file (void)
 			if(cobsetptr->cob_trace_file != NULL) {	/* If TRACE active, use that */
 				fp = cobsetptr->cob_trace_file;
 			} else {
-				fp = stdout;
+				fp = cobsetptr->cob_stdout;
 			}
 		}
 	} else {
-		fp = stderr;
+		fp = cobsetptr->cob_stderr;
 	}
 	return fp;
 #endif
@@ -10986,12 +11005,12 @@ cob_dump_module (char *reason)
 		}
 		if (mod->next == mod) {
 			/* not translated as highly unexpected */
-			fputs ("FIXME: recursive mod (module dump)\n", stderr);
+			fputs ("FIXME: recursive mod (module dump)\n", cobsetptr->cob_stderr);
 			break;
 		}
 		if (k++ == MAX_MODULE_ITERS) {
 			/* not translated as highly unexpected */
-			fputs ("max module iterations exceeded, possible broken chain\n", stderr);
+			fputs ("max module iterations exceeded, possible broken chain\n", cobsetptr->cob_stderr);
 			break;
 		}
 		if (mod->flag_dump_ready) {
@@ -11011,7 +11030,7 @@ cob_dump_module (char *reason)
 		if (fp == NULL) {
 			return;
 		}
-		if (fp != stderr) {
+		if (fp != cobsetptr->cob_stderr) {
 			if (reason) {
 				if (reason[0] == 0) {
 					reason = (char *)_ ("unknown");
@@ -11021,7 +11040,7 @@ cob_dump_module (char *reason)
 				fputc ('\n', fp);
 				fflush (fp);
 			}
-			if (fp != stdout) {
+			if (fp != cobsetptr->cob_stdout) {
 				/* was already sent to stderr before this function was called,
 				   so skip here for stdout/stderr ... */
 				if (!(dump_trace_started & DUMP_TRACE_ACTIVE_TRACE)) {
@@ -11031,7 +11050,7 @@ cob_dump_module (char *reason)
 				}
 			}
 		} else {
-			fflush (stderr);
+			fflush (cobsetptr->cob_stderr);
 		}
 
 		fputc ('\n', fp);
@@ -11059,7 +11078,7 @@ cob_dump_module (char *reason)
 		if (previous_locale) {
 			setlocale (LC_CTYPE, previous_locale);
 		}
-		if (fp != stdout && fp != stderr) {
+		if (fp != cobsetptr->cob_stdout && fp != cobsetptr->cob_stderr) {
 			char * fname = NULL;
 			if (cobsetptr->cob_dump_filename) {
 				fname = cobsetptr->cob_dump_filename;
@@ -11070,10 +11089,10 @@ cob_dump_module (char *reason)
 				fname = cobsetptr->cob_trace_filename;
 			}
 			if (fname != NULL) {
-				fputc ('\n', stderr);
-				fprintf (stderr, _("dump written to %s"), fname);
-				fputc ('\n', stderr);
-				fflush (stderr);
+				fputc ('\n', cobsetptr->cob_stderr);
+				fprintf (cobsetptr->cob_stderr, _("dump written to %s"), fname);
+				fputc ('\n', cobsetptr->cob_stderr);
+				fflush (cobsetptr->cob_stderr);
 			}
 		}
 	}

--- a/libcob/common.c
+++ b/libcob/common.c
@@ -8315,8 +8315,8 @@ set_config_val (char *value, int pos)
 		}
 
 		if (data_loc == offsetof (cob_settings, cob_stdin_filename)
-		    || data_loc == offsetof (cob_settings, cob_stdout_filename)
-		    || data_loc == offsetof (cob_settings, cob_stderr_filename)) {
+		 || data_loc == offsetof (cob_settings, cob_stdout_filename)
+		 || data_loc == offsetof (cob_settings, cob_stderr_filename)) {
 			cob_settings_termio ();
 		}
 	} else if (data_type & ENV_STR) {	/* String (environment expanded) */

--- a/libcob/common.h
+++ b/libcob/common.h
@@ -1848,8 +1848,9 @@ enum cob_runtime_option_switch {
 	COB_SET_RUNTIME_RESCAN_ENV = 2,		/* rescan environment variables */
 	COB_SET_RUNTIME_DISPLAY_PUNCH_FILE = 3,	/* 'p' is  FILE *  */
 	COB_SET_RUNTIME_DUMP_FILE = 4,	/* 'p' is  FILE *  */
-	COB_SET_RUNTIME_STDOUT_FILE = 5, /* 'p' is FILE * */
-	COB_SET_RUNTIME_STDERR_FILE = 6, /* 'p' is FILE * */
+	COB_SET_RUNTIME_STDIN_FILE = 5,
+	COB_SET_RUNTIME_STDOUT_FILE = 6, /* 'p' is FILE * */
+	COB_SET_RUNTIME_STDERR_FILE = 7, /* 'p' is FILE * */
 };
 COB_EXPIMP void			cob_set_runtime_option		(enum cob_runtime_option_switch opt, void *p);
 COB_EXPIMP void			*cob_get_runtime_option		(enum cob_runtime_option_switch opt);

--- a/libcob/common.h
+++ b/libcob/common.h
@@ -1848,9 +1848,9 @@ enum cob_runtime_option_switch {
 	COB_SET_RUNTIME_RESCAN_ENV = 2,		/* rescan environment variables */
 	COB_SET_RUNTIME_DISPLAY_PUNCH_FILE = 3,	/* 'p' is  FILE *  */
 	COB_SET_RUNTIME_DUMP_FILE = 4,	/* 'p' is  FILE *  */
-	COB_SET_RUNTIME_STDIN_FILE = 5,
-	COB_SET_RUNTIME_STDOUT_FILE = 6, /* 'p' is FILE * */
-	COB_SET_RUNTIME_STDERR_FILE = 7, /* 'p' is FILE * */
+	COB_SET_RUNTIME_STDIN_FILE = 5,		/* 'p' is FILE * */
+	COB_SET_RUNTIME_STDOUT_FILE = 6, 	/* 'p' is FILE * */
+	COB_SET_RUNTIME_STDERR_FILE = 7,	/* 'p' is FILE * */
 };
 COB_EXPIMP void			cob_set_runtime_option		(enum cob_runtime_option_switch opt, void *p);
 COB_EXPIMP void			*cob_get_runtime_option		(enum cob_runtime_option_switch opt);

--- a/libcob/common.h
+++ b/libcob/common.h
@@ -1847,7 +1847,9 @@ enum cob_runtime_option_switch {
 	COB_SET_RUNTIME_DISPLAY_PRINTER_FILE = 1,	/* 'p' is  FILE *  */
 	COB_SET_RUNTIME_RESCAN_ENV = 2,		/* rescan environment variables */
 	COB_SET_RUNTIME_DISPLAY_PUNCH_FILE = 3,	/* 'p' is  FILE *  */
-	COB_SET_RUNTIME_DUMP_FILE = 4	/* 'p' is  FILE *  */
+	COB_SET_RUNTIME_DUMP_FILE = 4,	/* 'p' is  FILE *  */
+	COB_SET_RUNTIME_STDOUT_FILE = 5, /* 'p' is FILE * */
+	COB_SET_RUNTIME_STDERR_FILE = 6, /* 'p' is FILE * */
 };
 COB_EXPIMP void			cob_set_runtime_option		(enum cob_runtime_option_switch opt, void *p);
 COB_EXPIMP void			*cob_get_runtime_option		(enum cob_runtime_option_switch opt);

--- a/libcob/fileio.c
+++ b/libcob/fileio.c
@@ -3634,9 +3634,9 @@ join_environment (void)
 	bdb_env->set_msgcall (bdb_env, bdb_msgcall_set);
 #endif
 #else
-	bdb_env->set_errfile (bdb_env, stderr);
+	bdb_env->set_errfile (bdb_env, cobsetptr->cob_stderr);
 #if (DB_VERSION_MAJOR > 4) || ((DB_VERSION_MAJOR == 4) && (DB_VERSION_MINOR > 2))
-	bdb_env->set_msgfile (bdb_env, stderr);
+	bdb_env->set_msgfile (bdb_env, cobsetptr->cob_stderr);
 #endif
 #endif
 	bdb_env->set_cachesize (bdb_env, 0, 2*1024*1024, 0);
@@ -6371,8 +6371,8 @@ cob_open (cob_file *f, const int mode, const int sharing, cob_field *fnstatus)
 			save_status (f, fnstatus, COB_STATUS_30_PERMANENT_ERROR);
 			return;
 		}
-		f->file = stdout;
-		f->fd = fileno (stdout);
+		f->file = cobsetptr->cob_stdout;
+		f->fd = fileno (cobsetptr->cob_stdout);
 		f->open_mode = mode;
 		save_status (f, fnstatus, COB_STATUS_00_SUCCESS);
 		return;

--- a/libcob/fileio.c
+++ b/libcob/fileio.c
@@ -9011,12 +9011,14 @@ cob_init_fileio (cob_global *lptr, cob_settings *sptr)
 void
 cob_settings_fileio (void) 
 {
+#ifdef WITH_DB
 	if (bdb_env) {
 		bdb_env->set_errfile (bdb_env, cobsetptr->cob_stderr);
 #if (DB_VERSION_MAJOR > 4) || ((DB_VERSION_MAJOR == 4) && (DB_VERSION_MINOR > 2))
 		bdb_env->set_msgfile (bdb_env, cobsetptr->cob_stderr);
 #endif
 	}
+#endif
 }
 
 /********************************************************************************/

--- a/libcob/fileio.c
+++ b/libcob/fileio.c
@@ -6360,8 +6360,8 @@ cob_open (cob_file *f, const int mode, const int sharing, cob_field *fnstatus)
 			save_status (f, fnstatus, COB_STATUS_30_PERMANENT_ERROR);
 			return;
 		}
-		f->file = stdin;
-		f->fd = fileno (stdin);
+		f->file = cobsetptr->cob_stdin;
+		f->fd = fileno (cobsetptr->cob_stdin);
 		f->open_mode = mode;
 		save_status (f, fnstatus, COB_STATUS_00_SUCCESS);
 		return;
@@ -9005,6 +9005,17 @@ cob_init_fileio (cob_global *lptr, cob_settings *sptr)
 #if	defined(WITH_INDEX_EXTFH) || defined(WITH_SEQRA_EXTFH)
 	extfh_cob_init_fileio (&sequential_funcs, &lineseq_funcs,
 			       &relative_funcs, &cob_file_write_opt);
+#endif
+}
+
+void
+cob_settings_fileio (void) 
+{
+#ifdef	WITH_DB
+	bdb_env->set_errfile (bdb_env, cobsetptr->cob_stderr);
+#if (DB_VERSION_MAJOR > 4) || ((DB_VERSION_MAJOR == 4) && (DB_VERSION_MINOR > 2))
+	bdb_env->set_msgfile (bdb_env, cobsetptr->cob_stderr);
+#endif
 #endif
 }
 

--- a/libcob/fileio.c
+++ b/libcob/fileio.c
@@ -9011,12 +9011,12 @@ cob_init_fileio (cob_global *lptr, cob_settings *sptr)
 void
 cob_settings_fileio (void) 
 {
-#ifdef	WITH_DB
-	bdb_env->set_errfile (bdb_env, cobsetptr->cob_stderr);
+	if (bdb_env) {
+		bdb_env->set_errfile (bdb_env, cobsetptr->cob_stderr);
 #if (DB_VERSION_MAJOR > 4) || ((DB_VERSION_MAJOR == 4) && (DB_VERSION_MINOR > 2))
-	bdb_env->set_msgfile (bdb_env, cobsetptr->cob_stderr);
+		bdb_env->set_msgfile (bdb_env, cobsetptr->cob_stderr);
 #endif
-#endif
+	}
 }
 
 /********************************************************************************/

--- a/libcob/fileio.c
+++ b/libcob/fileio.c
@@ -3628,17 +3628,7 @@ join_environment (void)
 				   "env_create", ret, db_strerror (ret));
 		return ret;
 	}
-#if	0	/* RXWRXW - BDB msg */
-	bdb_env->set_errcall (bdb_env, bdb_errcall_set);
-#if (DB_VERSION_MAJOR > 4) || ((DB_VERSION_MAJOR == 4) && (DB_VERSION_MINOR > 2))
-	bdb_env->set_msgcall (bdb_env, bdb_msgcall_set);
-#endif
-#else
-	bdb_env->set_errfile (bdb_env, cobsetptr->cob_stderr);
-#if (DB_VERSION_MAJOR > 4) || ((DB_VERSION_MAJOR == 4) && (DB_VERSION_MINOR > 2))
-	bdb_env->set_msgfile (bdb_env, cobsetptr->cob_stderr);
-#endif
-#endif
+	cob_settings_fileio ();
 	bdb_env->set_cachesize (bdb_env, 0, 2*1024*1024, 0);
 	bdb_env->set_alloc (bdb_env, cob_malloc, realloc, cob_free);
 	flags = DB_CREATE | DB_INIT_MPOOL | DB_INIT_CDB;
@@ -9013,9 +9003,16 @@ cob_settings_fileio (void)
 {
 #ifdef WITH_DB
 	if (bdb_env) {
+#if	0	/* RXWRXW - BDB msg */
+		bdb_env->set_errcall (bdb_env, bdb_errcall_set);
+#if (DB_VERSION_MAJOR > 4) || ((DB_VERSION_MAJOR == 4) && (DB_VERSION_MINOR > 2))
+		bdb_env->set_msgcall (bdb_env, bdb_msgcall_set);
+#endif
+#else
 		bdb_env->set_errfile (bdb_env, cobsetptr->cob_stderr);
 #if (DB_VERSION_MAJOR > 4) || ((DB_VERSION_MAJOR == 4) && (DB_VERSION_MINOR > 2))
 		bdb_env->set_msgfile (bdb_env, cobsetptr->cob_stderr);
+#endif
 #endif
 	}
 #endif

--- a/libcob/fileio.c
+++ b/libcob/fileio.c
@@ -6350,8 +6350,8 @@ cob_open (cob_file *f, const int mode, const int sharing, cob_field *fnstatus)
 			save_status (f, fnstatus, COB_STATUS_30_PERMANENT_ERROR);
 			return;
 		}
-		f->file = cobsetptr->cob_stdin;
-		f->fd = fileno (cobsetptr->cob_stdin);
+		f->file = COB_STDIN;
+		f->fd = fileno (COB_STDIN);
 		f->open_mode = mode;
 		save_status (f, fnstatus, COB_STATUS_00_SUCCESS);
 		return;
@@ -6361,8 +6361,8 @@ cob_open (cob_file *f, const int mode, const int sharing, cob_field *fnstatus)
 			save_status (f, fnstatus, COB_STATUS_30_PERMANENT_ERROR);
 			return;
 		}
-		f->file = cobsetptr->cob_stdout;
-		f->fd = fileno (cobsetptr->cob_stdout);
+		f->file = COB_STDOUT;
+		f->fd = fileno (COB_STDOUT);
 		f->open_mode = mode;
 		save_status (f, fnstatus, COB_STATUS_00_SUCCESS);
 		return;
@@ -9009,9 +9009,9 @@ cob_settings_fileio (void)
 		bdb_env->set_msgcall (bdb_env, bdb_msgcall_set);
 #endif
 #else
-		bdb_env->set_errfile (bdb_env, cobsetptr->cob_stderr);
+		bdb_env->set_errfile (bdb_env, COB_STDERR);
 #if (DB_VERSION_MAJOR > 4) || ((DB_VERSION_MAJOR == 4) && (DB_VERSION_MINOR > 2))
-		bdb_env->set_msgfile (bdb_env, cobsetptr->cob_stderr);
+		bdb_env->set_msgfile (bdb_env, COB_STDERR);
 #endif
 #endif
 	}

--- a/libcob/profiling.c
+++ b/libcob/profiling.c
@@ -600,7 +600,7 @@ cob_prof_end ()
 			/* Only print this line when we are not in test mode,
 			   or the file is called hidden.csv, so that we can
 			   run profiling while running the full testsuite */
-			fprintf (cobsetptr->cob_stderr, "File %s generated\n",
+			fprintf (COB_STDERR, "File %s generated\n",
 				cobsetptr->cob_prof_filename);
 		}
 	} else {

--- a/libcob/profiling.c
+++ b/libcob/profiling.c
@@ -600,7 +600,7 @@ cob_prof_end ()
 			/* Only print this line when we are not in test mode,
 			   or the file is called hidden.csv, so that we can
 			   run profiling while running the full testsuite */
-			fprintf (stderr, "File %s generated\n",
+			fprintf (cobsetptr->cob_stderr, "File %s generated\n",
 				cobsetptr->cob_prof_filename);
 		}
 	} else {

--- a/libcob/screenio.c
+++ b/libcob/screenio.c
@@ -317,7 +317,7 @@ cob_speaker_beep (void)
 {
 	int	fd;
 
-	fd = fileno (cobsetptr->cob_stdout);
+	fd = fileno (COB_STDOUT);
 	if (fd >= 0) {
 		(void)write (fd, "\a", (size_t)1);
 	}
@@ -1156,8 +1156,8 @@ cob_screen_init (void)
 	pending_accept = 0;
 	got_sys_char = 0;
 
-	fflush (cobsetptr->cob_stdout);
-	fflush (cobsetptr->cob_stderr);
+	fflush (COB_STDOUT);
+	fflush (COB_STDERR);
 
 #if	0	/* RXWRXW sigtin */
 #ifndef _WIN32

--- a/libcob/screenio.c
+++ b/libcob/screenio.c
@@ -317,7 +317,7 @@ cob_speaker_beep (void)
 {
 	int	fd;
 
-	fd = fileno (stdout);
+	fd = fileno (cobsetptr->cob_stdout);
 	if (fd >= 0) {
 		(void)write (fd, "\a", (size_t)1);
 	}
@@ -1156,8 +1156,8 @@ cob_screen_init (void)
 	pending_accept = 0;
 	got_sys_char = 0;
 
-	fflush (stdout);
-	fflush (stderr);
+	fflush (cobsetptr->cob_stdout);
+	fflush (cobsetptr->cob_stderr);
 
 #if	0	/* RXWRXW sigtin */
 #ifndef _WIN32

--- a/libcob/termio.c
+++ b/libcob/termio.c
@@ -337,17 +337,17 @@ cob_display (const int to_device, const int newline, const int varcnt, ...)
 	/* display to device ? */
 	switch (to_device) {
 	case 0:	/* general (SYSOUT) */
-		fp = stdout;
+		fp = cobsetptr->cob_stdout;
 		if (cobglobptr->cob_screen_initialized) {
 			if (!COB_DISP_TO_STDERR) {
 				disp_redirect = 1;
 			} else {
-				fp = stderr;
+				fp = cobsetptr->cob_stderr;
 			}
 		}
 		break;
 	case 1:	/* SYSERR */
-		fp = stderr;
+		fp = cobsetptr->cob_stderr;
 		break;
 	case 2:	/* PRINTER */
 		/* display to external specified print file handle */
@@ -363,7 +363,7 @@ cob_display (const int to_device, const int newline, const int varcnt, ...)
 			}
 			fp = fopen (cobsetptr->cob_display_print_filename, mode);
 			if (fp == NULL) {
-				fp = stderr;
+				fp = cobsetptr->cob_stderr;
 			} else {
 				close_fp = 1;
 			}
@@ -379,19 +379,19 @@ cob_display (const int to_device, const int newline, const int varcnt, ...)
 			}
 			fp = popen (cobsetptr->cob_display_print_pipe, mode);
 			if (fp == NULL) {
-				fp = stderr;
+				fp = cobsetptr->cob_stderr;
 			} else {
 				close_fp = 2;
 			}
 #endif
 		/* fallback: display to the defined SYSOUT */
 		} else {
-			fp = stdout;
+			fp = cobsetptr->cob_stdout;
 			if (cobglobptr->cob_screen_initialized) {
 				if (!COB_DISP_TO_STDERR) {
 					disp_redirect = 1;
 				} else {
-					fp = stderr;
+					fp = cobsetptr->cob_stderr;
 				}
 			}
 		}
@@ -431,7 +431,7 @@ cob_display (const int to_device, const int newline, const int varcnt, ...)
 		break;
 	/* LCOV_EXCL_START */
 	default:
-		fp = stderr;
+		fp = cobsetptr->cob_stderr;
 	}
 	/* LCOV_EXCL_STOP */
 
@@ -1053,7 +1053,7 @@ cob_accept (cob_field *f)
 	}
 
 	/* always flush to ensure buffered output is seen */
-	fflush (stdout);
+	fflush (cobsetptr->cob_stdout);
 
 	/* extension: ACCEPT OMITTED */
 	if (unlikely (!f)) {

--- a/libcob/termio.c
+++ b/libcob/termio.c
@@ -39,6 +39,11 @@
 #define SIGINT 2
 #endif
 
+#ifdef _WIN32
+#include <io.h>
+#include <fcntl.h>
+#endif
+
 /* include internal and external libcob definitions, forcing exports */
 #define	COB_LIB_EXPIMP
 #include "coblocal.h"
@@ -337,17 +342,17 @@ cob_display (const int to_device, const int newline, const int varcnt, ...)
 	/* display to device ? */
 	switch (to_device) {
 	case 0:	/* general (SYSOUT) */
-		fp = cobsetptr->cob_stdout;
+		fp = COB_STDOUT;
 		if (cobglobptr->cob_screen_initialized) {
 			if (!COB_DISP_TO_STDERR) {
 				disp_redirect = 1;
 			} else {
-				fp = cobsetptr->cob_stderr;
+				fp = COB_STDERR;
 			}
 		}
 		break;
 	case 1:	/* SYSERR */
-		fp = cobsetptr->cob_stderr;
+		fp = COB_STDERR;
 		break;
 	case 2:	/* PRINTER */
 		/* display to external specified print file handle */
@@ -363,7 +368,7 @@ cob_display (const int to_device, const int newline, const int varcnt, ...)
 			}
 			fp = fopen (cobsetptr->cob_display_print_filename, mode);
 			if (fp == NULL) {
-				fp = cobsetptr->cob_stderr;
+				fp = COB_STDERR;
 			} else {
 				close_fp = 1;
 			}
@@ -379,19 +384,19 @@ cob_display (const int to_device, const int newline, const int varcnt, ...)
 			}
 			fp = popen (cobsetptr->cob_display_print_pipe, mode);
 			if (fp == NULL) {
-				fp = cobsetptr->cob_stderr;
+				fp = COB_STDERR;
 			} else {
 				close_fp = 2;
 			}
 #endif
 		/* fallback: display to the defined SYSOUT */
 		} else {
-			fp = cobsetptr->cob_stdout;
+			fp = COB_STDOUT;
 			if (cobglobptr->cob_screen_initialized) {
 				if (!COB_DISP_TO_STDERR) {
 					disp_redirect = 1;
 				} else {
-					fp = cobsetptr->cob_stderr;
+					fp = COB_STDERR;
 				}
 			}
 		}
@@ -431,7 +436,7 @@ cob_display (const int to_device, const int newline, const int varcnt, ...)
 		break;
 	/* LCOV_EXCL_START */
 	default:
-		fp = cobsetptr->cob_stderr;
+		fp = COB_STDERR;
 	}
 	/* LCOV_EXCL_STOP */
 
@@ -1053,12 +1058,12 @@ cob_accept (cob_field *f)
 	}
 
 	/* always flush to ensure buffered output is seen */
-	fflush (cobsetptr->cob_stdout);
+	fflush (COB_STDOUT);
 
 	/* extension: ACCEPT OMITTED */
 	if (unlikely (!f)) {
 		for (; ; ) {
-			ipchr = getc (cobsetptr->cob_stdin);
+			ipchr = getc (COB_STDIN);
 			if (ipchr == '\n' || ipchr == EOF) {
 				break;
 			} else if (ipchr == 03) {
@@ -1073,7 +1078,7 @@ cob_accept (cob_field *f)
 	size = 0;
 	/* Read a line */
 	for (; size < COB_MEDIUM_MAX; ) {
-		ipchr = getc (cobsetptr->cob_stdin);
+		ipchr = getc (COB_STDIN);
 		if (unlikely (ipchr == EOF)) {
 			cob_set_exception (COB_EC_IMP_ACCEPT);
 			if (!size) {
@@ -1101,100 +1106,136 @@ cob_accept (cob_field *f)
 static void
 cob_stdin_termio (void)
 {
-	if (!cobsetptr->cob_stdin_filename) {
-		return;
-	}
-
-	if (cobsetptr->cob_stdin_filename_set) {
-		if (strcmp (cobsetptr->cob_stdin_filename,
-		cobsetptr->cob_stdin_filename_set) == 0) {
+	if (cobsetptr->cob_stdin_filename) {
+		FILE *stdin_f = NULL;
+		if (cobsetptr->cob_stdin_filename_set &&
+		    strcmp (cobsetptr->cob_stdin_filename,
+	    cobsetptr->cob_stdin_filename_set) == 0) {
 			return;
 		}
-		fclose (cobsetptr->cob_stdin);
-		cob_free (cobsetptr->cob_stdin_filename_set);
-		cobsetptr->cob_stdin_filename_set = NULL;
+
+		if (!cobsetptr->cob_unix_lf) {
+			stdin_f = fopen (cobsetptr->cob_stdin_filename, "r");
+		} else {
+			stdin_f = fopen (cobsetptr->cob_stdin_filename, "rb");
+		}
+
+		if (stdin_f) {
+			if (cobsetptr->cob_stdin_filename_set) {
+				cob_free (cobsetptr->cob_stdin_filename_set);
+				cobsetptr->cob_stdin_filename_set = NULL;
+				fclose (COB_STDIN);
+			}
+			COB_STDIN = stdin_f;
+			cobsetptr->cob_stdin_filename_set =
+				cob_strdup (cobsetptr->cob_stdin_filename);
+		} else {
+			cob_free (cobsetptr->cob_stdin_filename);
+			cobsetptr->cob_stdin_filename = NULL;
+		}
 	}
 
-	if (!cobsetptr->cob_unix_lf) {
-		cobsetptr->cob_stdin = fopen (cobsetptr->cob_stdin_filename, "r");
-	} else {
-		cobsetptr->cob_stdin = fopen (cobsetptr->cob_stdin_filename, "rb");
+	if (!COB_STDIN) {
+		COB_STDIN = stdin;
 	}
 
-	if (!cobsetptr->cob_stdin) {
-		cob_free (cobsetptr->cob_stdin_filename);
-		cobsetptr->cob_stdin_filename = NULL;
-		cobsetptr->cob_stdin = stdin;
-		return;
+#ifdef _WIN32
+	if (cobsetptr->cob_unix_lf) {
+		(void)_setmode (_fileno (COB_STDIN), _O_BINARY);
 	}
-
-	cobsetptr->cob_stdin_filename_set =
-		cob_strdup (cobsetptr->cob_stdin_filename);
+#endif
 }
 
 static void
 cob_stdout_termio (void)
 {
-	if (!cobsetptr->cob_stdout_filename) {
-		return;
-	}
-
-	if (cobsetptr->cob_stdout_filename_set) {
-		if (strcmp (cobsetptr->cob_stdout_filename,
-		cobsetptr->cob_stdout_filename_set) == 0) {
+	if (cobsetptr->cob_stdout_filename) {
+		FILE *stdout_f = NULL;
+		if (cobsetptr->cob_stdout_filename_set &&
+		    strcmp (cobsetptr->cob_stdout_filename,
+		    cobsetptr->cob_stdout_filename_set) == 0) {
 			return;
 		}
-		fclose (cobsetptr->cob_stdout);
-		cob_free (cobsetptr->cob_stdout_filename);
-		cobsetptr->cob_stdout_filename = NULL;
+
+		stdout_f = cob_open_logfile ( cobsetptr->cob_stdout_filename);
+
+		if (stdout_f) {
+			if (cobsetptr->cob_stdout_filename_set) {
+				fclose (COB_STDOUT);
+				cob_free (cobsetptr->cob_stdout_filename_set);
+				cobsetptr->cob_stdout_filename_set = NULL;
+			}
+			COB_STDOUT = stdout_f;
+			cobsetptr->cob_stdout_filename_set =
+				cob_strdup (cobsetptr->cob_stdout_filename);
+		} else {
+			cob_free (cobsetptr->cob_stdout_filename);
+			cobsetptr->cob_stdout_filename = NULL;
+		}
 	}
 
-	cobsetptr->cob_stdout = cob_open_logfile (cobsetptr->cob_stdout_filename);
-
-	if (!cobsetptr->cob_stdout) {
-		cob_free (cobsetptr->cob_stdout_filename);
-		cobsetptr->cob_stdout_filename = NULL;
-		cobsetptr->cob_stdout = stdout;
-		return;
+	if (!COB_STDOUT) {
+		COB_STDOUT = stdout;
 	}
 
-	cobsetptr->cob_stdout_filename_set =
-		cob_strdup (cobsetptr->cob_stdout_filename);
+#ifdef _WIN32
+	if (cobsetptr->cob_unix_lf) {
+		(void)_setmode (_fileno (COB_STDOUT), _O_BINARY);
+	}
+#endif
 }
 
 static void
 cob_stderr_termio (void)
 {
-	if (!cobsetptr->cob_stderr_filename) {
-		return;
-	}
-
-	if (cobsetptr->cob_stderr_filename_set) {
-		if (strcmp (cobsetptr->cob_stderr_filename,
-		cobsetptr->cob_stderr_filename_set) == 0) {
+	if (cobsetptr->cob_stderr_filename) {
+		FILE *stderr_f = NULL;
+		if (cobsetptr->cob_stderr_filename_set &&
+		    strcmp (cobsetptr->cob_stderr_filename,
+		    cobsetptr->cob_stderr_filename_set) == 0) {
 			return;
 		}
-		fclose (cobsetptr->cob_stderr);
-		cob_free (cobsetptr->cob_stderr_filename);
-		cobsetptr->cob_stderr_filename = NULL;
+
+		stderr_f = cob_open_logfile (cobsetptr->cob_stderr_filename);
+
+		if (stderr_f) {
+			if (cobsetptr->cob_stderr_filename_set) {
+				fclose (COB_STDERR);
+				cob_free (cobsetptr->cob_stderr_filename_set);
+				cobsetptr->cob_stderr_filename_set = NULL;
+			}
+			COB_STDERR = stderr_f;
+			cobsetptr->cob_stderr_filename_set =
+				cob_strdup (cobsetptr->cob_stderr_filename);
+		} else {
+			cob_free (cobsetptr->cob_stderr_filename);
+			cobsetptr->cob_stderr_filename = NULL;
+		}
 	}
 
-	cobsetptr->cob_stderr = cob_open_logfile (cobsetptr->cob_stderr_filename);
-
-	if (!cobsetptr->cob_stderr) {
-		cob_free (cobsetptr->cob_stderr_filename);
-		cobsetptr->cob_stderr_filename = NULL;
-		cobsetptr->cob_stderr = stderr;
-		return;
+	if (!COB_STDERR) {
+		COB_STDERR = stderr;
 	}
 
-	cobsetptr->cob_stderr_filename_set =
-		cob_strdup (cobsetptr->cob_stderr_filename);
+#ifdef _WIN32
+	if (cobsetptr->cob_unix_lf) {
+		(void)_setmode (_fileno (COB_STDERR), _O_BINARY);
+	}
+#endif
+
+	cob_settings_fileio();
 }
 
 void
 cob_settings_termio (void)
 {
+	/* Initialization of cob_stdin/cob_stdout/cob_stderr:
+	If a filename is provided, it is preferred. If there was a previous file
+	opened with a different filename, it is flushed and closed. If the filename
+	is invalid, it is ignored. For the other cases, the previous file is not
+	owned by libcob, so it is not closed. Handling them is the responsibility
+	of the programmer. Additionally, on Windows the mode of the file is set to
+	binary. */
 	cob_stdin_termio ();
 	cob_stdout_termio ();
 	cob_stderr_termio ();

--- a/libcob/termio.c
+++ b/libcob/termio.c
@@ -1098,9 +1098,113 @@ cob_accept (cob_field *f)
 	cob_move (&temp, f);
 }
 
+static void
+cob_stdin_termio (void)
+{
+	if (!cobsetptr->cob_stdin_filename) {
+		return;
+	}
+
+	if (cobsetptr->cob_stdin_filename_set) {
+		if (strcmp (cobsetptr->cob_stdin_filename,
+		cobsetptr->cob_stdin_filename_set) == 0) {
+			return;
+		}
+		fclose (cobsetptr->cob_stdin);
+		cob_free (cobsetptr->cob_stdin_filename_set);
+		cobsetptr->cob_stdin_filename_set = NULL;
+	}
+
+	if (!cobsetptr->cob_unix_lf) {
+		cobsetptr->cob_stdin = fopen (cobsetptr->cob_stdin_filename, "r");
+	} else {
+		cobsetptr->cob_stdin = fopen (cobsetptr->cob_stdin_filename, "rb");
+	}
+
+	if (!cobsetptr->cob_stdin) {
+		cob_free (cobsetptr->cob_stdin_filename);
+		cobsetptr->cob_stdin_filename = NULL;
+		cobsetptr->cob_stdin = stdin;
+		return;
+	}
+
+	cobsetptr->cob_stdin_filename_set =
+		cob_strdup (cobsetptr->cob_stdin_filename);
+}
+
+static void
+cob_stdout_termio (void)
+{
+	if (!cobsetptr->cob_stdout_filename) {
+		return;
+	}
+
+	if (cobsetptr->cob_stdout_filename_set) {
+		if (strcmp (cobsetptr->cob_stdout_filename,
+		cobsetptr->cob_stdout_filename_set) == 0) {
+			return;
+		}
+		fclose (cobsetptr->cob_stdout);
+		cob_free (cobsetptr->cob_stdout_filename);
+		cobsetptr->cob_stdout_filename = NULL;
+	}
+
+	cobsetptr->cob_stdout = cob_open_logfile (cobsetptr->cob_stdout_filename);
+
+	if (!cobsetptr->cob_stdout) {
+		cob_free (cobsetptr->cob_stdout_filename);
+		cobsetptr->cob_stdout_filename = NULL;
+		cobsetptr->cob_stdout = stdout;
+		return;
+	}
+
+	cobsetptr->cob_stdout_filename_set =
+		cob_strdup (cobsetptr->cob_stdout_filename);
+}
+
+static void
+cob_stderr_termio (void)
+{
+	if (!cobsetptr->cob_stderr_filename) {
+		return;
+	}
+
+	if (cobsetptr->cob_stderr_filename_set) {
+		if (strcmp (cobsetptr->cob_stderr_filename,
+		cobsetptr->cob_stderr_filename_set) == 0) {
+			return;
+		}
+		fclose (cobsetptr->cob_stderr);
+		cob_free (cobsetptr->cob_stderr_filename);
+		cobsetptr->cob_stderr_filename = NULL;
+	}
+
+	cobsetptr->cob_stderr = cob_open_logfile (cobsetptr->cob_stderr_filename);
+
+	if (!cobsetptr->cob_stderr) {
+		cob_free (cobsetptr->cob_stderr_filename);
+		cobsetptr->cob_stderr_filename = NULL;
+		cobsetptr->cob_stderr = stderr;
+		return;
+	}
+
+	cobsetptr->cob_stderr_filename_set =
+		cob_strdup (cobsetptr->cob_stderr_filename);
+}
+
+void
+cob_settings_termio (void)
+{
+	cob_stdin_termio ();
+	cob_stdout_termio ();
+	cob_stderr_termio ();
+}
+
 void
 cob_init_termio (cob_global *lptr, cob_settings *sptr)
 {
 	cobglobptr = lptr;
 	cobsetptr  = sptr;
+
+	cob_settings_termio ();
 }

--- a/libcob/termio.c
+++ b/libcob/termio.c
@@ -1058,7 +1058,7 @@ cob_accept (cob_field *f)
 	/* extension: ACCEPT OMITTED */
 	if (unlikely (!f)) {
 		for (; ; ) {
-			ipchr = getchar ();
+			ipchr = getc (cobsetptr->cob_stdin);
 			if (ipchr == '\n' || ipchr == EOF) {
 				break;
 			} else if (ipchr == 03) {
@@ -1073,7 +1073,7 @@ cob_accept (cob_field *f)
 	size = 0;
 	/* Read a line */
 	for (; size < COB_MEDIUM_MAX; ) {
-		ipchr = getchar ();
+		ipchr = getc (cobsetptr->cob_stdin);
 		if (unlikely (ipchr == EOF)) {
 			cob_set_exception (COB_EC_IMP_ACCEPT);
 			if (!size) {

--- a/libcob/termio.c
+++ b/libcob/termio.c
@@ -1108,9 +1108,9 @@ cob_stdin_termio (void)
 {
 	if (cobsetptr->cob_stdin_filename) {
 		FILE *stdin_f = NULL;
-		if (cobsetptr->cob_stdin_filename_set &&
-		    strcmp (cobsetptr->cob_stdin_filename,
-	    cobsetptr->cob_stdin_filename_set) == 0) {
+		if (cobsetptr->cob_stdin_filename_set
+		 && strcmp (cobsetptr->cob_stdin_filename,
+		            cobsetptr->cob_stdin_filename_set) == 0) {
 			return;
 		}
 

--- a/tests/ChangeLog
+++ b/tests/ChangeLog
@@ -1,4 +1,8 @@
 
+2026-07-07  Oğuzcan Kırmemiş <oguzcan.kirmemis@gmail.com>
+
+	* testsuite.src/run_misc.at: add test for stdin/stdout/stderr redirection
+
 2025-12-04  Simon Sobisch <simonsobisch@gnu.org>
 
 	* atlocal.in: reordered to correctly use perf/valgrind definitions also

--- a/tests/ChangeLog
+++ b/tests/ChangeLog
@@ -1,8 +1,4 @@
 
-2026-07-07  Oğuzcan Kırmemiş <oguzcan.kirmemis@gmail.com>
-
-	* testsuite.src/run_misc.at: add test for stdin/stdout/stderr redirection
-
 2025-12-04  Simon Sobisch <simonsobisch@gnu.org>
 
 	* atlocal.in: reordered to correctly use perf/valgrind definitions also

--- a/tests/testsuite.src/run_misc.at
+++ b/tests/testsuite.src/run_misc.at
@@ -4972,7 +4972,7 @@ main (int argc, char **argv)
     cob_tidy ();
 
     /* Check normal exit second time */
-    if (cob_ret != 1) {
+    if (cob_ret != 0) {
       return 2;
     }
 

--- a/tests/testsuite.src/run_misc.at
+++ b/tests/testsuite.src/run_misc.at
@@ -16573,8 +16573,8 @@ AT_CHECK([$COMPILE prog.cob], [0], [], [])
 AT_CHECK([$COMPILE caller.c], [0], [], [])
 AT_CHECK([$COMPILE_MODULE callee.cob], [0], [], [])
 
-AT_CHECK([timeout 20s $COBCRUN_DIRECT ./prog], [0], [], [])
-AT_CHECK([timeout 20s ./caller], [0], [], [])
+AT_CHECK([$COBCRUN_DIRECT ./prog], [0], [], [])
+AT_CHECK([./caller], [0], [], [])
 
 AT_CLEANUP
 

--- a/tests/testsuite.src/run_misc.at
+++ b/tests/testsuite.src/run_misc.at
@@ -16417,7 +16417,38 @@ AT_CLEANUP
 
 AT_SETUP([stdin/stdout/stderr redirection])
 AT_KEYWORDS([runmisc cob_set_runtime_option COB_SET_RUNTIME_STDIN_FILE
-   COB_SET_RUNTIME_STDOUT_FILE COB_SET_RUNTIME_STDERR_FILE])
+   COB_SET_RUNTIME_STDOUT_FILE COB_SET_RUNTIME_STDERR_FILE COB_STDIN_FILE
+   COB_STDOUT_FILE COB_STDERR_FILE])
+
+AT_DATA([prog.cob], [
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. prog.
+       ENVIRONMENT DIVISION.
+       CONFIGURATION SECTION.
+       SPECIAL-NAMES.
+          SYSERR IS STANDARD-ERROR.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+          01 INPUT-VAR PIC X(6).
+       PROCEDURE DIVISION.
+          SET ENVIRONMENT "COB_STDOUT_FILE"
+             TO "prog_stdin".
+          DISPLAY "STDOUT".
+          SET ENVIRONMENT "COB_STDERR_FILE"
+             TO "+prog_stdin".
+          DISPLAY "STDERR" UPON SYSERR.
+          SET ENVIRONMENT "COB_STDIN_FILE"
+             TO "prog_stdin".
+          ACCEPT INPUT-VAR.
+          IF NOT INPUT-VAR = "STDOUT" THEN
+             STOP RUN RETURNING 1
+          END-IF.
+          ACCEPT INPUT-VAR.
+          IF NOT INPUT-VAR = "STDERR" THEN
+             STOP RUN RETURNING 2
+          END-IF.
+          STOP RUN.
+])
 
 AT_DATA([callee.cob], [
        IDENTIFICATION DIVISION.
@@ -16531,10 +16562,11 @@ int main (int argc, char **argv) {
 }
 ]])
 
+AT_CHECK([$COMPILE prog.cob], [0], [], [])
 AT_CHECK([$COMPILE caller.c], [0], [], [])
 AT_CHECK([$COMPILE_MODULE callee.cob], [0], [], [])
 
-AT_CHECK([./caller], [0], [], [])
+AT_CHECK([$COBCRUN_DIRECT ./prog], [0], [], [])
 AT_CHECK([./caller], [0], [], [])
 
 AT_CLEANUP

--- a/tests/testsuite.src/run_misc.at
+++ b/tests/testsuite.src/run_misc.at
@@ -16415,8 +16415,9 @@ AT_CHECK([$COBCRUN_DIRECT ./prog], [0],
 AT_CLEANUP
 
 
-AT_SETUP([stdout/stderr redirection])
-AT_KEYWORDS([runmisc cob_set_runtime_option COB_SET_RUNTIME_STDOUT_FILE COB_SET_RUNTIME_STDERR_FILE])
+AT_SETUP([stdin/stdout/stderr redirection])
+AT_KEYWORDS([runmisc cob_set_runtime_option COB_SET_RUNTIME_STDIN_FILE
+   COB_SET_RUNTIME_STDOUT_FILE COB_SET_RUNTIME_STDERR_FILE])
 
 AT_DATA([callee.cob], [
        IDENTIFICATION DIVISION.
@@ -16425,9 +16426,14 @@ AT_DATA([callee.cob], [
        CONFIGURATION SECTION.
        SPECIAL-NAMES.
           SYSERR IS STANDARD-ERROR.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+          01 INPUT-VAR PIC X(6).
        PROCEDURE DIVISION.
-          DISPLAY "STDERR" UPON SYSERR.
-          DISPLAY "STDOUT".
+          ACCEPT INPUT-VAR.
+          DISPLAY INPUT-VAR UPON SYSERR.
+          ACCEPT INPUT-VAR.
+          DISPLAY INPUT-VAR.
           STOP RUN.
 ])
 
@@ -16439,38 +16445,63 @@ AT_DATA([caller.c], [[
 #include <libcob.h>
 
 int main (int argc, char **argv) {
+   int stdin_pipe[2];
    int stdout_pipe[2];
    int stderr_pipe[2];
+   FILE *stdin_read;
    FILE *stdout_write;
    FILE *stderr_write;
    char buffer[128];
    ssize_t nbytes;
    int cob_ret;
 
-   /* Create two pipes for stdout/stderr */
-   if (pipe (stdout_pipe) == -1) {
-      perror("Problem in creating stdout pipe");
+   /* Create pipes for stdin/stdout/stderr */
+   if (pipe (stdin_pipe) == -1) {
+      perror ("Problem in creating stdin pipe");
       return 1;
+   }
+   if (pipe (stdout_pipe) == -1) {
+      perror ("Problem in creating stdout pipe");
+      return 2;
    }
    if (pipe (stderr_pipe) == -1) {
       perror ("Problem in creating stderr pipe");
-      return 2;
+      return 3;
    }
 
+   stdin_read = fdopen (stdin_pipe[0], "r");
+   if (!stdin_read) {
+      perror ("Problem in fdopen for stdin read");
+      return 4;
+   }
    stdout_write = fdopen (stdout_pipe[1], "w");
    if (!stdout_write) {
       perror ("Problem in fdopen for stdout write");
-      return 3;
+      return 5;
    }
    stderr_write = fdopen (stderr_pipe[1], "w");
    if (!stderr_write) {
       perror ("Problem in fdopen for stderr write");
-      return 4;
+      return 6;
    }
 
-   /* Initialize runtime and set up stdout/stderr redirection */
+   /* Prepare input for COBOL program */
+   nbytes = write (stdin_pipe[1], "STDERR\n", 7);
+   if (nbytes != 7) {
+      perror ("Problem in writing 'STDERR' to stdin");
+      return 7;
+   }
+   nbytes = write (stdin_pipe[1], "STDOUT\n", 7);
+   if (nbytes != 7) {
+      perror ("Problem in writing 'STDOUT' to stdin");
+      return 8;
+   }
+   fclose (stdin_read);
+
+   /* Initialize runtime and set up stdin/stdout/stderr redirection */
    cob_init (0, NULL);
 
+   cob_set_runtime_option (COB_SET_RUNTIME_STDIN_FILE, stdin_read);
    cob_set_runtime_option (COB_SET_RUNTIME_STDOUT_FILE, stdout_write);
    cob_set_runtime_option (COB_SET_RUNTIME_STDERR_FILE, stderr_write);
 
@@ -16478,11 +16509,11 @@ int main (int argc, char **argv) {
    cob_ret = cob_call_with_exception_check ("callee", 0, NULL);
    if (cob_ret != 1) {
       fprintf (stderr, "COBOL program did not normally exit: %d", cob_ret);
-      return 5;
+      return 9;
    }
    if (cob_last_exit_code () != 0) {
       fprintf (stderr, "COBOL program did not exit with ok code: %d", cob_last_exit_code ());
-      return 6;
+      return 10;
    }
 
    /* Close write-ends of the stdout/stderr pipes */
@@ -16495,11 +16526,11 @@ int main (int argc, char **argv) {
       buffer[nbytes] = '\0';
    } else {
       perror ("Problem in reading stdout pipe");
-      return 7;
+      return 11;
    }
    if (strcmp ("STDOUT\n", buffer) != 0) {
       fprintf (stderr, "Redirection of stdout failed, COBOL wrote: %s", buffer);
-      return 8;
+      return 12;
    }
 
    /* Check result of COBOL program in read end of stderr pipe */
@@ -16508,16 +16539,17 @@ int main (int argc, char **argv) {
       buffer[nbytes] = '\0';
    } else {
       perror ("Problem in reading stderr pipe");
-      return 9;
+      return 13;
    }
    if (strcmp ("STDERR\n", buffer) != 0) {
       fprintf (stderr, "Redirection of stderr failed, COBOL wrote: %s", buffer);
-      return 10;
+      return 14;
    }
 
    /* Clean up and terminate */
+   close (stdin_pipe[1]);
    close (stdout_pipe[0]);
-   close (stderr_pipe[1]);
+   close (stderr_pipe[0]);
 
    return 0;
 }

--- a/tests/testsuite.src/run_misc.at
+++ b/tests/testsuite.src/run_misc.at
@@ -16470,7 +16470,6 @@ AT_DATA([callee.cob], [
 
 AT_DATA([caller.c], [[
 #include <stdio.h>
-#include <unistd.h>
 #include <stdlib.h>
 #include <string.h>
 #include <libcob.h>

--- a/tests/testsuite.src/run_misc.at
+++ b/tests/testsuite.src/run_misc.at
@@ -16501,8 +16501,12 @@ int main (int argc, char **argv) {
       perror ("Problem in writing 'STDOUT' to stdin");
       return 3;
    }
-   fflush (cob_stdin);
-   rewind (cob_stdin);
+   fclose (cob_stdin);
+   cob_stdin = fopen ("cob_stdin", "r+b");
+   if (!cob_stdin) {
+      fprintf (stderr, "Problem in opening stdin file for read");
+      return -1;
+   }
 
    /* Initialize runtime and set up stdin/stdout/stderr redirection */
    cob_init (0, NULL);
@@ -16523,11 +16527,15 @@ int main (int argc, char **argv) {
    }
 
    /* Reset stdout and stderr for reading */
-   fflush (cob_stdout);
-   rewind (cob_stdout);
-   fflush (cob_stderr);
-   rewind (cob_stderr);
-
+   fclose (cob_stdout);
+   fclose (cob_stderr);
+   cob_stdout = fopen ("cob_stdout", "r+b");
+   cob_stderr = fopen ("cob_stderr", "r+b");
+   if (!cob_stdout || !cob_stderr) {
+      fprintf (stderr, "Problem in opening stdout/stderr files for read");
+      return -1;
+   }
+   
    /* Check result of COBOL program in stdout */
    buffer[0] = '\0';
    fgets_ret = fgets (buffer, sizeof(buffer) - 1, cob_stdout);
@@ -16553,9 +16561,9 @@ int main (int argc, char **argv) {
    }
 
    /* Clean up and terminate */
-   //fclose (cob_stdin);
-   //fclose (cob_stdout);
-   //fclose (cob_stderr);
+   fclose (cob_stdin);
+   fclose (cob_stdout);
+   fclose (cob_stderr);
 
    return 0;
 }

--- a/tests/testsuite.src/run_misc.at
+++ b/tests/testsuite.src/run_misc.at
@@ -16445,111 +16445,88 @@ AT_DATA([caller.c], [[
 #include <libcob.h>
 
 int main (int argc, char **argv) {
-   int stdin_pipe[2];
-   int stdout_pipe[2];
-   int stderr_pipe[2];
-   FILE *stdin_read;
-   FILE *stdout_write;
-   FILE *stderr_write;
+   FILE *cob_stdin;
+   FILE *cob_stdout;
+   FILE *cob_stderr;
    char buffer[128];
    ssize_t nbytes;
    int cob_ret;
 
-   /* Create pipes for stdin/stdout/stderr */
-   if (pipe (stdin_pipe) == -1) {
-      perror ("Problem in creating stdin pipe");
+   /* Create files for stdin/stdout/stderr */
+   cob_stdin = fopen ("cob_stdin", "w+b");
+   if (!cob_stdin) {
+      perror ("Problem in creating stdin file");
       return 1;
    }
-   if (pipe (stdout_pipe) == -1) {
+   cob_stdout= fopen ("cob_stdout", "w+b");
+   if (!cob_stdout) {
       perror ("Problem in creating stdout pipe");
       return 2;
    }
-   if (pipe (stderr_pipe) == -1) {
+   cob_stderr = fopen ("cob_stderr", "w+b");
+   if (!cob_stderr) {
       perror ("Problem in creating stderr pipe");
       return 3;
    }
 
-   stdin_read = fdopen (stdin_pipe[0], "r");
-   if (!stdin_read) {
-      perror ("Problem in fdopen for stdin read");
-      return 4;
-   }
-   stdout_write = fdopen (stdout_pipe[1], "w");
-   if (!stdout_write) {
-      perror ("Problem in fdopen for stdout write");
-      return 5;
-   }
-   stderr_write = fdopen (stderr_pipe[1], "w");
-   if (!stderr_write) {
-      perror ("Problem in fdopen for stderr write");
-      return 6;
-   }
-
    /* Prepare input for COBOL program */
-   nbytes = write (stdin_pipe[1], "STDERR\n", 7);
+   nbytes = fprintf (cob_stdin, "STDERR\n");
    if (nbytes != 7) {
       perror ("Problem in writing 'STDERR' to stdin");
-      return 7;
+      return 4;
    }
-   nbytes = write (stdin_pipe[1], "STDOUT\n", 7);
+   nbytes = fprintf (cob_stdin, "STDOUT\n");
    if (nbytes != 7) {
       perror ("Problem in writing 'STDOUT' to stdin");
-      return 8;
+      return 5;
    }
+   fflush (cob_stdin);
+   rewind (cob_stdin);
 
    /* Initialize runtime and set up stdin/stdout/stderr redirection */
    cob_init (0, NULL);
-   cob_set_runtime_option (COB_SET_RUNTIME_STDIN_FILE, stdin_read);
-   cob_set_runtime_option (COB_SET_RUNTIME_STDOUT_FILE, stdout_write);
-   cob_set_runtime_option (COB_SET_RUNTIME_STDERR_FILE, stderr_write);
-   
+   cob_set_runtime_option (COB_SET_RUNTIME_STDIN_FILE, cob_stdin);
+   cob_set_runtime_option (COB_SET_RUNTIME_STDOUT_FILE, cob_stdout);
+   cob_set_runtime_option (COB_SET_RUNTIME_STDERR_FILE, cob_stderr);
+
    /* Call COBOL program */
    cob_ret = cob_call_with_exception_check ("callee", 0, NULL);
 
    if (cob_ret != 1) {
       fprintf (stderr, "COBOL program did not normally exit: %d", cob_ret);
-      return 9;
+      return 6;
    }
    if (cob_last_exit_code () != 0) {
       fprintf (stderr, "COBOL program did not exit with ok code: %d", cob_last_exit_code ());
-      return 10;
+      return 7;
    }
 
-   /* Close COBOL-ends of stdin/stdout/stderr pipes */
-   fclose (stdin_read);
-   fclose (stdout_write);
-   fclose (stderr_write);
+   /* Reset stdout and stderr for reading */
+   fflush (cob_stdout);
+   rewind (cob_stdout);
+   fflush (cob_stderr);
+   rewind (cob_stderr);
 
-   /* Check result of COBOL program in read end of stdout pipe */
-   nbytes = read (stdout_pipe[0], buffer, sizeof(buffer) - 1);
-   if (nbytes >= 0) {
-      buffer[nbytes] = '\0';
-   } else {
-      perror ("Problem in reading stdout pipe");
-      return 11;
-   }
+   /* Check result of COBOL program in stdout */
+   buffer[0] = '\0';
+   fgets (buffer, sizeof(buffer) - 1, cob_stdout);
    if (strcmp ("STDOUT\n", buffer) != 0) {
       fprintf (stderr, "Redirection of stdout failed, COBOL wrote: %s", buffer);
-      return 12;
+      return 8;
    }
 
-   /* Check result of COBOL program in read end of stderr pipe */
-   nbytes = read (stderr_pipe[0], buffer, sizeof(buffer) - 1);
-   if (nbytes >= 0) {
-      buffer[nbytes] = '\0';
-   } else {
-      perror ("Problem in reading stderr pipe");
-      return 13;
-   }
+   /* Check result of COBOL program in stderr */
+   buffer[0] = '\0';
+   fgets (buffer, sizeof(buffer) - 1, cob_stderr);
    if (strcmp ("STDERR\n", buffer) != 0) {
       fprintf (stderr, "Redirection of stderr failed, COBOL wrote: %s", buffer);
-      return 14;
+      return 9;
    }
 
    /* Clean up and terminate */
-   close (stdin_pipe[1]);
-   close (stdout_pipe[0]);
-   close (stderr_pipe[0]);
+   fclose (cob_stdin);
+   fclose (cob_stdout);
+   fclose (cob_stderr);
 
    return 0;
 }

--- a/tests/testsuite.src/run_misc.at
+++ b/tests/testsuite.src/run_misc.at
@@ -16477,7 +16477,7 @@ AT_DATA([caller.c], [[
 int main (int argc, char **argv) {
    char buffer[128];
    char *fgets_ret;
-   ssize_t nbytes;
+   int nbytes;
    int cob_ret;
 
    /* Files for stdin/stdout/stderr redirection */

--- a/tests/testsuite.src/run_misc.at
+++ b/tests/testsuite.src/run_misc.at
@@ -16445,41 +16445,31 @@ AT_DATA([caller.c], [[
 #include <libcob.h>
 
 int main (int argc, char **argv) {
-   FILE *cob_stdin;
-   FILE *cob_stdout;
-   FILE *cob_stderr;
    char buffer[128];
    char *fgets_ret;
    ssize_t nbytes;
    int cob_ret;
 
-   /* Create files for stdin/stdout/stderr */
-   cob_stdin = fopen ("cob_stdin", "w+b");
-   if (!cob_stdin) {
-      perror ("Problem in creating stdin file");
+   /* Files for stdin/stdout/stderr redirection */
+   FILE *cob_stdin = fopen ("cob_stdin", "w+b");
+   FILE *cob_stdout = fopen ("cob_stdout", "w+b");
+   FILE *cob_stderr = fopen ("cob_stderr", "w+b");
+
+   if (!cob_stdin || !cob_stdout || !cob_stderr) {
+      fprintf (stderr, "Problem in creating stdin/stdout/stderr files");
       return 1;
-   }
-   cob_stdout= fopen ("cob_stdout", "w+b");
-   if (!cob_stdout) {
-      perror ("Problem in creating stdout pipe");
-      return 2;
-   }
-   cob_stderr = fopen ("cob_stderr", "w+b");
-   if (!cob_stderr) {
-      perror ("Problem in creating stderr pipe");
-      return 3;
    }
 
    /* Prepare input for COBOL program */
    nbytes = fprintf (cob_stdin, "STDERR\n");
    if (nbytes != 7) {
       perror ("Problem in writing 'STDERR' to stdin");
-      return 4;
+      return 2;
    }
    nbytes = fprintf (cob_stdin, "STDOUT\n");
    if (nbytes != 7) {
       perror ("Problem in writing 'STDOUT' to stdin");
-      return 5;
+      return 3;
    }
    fflush (cob_stdin);
    rewind (cob_stdin);
@@ -16495,11 +16485,11 @@ int main (int argc, char **argv) {
 
    if (cob_ret != 1) {
       fprintf (stderr, "COBOL program did not normally exit: %d\n", cob_ret);
-      return 6;
+      return 4;
    }
    if (cob_last_exit_code () != 0) {
       fprintf (stderr, "COBOL program did not exit with ok code: %d\n", cob_last_exit_code ());
-      return 7;
+      return 5;
    }
 
    /* Reset stdout and stderr for reading */
@@ -16513,11 +16503,11 @@ int main (int argc, char **argv) {
    fgets_ret = fgets (buffer, sizeof(buffer) - 1, cob_stdout);
    if (fgets_ret != buffer) {
       fprintf (stderr, "Reading from stdout failed\n");
-      return 8;
+      return 6;
    }
    if (strcmp ("STDOUT\n", buffer) != 0) {
       fprintf (stderr, "Redirection of stdout failed, COBOL wrote: %s\n", buffer);
-      return 9;
+      return 7;
    }
 
    /* Check result of COBOL program in stderr */
@@ -16525,11 +16515,11 @@ int main (int argc, char **argv) {
    fgets_ret = fgets (buffer, sizeof(buffer) - 1, cob_stderr);
    if (fgets_ret != buffer) {
       fprintf (stderr, "Reading from stderr failed\n");
-      return 10;
+      return 8;
    }
    if (strcmp ("STDERR\n", buffer) != 0) {
       fprintf (stderr, "Redirection of stderr failed, COBOL wrote: %s\n", buffer);
-      return 11;
+      return 9;
    }
 
    /* Clean up and terminate */

--- a/tests/testsuite.src/run_misc.at
+++ b/tests/testsuite.src/run_misc.at
@@ -16449,6 +16449,7 @@ int main (int argc, char **argv) {
    FILE *cob_stdout;
    FILE *cob_stderr;
    char buffer[128];
+   char *fgets_ret;
    ssize_t nbytes;
    int cob_ret;
 
@@ -16493,11 +16494,11 @@ int main (int argc, char **argv) {
    cob_ret = cob_call_with_exception_check ("callee", 0, NULL);
 
    if (cob_ret != 1) {
-      fprintf (stderr, "COBOL program did not normally exit: %d", cob_ret);
+      fprintf (stderr, "COBOL program did not normally exit: %d\n", cob_ret);
       return 6;
    }
    if (cob_last_exit_code () != 0) {
-      fprintf (stderr, "COBOL program did not exit with ok code: %d", cob_last_exit_code ());
+      fprintf (stderr, "COBOL program did not exit with ok code: %d\n", cob_last_exit_code ());
       return 7;
    }
 
@@ -16509,18 +16510,26 @@ int main (int argc, char **argv) {
 
    /* Check result of COBOL program in stdout */
    buffer[0] = '\0';
-   fgets (buffer, sizeof(buffer) - 1, cob_stdout);
-   if (strcmp ("STDOUT\n", buffer) != 0) {
-      fprintf (stderr, "Redirection of stdout failed, COBOL wrote: %s", buffer);
+   fgets_ret = fgets (buffer, sizeof(buffer) - 1, cob_stdout);
+   if (fgets_ret != buffer) {
+      fprintf (stderr, "Reading from stdout failed\n");
       return 8;
+   }
+   if (strcmp ("STDOUT\n", buffer) != 0) {
+      fprintf (stderr, "Redirection of stdout failed, COBOL wrote: %s\n", buffer);
+      return 9;
    }
 
    /* Check result of COBOL program in stderr */
    buffer[0] = '\0';
-   fgets (buffer, sizeof(buffer) - 1, cob_stderr);
+   fgets_ret = fgets (buffer, sizeof(buffer) - 1, cob_stderr);
+   if (fgets_ret != buffer) {
+      fprintf (stderr, "Reading from stderr failed\n");
+      return 10;
+   }
    if (strcmp ("STDERR\n", buffer) != 0) {
-      fprintf (stderr, "Redirection of stderr failed, COBOL wrote: %s", buffer);
-      return 9;
+      fprintf (stderr, "Redirection of stderr failed, COBOL wrote: %s\n", buffer);
+      return 11;
    }
 
    /* Clean up and terminate */

--- a/tests/testsuite.src/run_misc.at
+++ b/tests/testsuite.src/run_misc.at
@@ -16573,8 +16573,8 @@ AT_CHECK([$COMPILE prog.cob], [0], [], [])
 AT_CHECK([$COMPILE caller.c], [0], [], [])
 AT_CHECK([$COMPILE_MODULE callee.cob], [0], [], [])
 
-AT_CHECK([$COBCRUN_DIRECT ./prog], [0], [], [])
-AT_CHECK([./caller], [0], [], [])
+AT_CHECK([timeout 20s $COBCRUN_DIRECT ./prog], [0], [], [])
+AT_CHECK([timeout 20s ./caller], [0], [], [])
 
 AT_CLEANUP
 

--- a/tests/testsuite.src/run_misc.at
+++ b/tests/testsuite.src/run_misc.at
@@ -16465,7 +16465,7 @@ AT_DATA([callee.cob], [
           DISPLAY INPUT-VAR UPON SYSERR.
           ACCEPT INPUT-VAR.
           DISPLAY INPUT-VAR.
-          STOP RUN.
+          GOBACK.
 ])
 
 AT_DATA([caller.c], [[
@@ -16511,9 +16511,9 @@ int main (int argc, char **argv) {
    cob_set_runtime_option (COB_SET_RUNTIME_STDERR_FILE, cob_stderr);
 
    /* Call COBOL program */
-   cob_ret = cob_call_with_exception_check ("callee", 0, NULL);
+   cob_ret = cob_call ("callee", 0, NULL);
 
-   if (cob_ret != 1) {
+   if (cob_ret != 0) {
       fprintf (stderr, "COBOL program did not normally exit: %d\n", cob_ret);
       return 4;
    }

--- a/tests/testsuite.src/run_misc.at
+++ b/tests/testsuite.src/run_misc.at
@@ -16415,8 +16415,8 @@ AT_CHECK([$COBCRUN_DIRECT ./prog], [0],
 AT_CLEANUP
 
 
-AT_SETUP([COB_SET_RUNTIME_STDOUT_FILE/COB_SET_RUNTIME_STDERR_FILE changes runtime stdout/stderr])
-AT_KEYWORDS([runmisc cob_set_runtime_option stdout_stderr_redirection])
+AT_SETUP([stdout/stderr redirection])
+AT_KEYWORDS([runmisc cob_set_runtime_option COB_SET_RUNTIME_STDOUT_FILE COB_SET_RUNTIME_STDERR_FILE])
 
 AT_DATA([callee.cob], [
        IDENTIFICATION DIVISION.

--- a/tests/testsuite.src/run_misc.at
+++ b/tests/testsuite.src/run_misc.at
@@ -4972,7 +4972,7 @@ main (int argc, char **argv)
     cob_tidy ();
 
     /* Check normal exit second time */
-    if (cob_ret != 0) {
+    if (cob_ret != 1) {
       return 2;
     }
 
@@ -16414,4 +16414,120 @@ AT_CHECK([$COBCRUN_DIRECT ./prog], [0],
 
 AT_CLEANUP
 
+
+AT_SETUP([COB_SET_RUNTIME_STDOUT_FILE/COB_SET_RUNTIME_STDERR_FILE changes runtime stdout/stderr])
+AT_KEYWORDS([runmisc cob_set_runtime_option stdout_stderr_redirection])
+
+AT_DATA([callee.cob], [
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. callee.
+       ENVIRONMENT DIVISION.
+       CONFIGURATION SECTION.
+       SPECIAL-NAMES.
+          SYSERR IS STANDARD-ERROR.
+       PROCEDURE DIVISION.
+          DISPLAY "STDERR" UPON SYSERR.
+          DISPLAY "STDOUT".
+          STOP RUN.
+])
+
+AT_DATA([caller.c], [[
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <string.h>
+#include <libcob.h>
+
+int main (int argc, char **argv) {
+   int stdout_pipe[2];
+   int stderr_pipe[2];
+   FILE *stdout_write;
+   FILE *stderr_write;
+   char buffer[128];
+   ssize_t nbytes;
+   int cob_ret;
+
+   /* Create two pipes for stdout/stderr */
+   if (pipe (stdout_pipe) == -1) {
+      perror("Problem in creating stdout pipe");
+      return 1;
+   }
+   if (pipe (stderr_pipe) == -1) {
+      perror ("Problem in creating stderr pipe");
+      return 2;
+   }
+
+   stdout_write = fdopen (stdout_pipe[1], "w");
+   if (!stdout_write) {
+      perror ("Problem in fdopen for stdout write");
+      return 3;
+   }
+   stderr_write = fdopen (stderr_pipe[1], "w");
+   if (!stderr_write) {
+      perror ("Problem in fdopen for stderr write");
+      return 4;
+   }
+
+   /* Initialize runtime and set up stdout/stderr redirection */
+   cob_init (0, NULL);
+
+   cob_set_runtime_option (COB_SET_RUNTIME_STDOUT_FILE, stdout_write);
+   cob_set_runtime_option (COB_SET_RUNTIME_STDERR_FILE, stderr_write);
+
+   /* Call COBOL program */
+   cob_ret = cob_call_with_exception_check ("callee", 0, NULL);
+   if (cob_ret != 1) {
+      fprintf (stderr, "COBOL program did not normally exit: %d", cob_ret);
+      return 5;
+   }
+   if (cob_last_exit_code () != 0) {
+      fprintf (stderr, "COBOL program did not exit with ok code: %d", cob_last_exit_code ());
+      return 6;
+   }
+
+   /* Close write-ends of the stdout/stderr pipes */
+   fclose(stdout_write);
+   fclose(stderr_write);
+
+   /* Check result of COBOL program in read end of stdout pipe */
+   nbytes = read (stdout_pipe[0], buffer, sizeof(buffer) - 1);
+   if (nbytes >= 0) {
+      buffer[nbytes] = '\0';
+   } else {
+      perror ("Problem in reading stdout pipe");
+      return 7;
+   }
+   if (strcmp ("STDOUT\n", buffer) != 0) {
+      fprintf (stderr, "Redirection of stdout failed, COBOL wrote: %s", buffer);
+      return 8;
+   }
+
+   /* Check result of COBOL program in read end of stderr pipe */
+   nbytes = read (stderr_pipe[0], buffer, sizeof(buffer) - 1);
+   if (nbytes >= 0) {
+      buffer[nbytes] = '\0';
+   } else {
+      perror ("Problem in reading stderr pipe");
+      return 9;
+   }
+   if (strcmp ("STDERR\n", buffer) != 0) {
+      fprintf (stderr, "Redirection of stderr failed, COBOL wrote: %s", buffer);
+      return 10;
+   }
+
+   /* Clean up and terminate */
+   close (stdout_pipe[0]);
+   close (stderr_pipe[1]);
+
+   return 0;
+}
+]])
+
+AT_CHECK([$COMPILE caller.c], [0], [], [])
+AT_CHECK([$COMPILE_MODULE callee.cob], [0], [], [])
+
+AT_CHECK([./caller], [0], [], [])
+AT_CHECK([./caller], [0], [], [])
+
+AT_CLEANUP
 

--- a/tests/testsuite.src/run_misc.at
+++ b/tests/testsuite.src/run_misc.at
@@ -16553,9 +16553,9 @@ int main (int argc, char **argv) {
    }
 
    /* Clean up and terminate */
-   fclose (cob_stdin);
-   fclose (cob_stdout);
-   fclose (cob_stderr);
+   //fclose (cob_stdin);
+   //fclose (cob_stdout);
+   //fclose (cob_stderr);
 
    return 0;
 }

--- a/tests/testsuite.src/run_misc.at
+++ b/tests/testsuite.src/run_misc.at
@@ -16496,17 +16496,16 @@ int main (int argc, char **argv) {
       perror ("Problem in writing 'STDOUT' to stdin");
       return 8;
    }
-   fclose (stdin_read);
 
    /* Initialize runtime and set up stdin/stdout/stderr redirection */
    cob_init (0, NULL);
-
    cob_set_runtime_option (COB_SET_RUNTIME_STDIN_FILE, stdin_read);
    cob_set_runtime_option (COB_SET_RUNTIME_STDOUT_FILE, stdout_write);
    cob_set_runtime_option (COB_SET_RUNTIME_STDERR_FILE, stderr_write);
-
+   
    /* Call COBOL program */
    cob_ret = cob_call_with_exception_check ("callee", 0, NULL);
+
    if (cob_ret != 1) {
       fprintf (stderr, "COBOL program did not normally exit: %d", cob_ret);
       return 9;
@@ -16516,9 +16515,10 @@ int main (int argc, char **argv) {
       return 10;
    }
 
-   /* Close write-ends of the stdout/stderr pipes */
-   fclose(stdout_write);
-   fclose(stderr_write);
+   /* Close COBOL-ends of stdin/stdout/stderr pipes */
+   fclose (stdin_read);
+   fclose (stdout_write);
+   fclose (stderr_write);
 
    /* Check result of COBOL program in read end of stdout pipe */
    nbytes = read (stdout_pipe[0], buffer, sizeof(buffer) - 1);


### PR DESCRIPTION
This PR adds runtime options `COB_SET_RUNTIME_STDOUT_FILE` and `COB_SET_RUNTIME_STDERR_FILE` which allows control over the location where the stdout/stderr output is written.

# Motivation

For modules written in C that interact with libcob, it is currently difficult to change the location of stdout/stderr output without disturbing the stdout/stderr of the whole process (i.e., other threads). This is especially useful for thread applications, where it is desired that each thread gets its own stdout/stderr without disturbing the one another.

With these options, the main program can easily redirect the output of the COBOL program (including the messages from the runtime itself) and decide what to do with it. For that reason, the main program is also responsible for managing the lifetime of the passed stdout/stderr files, should they be used.

# Implementation

- Add `COB_SET_RUNTIME_STDOUT_FILE` and `COB_SET_RUNTIME_STDERR_FILE` options to `cob_runtime_option_switch` in `common.h`.
- Extend the `cob_settings` in `coblocal.h` to store the location of configured `stdout/stderr`. By default, they are initialized to stdout/stderr of the process.
- Add support for both options in `cob_set_runtime_option` and `cob_get_runtime_option` in `common.c`.
- Adjust all print statements in across all various files in the runtime, i.e., under `./libcob`, so that they behave accordingly.
- Document both options in `doc/gnucobol.texi`.