### PR TITLE
Fix COB_SYNC

### DIFF
--- a/libcob/ChangeLog
+++ b/libcob/ChangeLog
@@ -1,4 +1,16 @@
 
+2026-09-08  David Declerck <david.declerck@ocamlpro.com>
+
+	* fileio.h (cob_file_operation, cob_file): new enum
+	  cob_file_operation to memorize the last file operation
+	* fileio.c: use the new file field last_operation instead
+	  of last_operation_open
+	* fileio.c (cob_file_fcd_sync): move reset of last_operation
+	  to save_status to fix a bug (uneffetive COB_SYNC)
+	* fileio.c (cob_sync): add missing condition - fflush
+	  should only be called when the last operation is a write
+	  (follow-up to 2026-08-13)
+
 2026-09-01  Fabrice Le Fessant <fabrice.le_fessant@ocamlpro.com>
 
 	* profiling.c (print_stack): export/debug option with environment

--- a/libcob/common.h
+++ b/libcob/common.h
@@ -854,6 +854,20 @@ enum cob_file_access_mode {
 	COB_ACCESS_RANDOM = 3
 };
 
+/* io_routine */
+enum cob_file_operation {
+	COB_LAST_NONE		= 0,
+	COB_LAST_START		= 1,
+	COB_LAST_READ_SEQ	= 2,
+	COB_LAST_READ		= 3,
+	COB_LAST_WRITE		= 4,
+	COB_LAST_REWRITE	= 5,
+	COB_LAST_DELETE		= 6,
+	COB_LAST_OPEN		= 7,
+	COB_LAST_CLOSE		= 8,
+	COB_LAST_DELETE_FILE	= 9
+};
+
 /* SELECT features */
 
 #define	COB_SELECT_FILE_STATUS	(1U << 0)
@@ -1435,6 +1449,7 @@ typedef struct __cob_file {
 	const unsigned char* code_set_read;	/* CODE-SET conversion for READs */
 	size_t			nconvert_fields;	/* Number of logical fields to convert */
 	cob_field	*convert_field;		/* logical fields to convert for CODE-SET */
+	enum cob_file_operation		last_operation;		/* Most recent I/O operation */
 } cob_file;
 
 

--- a/libcob/fileio.c
+++ b/libcob/fileio.c
@@ -542,7 +542,6 @@ static cob_settings	*cobsetptr = NULL;
 static unsigned int	eop_status = 0;
 static unsigned int	check_eop_status = 0;
 static int		cob_vsq_len = 0;
-static int		last_operation_open = 0;
 
 static struct file_list	*file_cache = NULL;
 
@@ -1403,7 +1402,10 @@ cob_sync (cob_file *f)
 		return;
 	}
 	if (f->organization != COB_ORG_SORT && f->open_mode != COB_OPEN_INPUT) {
-		if (f->file) {
+		if (f->file
+		 && (f->last_operation == COB_LAST_WRITE
+		  || f->last_operation == COB_LAST_REWRITE
+		  || f->last_operation == COB_LAST_DELETE)) {
 			fflush ((FILE *)f->file);
 		}
 		if (f->fd >= 0) {
@@ -1502,7 +1504,7 @@ save_status (cob_file *f, cob_field *fnstatus, const int status)
 			eop_status = 0;
 		}
 		if (cobsetptr->cob_do_sync
-		 && !last_operation_open
+		 && f->last_operation != COB_LAST_OPEN
 		 && f->open_mode != COB_OPEN_CLOSED) {
 			cob_sync (f);
 		}
@@ -1512,6 +1514,7 @@ save_status (cob_file *f, cob_field *fnstatus, const int status)
 	if (f->fcd) {
 		cob_file_fcd_sync (f);			/* Copy cob_file to app's FCD */
 	}
+	f->last_operation = COB_LAST_NONE;
 }
 
 /* Regular file */
@@ -6322,7 +6325,7 @@ cob_open (cob_file *f, const int mode, const int sharing, cob_field *fnstatus)
 {
 	/*: GC4: mode as cob_open_mode */
 
-	last_operation_open = 1;
+	f->last_operation = COB_LAST_OPEN;
 
 	/* File was previously closed with lock */
 	if (f->open_mode == COB_OPEN_LOCKED) {
@@ -6460,6 +6463,7 @@ cob_close (cob_file *f, cob_field *fnstatus, const int opt, const int remfil)
 	struct file_list	*m;
 	int			ret;
 
+	f->last_operation = COB_LAST_CLOSE;
 	f->flag_read_done = 0;
 	f->flag_operation = 0;
 
@@ -6548,6 +6552,7 @@ cob_start (cob_file *f, const int cond, cob_field *key,
 	int		ret;
 	cob_field	tempkey;
 
+	f->last_operation = COB_LAST_START;
 	f->flag_read_done = 0;
 	f->flag_first_read = 0;
 
@@ -6598,6 +6603,7 @@ cob_read (cob_file *f, cob_field *key, cob_field *fnstatus, const int read_opts)
 	int	ret;
 
 	f->flag_read_done = 0;
+	f->last_operation = COB_LAST_READ;
 
 	if (unlikely (f->open_mode != COB_OPEN_INPUT
 		       && f->open_mode != COB_OPEN_I_O)) {
@@ -6617,6 +6623,7 @@ cob_read (cob_file *f, cob_field *key, cob_field *fnstatus, const int read_opts)
 
 	/* Sequential read at the end of file is an error */
 	if (key == NULL) {
+		f->last_operation = COB_LAST_READ_SEQ;
 		if (unlikely (f->flag_end_of_file
 		           && !(read_opts & COB_READ_PREVIOUS))) {
 			save_status (f, fnstatus, COB_STATUS_46_READ_ERROR);
@@ -6697,6 +6704,7 @@ cob_read_next (cob_file *f, cob_field *fnstatus, const int read_opts)
 {
 	int	ret,idx;
 
+	f->last_operation = COB_LAST_READ_SEQ;
 	f->flag_read_done = 0;
 
 	if (unlikely (f->open_mode != COB_OPEN_INPUT
@@ -6809,6 +6817,7 @@ void
 cob_write (cob_file *f, cob_field *rec, const int opt, cob_field *fnstatus,
 	   const unsigned int check_eop)
 {
+	f->last_operation = COB_LAST_WRITE;
 	f->flag_read_done = 0;
 
 	if (f->access_mode == COB_ACCESS_SEQUENTIAL) {
@@ -6918,6 +6927,7 @@ cob_rewrite (cob_file *f, cob_field *rec, const int opt, cob_field *fnstatus)
 
 	read_done = f->flag_read_done;
 	f->flag_read_done = 0;
+	f->last_operation = COB_LAST_REWRITE;
 
 	if (unlikely (f->open_mode != COB_OPEN_I_O)) {
 		save_status (f, fnstatus, COB_STATUS_49_I_O_DENIED);
@@ -7028,6 +7038,7 @@ cob_delete (cob_file *f, cob_field *fnstatus)
 
 	read_done = f->flag_read_done;
 	f->flag_read_done = 0;
+	f->last_operation = COB_LAST_DELETE;
 
 	if (unlikely (f->open_mode != COB_OPEN_I_O)) {
 		save_status (f, fnstatus, COB_STATUS_49_I_O_DENIED);
@@ -7070,6 +7081,7 @@ cob_rollback (void)
 void
 cob_delete_file (cob_file *f, cob_field *fnstatus)
 {
+	f->last_operation = COB_LAST_DELETE_FILE;
 	if (f->organization == COB_ORG_SORT) {
 		save_status (f, fnstatus, COB_STATUS_30_PERMANENT_ERROR);
 		return;
@@ -9867,6 +9879,7 @@ cob_extfh_open (EXTFH_FUNC callfh, cob_file *f,
 
 	COB_UNUSED (sharing);
 
+	f->last_operation = COB_LAST_OPEN;
 	fcd = find_fcd (f, 1);
 	f->last_open_mode = (unsigned char)mode;
 	if (mode == COB_OPEN_OUTPUT)
@@ -9905,6 +9918,7 @@ cob_extfh_close (EXTFH_FUNC callfh, cob_file *f,
 
 	COB_UNUSED (remfil);
 
+	f->last_operation = COB_LAST_CLOSE;
 	fcd = find_fcd (f, 1);
 	STCOMPX4 (opt, fcd->opt);
 
@@ -9971,6 +9985,7 @@ cob_extfh_start (EXTFH_FUNC callfh, cob_file *f,
 	int	recn;
 	int	keyn,keylen,partlen;
 
+	f->last_operation = COB_LAST_START;
 	fcd = find_fcd (f, 1);
 	if (f->organization == COB_ORG_INDEXED) {
 		keyn = cob_findkey(f,key,&keylen,&partlen);
@@ -10013,9 +10028,11 @@ cob_extfh_read (EXTFH_FUNC callfh, cob_file *f,
 	int	recn;
 	int	keyn,keylen,partlen;
 
+	f->last_operation = COB_LAST_READ;
 	fcd = find_fcd (f, 1);
 	STCOMPX4 (read_opts, fcd->opt);
 	if (key == NULL) {
+		f->last_operation = COB_LAST_READ_SEQ;
 		if ((read_opts & COB_READ_PREVIOUS)) {
 			STCOMPX2(OP_READ_PREV, opcode);
 		} else {
@@ -10057,6 +10074,7 @@ cob_extfh_read_next (EXTFH_FUNC callfh, cob_file *f,
 	FCD3	*fcd;
 	int	recn;
 
+	f->last_operation = COB_LAST_READ_SEQ;
 	fcd = find_fcd (f, 1);
 	STCOMPX4(read_opts, fcd->opt);
 	if ((read_opts & COB_READ_PREVIOUS)) {
@@ -10084,6 +10102,7 @@ cob_extfh_write (EXTFH_FUNC callfh, cob_file *f,
 	FCD3	*fcd;
 	int	recn;
 
+	f->last_operation = COB_LAST_WRITE;
 	fcd = find_fcd (f, 1);
 	STCOMPX2(OP_WRITE, opcode);
 	STCOMPX2(check_eop, fcd->eop);
@@ -10119,6 +10138,7 @@ cob_extfh_rewrite (EXTFH_FUNC callfh, cob_file *f,
 	FCD3	*fcd;
 	int	recn;
 
+	f->last_operation = COB_LAST_REWRITE;
 	fcd = find_fcd (f, 1);
 	STCOMPX2 (OP_REWRITE, opcode);
 	STCOMPX4 (opt, fcd->opt);
@@ -10151,6 +10171,7 @@ cob_extfh_delete (EXTFH_FUNC callfh, cob_file *f,
 	FCD3	*fcd;
 	int	recn;
 
+	f->last_operation = COB_LAST_DELETE;
 	fcd = find_fcd (f, 1);
 	STCOMPX2 (OP_DELETE, opcode);
 	if (f->organization == COB_ORG_RELATIVE) {
@@ -10233,8 +10254,7 @@ cob_fcd_file_sync (cob_file *f, char *external_file_open_name)
 static void
 cob_file_fcd_sync (cob_file *f)
 {
-	if (last_operation_open == 1) {
-		last_operation_open = 0;
+	if (f->last_operation == COB_LAST_OPEN) {
 		copy_file_to_fcd (f, f->fcd);
 	} else {
 		update_file_to_fcd (f, f->fcd, NULL);


### PR DESCRIPTION
This PR fixes two things:
- a first bug prevented COB_SYNC from actually working (dead condition)
- fixing it revealed another bug, where the use of COB_SYNC caused incomplete reads (actualy PR #313 attempted to fix this, but there was a missing part - ie calling `fflush` only after write operations)