### PR TITLE
Pass C runtime that is linked with libcob in cobc for MSVC

### DIFF
--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -188,18 +188,15 @@ jobs:
           sed -i '/run_misc/{N;/write to internal storage (1)/{N;N;N;N;s/traceon/traceon; echo "workflow:1">"$at_check_line_file"; at_fn_check_skip 77/;}}' tests/testsuite
 
       # Fail tests that behave differently under MSVC Debug
-      # - System routine CBL_GC_HOSTED: fails because libcob is linked with the debug version
-      #   of the C runtime while the generated module is linked with the release version
-      #   CHECKME: cobc should use cl.exe /MTd and therefore all should use the debug runtime
       # - Internal storage: runtime checks abort before signal handler
-      # - COB_SIGNAL_REGIME 0/1: runtime checks abort before signal handler
       - name: Adjust testsuite for Debug target
         if: ${{ matrix.target == 'Debug' }}
         shell: C:\shells\msys2bash.cmd {0}
         run: |
-          sed -i '/run_extensions/{N;/System routine CBL_GC_HOSTED/{N;s/at_xfail=no/at_xfail=yes/;}}' tests/testsuite
           sed -i '/run_misc/{N;/write to internal storage (1)/{N;N;N;N;s/traceon/traceon; echo "workflow:1">"$at_check_line_file"; at_fn_check_skip 77/;}}' tests/testsuite
-          sed -i '/run_misc/{N;/COB_SIGNAL_REGIME 0/{N;s/at_xfail=no/at_xfail=yes/;}}' tests/testsuite
+      #    we keep an example of how to change failure expectation just before
+      #    running the tests:
+      #    sed -i '/run_misc/{N;/COB_SIGNAL_REGIME 0/{N;s/at_xfail=no/at_xfail=yes/;}}' tests/testsuite
 
       - name: Run testsuite
         run: |


### PR DESCRIPTION
The current version does not ensure that the C runtimes of libcob and compiled target match. This can cause undefined behavior if there is a communication between the two C runtimes, like passing a FILE pointer from one to another. This also fixes the issue with two failing CI tests (CBL_GC_HOSTED, COB_SIGNAL_REGIME) that is otherwise failing in MSVC builds.